### PR TITLE
Enable high-resolution SDL2 rendering.

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -705,7 +705,7 @@ static SDL_Surface * init_sdl_video(int width, int height, int bpp, Uint32 flags
     
 	int window_width = width;
 	int window_height = height;
-    Uint32 window_flags = 0;
+	Uint32 window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
 	const int window_flags_to_monitor = SDL_WINDOW_FULLSCREEN;
 	
 	if (flags & SDL_WINDOW_FULLSCREEN) {


### PR DESCRIPTION
Combined with 'scale_nearest true', this offers sharp graphics on retina
displays.