### PR TITLE
Add high resolution flag to SheepShaver plist template

### DIFF
--- a/SheepShaver/src/MacOSX/Info.plist.in
+++ b/SheepShaver/src/MacOSX/Info.plist.in
@@ -46,5 +46,7 @@
 		<key>x86_64</key>
 		<string>10.7.0</string>
 	</dict>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
- Add `NSHighResolutionCapable` to SheepShaver plist template.
- Tested a build on MacOS 10.14.2, preference panes now render in high resolution mode:
<img width="692" alt="screen shot 2019-02-02 at 10 42 51 am" src="https://user-images.githubusercontent.com/4617974/52167922-9c15a880-26d7-11e9-8499-41182a6c324d.png">
- Would probably work for Basilisk, but I couldn't get a build on master in order to test