### PR TITLE
Add prefs item "dayofs" for finer-grained time offset

### DIFF
--- a/BasiliskII/src/macos_util.cpp
+++ b/BasiliskII/src/macos_util.cpp
@@ -136,6 +136,7 @@ uint32 TimeToMacTime(time_t t)
 	struct tm *local = localtime(&t);
 	const int TM_EPOCH_YEAR = 1900;
 	const int MAC_EPOCH_YEAR = 1904;
+	// Clip year and day offsets to prevent dates earlier than 1-Jan-1904
 	local->tm_year = std::max(MAC_EPOCH_YEAR - TM_EPOCH_YEAR, local->tm_year - PrefsFindInt32("yearofs"));
 	int a4 = ((local->tm_year + TM_EPOCH_YEAR) >> 2) - !(local->tm_year & 3);
 	int b4 = (MAC_EPOCH_YEAR >> 2) - !(MAC_EPOCH_YEAR & 3);
@@ -145,7 +146,10 @@ uint32 TimeToMacTime(time_t t)
 	int b400 = b100 >> 2;
 	int intervening_leap_days = (a4 - b4) - (a100 - b100) + (a400 - b400);
 	uint32 days = local->tm_yday + 365 * (local->tm_year - 4) + intervening_leap_days;
-	return local->tm_sec + 60 * (local->tm_min + 60 * (local->tm_hour + 24 * days));
+	int32 dayofs = PrefsFindInt32("dayofs");
+	if(dayofs > 0 && dayofs > days)
+		dayofs = days;
+	return local->tm_sec + 60 * (local->tm_min + 60 * (local->tm_hour + 24 * (days - dayofs)));
 }
 
 /*

--- a/BasiliskII/src/prefs_items.cpp
+++ b/BasiliskII/src/prefs_items.cpp
@@ -76,6 +76,7 @@ prefs_desc common_prefs_items[] = {
 	{"scale_nearest",TYPE_BOOLEAN,false,"nearest neighbor scaling"},
 	{"scale_integer",TYPE_BOOLEAN,false,"integer scaling"},
 	{"yearofs", TYPE_INT32, 0,			"year offset"},
+	{"dayofs", TYPE_INT32, 0,			"day offset"},
 	{NULL, TYPE_END, false, NULL} // End of list
 };
 

--- a/SheepShaver/src/macos_util.cpp
+++ b/SheepShaver/src/macos_util.cpp
@@ -335,6 +335,7 @@ uint32 TimeToMacTime(time_t t)
 #endif
 	const int TM_EPOCH_YEAR = 1900;
 	const int MAC_EPOCH_YEAR = 1904;
+	// Clip year and day offsets to prevent dates earlier than 1-Jan-1904
 	local->tm_year = std::max(MAC_EPOCH_YEAR - TM_EPOCH_YEAR, local->tm_year - PrefsFindInt32("yearofs"));
 	int a4 = ((local->tm_year + TM_EPOCH_YEAR) >> 2) - !(local->tm_year & 3);
 	int b4 = (MAC_EPOCH_YEAR >> 2) - !(MAC_EPOCH_YEAR & 3);
@@ -344,7 +345,10 @@ uint32 TimeToMacTime(time_t t)
 	int b400 = b100 >> 2;
 	int intervening_leap_days = (a4 - b4) - (a100 - b100) + (a400 - b400);
 	uint32 days = local->tm_yday + 365 * (local->tm_year - 4) + intervening_leap_days;
-	return local->tm_sec + 60 * (local->tm_min + 60 * (local->tm_hour + 24 * days));
+	int32 dayofs = PrefsFindInt32("dayofs");
+	if(dayofs > 0 && dayofs > days)
+		dayofs = days;
+	return local->tm_sec + 60 * (local->tm_min + 60 * (local->tm_hour + 24 * (days - dayofs)));
 }
 
 

--- a/SheepShaver/src/prefs_items.cpp
+++ b/SheepShaver/src/prefs_items.cpp
@@ -64,6 +64,7 @@ prefs_desc common_prefs_items[] = {
 	{"scale_integer",TYPE_BOOLEAN,false,"integer scaling"},
 	{"cpuclock", TYPE_INT32, 0,			"CPU clock [MHz] of system info"},
 	{"yearofs", TYPE_INT32, 0,			"year offset"},
+	{"dayofs", TYPE_INT32, 0,			"day offset"},
 	{NULL, TYPE_END, false, NULL} // End of list
 };
 


### PR DESCRIPTION
Similar to the ‘yearofs’ setting. Both prefs items can be combined.
For instance, using _yearofs=1_ and _dayofs=-1_ when the real date is 2019-02-09 will cause a date of 2018-02-10 inside the emulated OS.