### PR TITLE
Moving SDL mutex to avoid deadlock

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -1094,12 +1094,10 @@ void driver_base::update_palette(void)
 
 	if ((int)VIDEO_MODE_DEPTH <= VIDEO_DEPTH_8BIT) {
 		SDL_SetSurfacePalette(s, sdl_palette);
-		SDL_LockMutex(sdl_update_video_mutex);
 		sdl_update_video_rect.x = 0;
 		sdl_update_video_rect.y = 0;
 		sdl_update_video_rect.w = VIDEO_MODE_X;
 		sdl_update_video_rect.h = VIDEO_MODE_Y;
-		SDL_UnlockMutex(sdl_update_video_mutex);
 	}
 }
 
@@ -2514,6 +2512,7 @@ static inline void possibly_ungrab_mouse()
 
 static inline void handle_palette_changes(void)
 {
+	SDL_LockMutex(sdl_update_video_mutex);
 	LOCK_PALETTE;
 
 	if (sdl_palette_changed) {
@@ -2522,6 +2521,7 @@ static inline void handle_palette_changes(void)
 	}
 
 	UNLOCK_PALETTE;
+	SDL_UnlockMutex(sdl_update_video_mutex);
 }
 
 static void video_refresh_window_static(void);


### PR DESCRIPTION
I [posted this on E-Maculation's forum](https://www.emaculation.com/forum/viewtopic.php?f=20&t=10075&p=62360#p62360); it's basically a followup to a brief issue with SDL 2 mutex locks that were causing SheepShaver to crash.  The added mutexes fixed the crash, but a deadlock condition could still occur between the buffer update and screen redraw because of the locking order.  This minor patch adjusts the order, and it appears to fix the deadlock issue!