### PR TITLE
SDL mutex deadlock and video fix, try 2

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -875,6 +875,8 @@ static int present_sdl_video()
 	SDL_SetRenderDrawColor(sdl_renderer, 0, 0, 0, 0);	// Use black
 	SDL_RenderClear(sdl_renderer);						// Clear the display
 	
+	// We're about to work with sdl_update_video_rect, so stop other threads from
+	// modifying it!
 	LOCK_PALETTE;
 	SDL_LockMutex(sdl_update_video_mutex);
     // Convert from the guest OS' pixel format, to the host OS' texture, if necessary.
@@ -890,11 +892,7 @@ static int present_sdl_video()
 			return -1;
 		}
 	}
-	UNLOCK_PALETTE;
-
-	// We're about to work with sdl_update_video_rect, so stop other threads from
-	// modifying it!
-//	SDL_LockMutex(sdl_update_video_mutex);
+	UNLOCK_PALETTE; // passed potential deadlock, can unlock palette
 	
     // Update the host OS' texture
     void * srcPixels = (void *)((uint8_t *)host_surface->pixels +

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -875,23 +875,26 @@ static int present_sdl_video()
 	SDL_SetRenderDrawColor(sdl_renderer, 0, 0, 0, 0);	// Use black
 	SDL_RenderClear(sdl_renderer);						// Clear the display
 	
+	LOCK_PALETTE;
+	SDL_LockMutex(sdl_update_video_mutex);
     // Convert from the guest OS' pixel format, to the host OS' texture, if necessary.
     if (host_surface != guest_surface &&
 		host_surface != NULL &&
 		guest_surface != NULL)
 	{
 		SDL_Rect destRect = sdl_update_video_rect;
-		LOCK_PALETTE;
-		SDL_LockMutex(sdl_update_video_mutex);
 		int result = SDL_BlitSurface(guest_surface, &sdl_update_video_rect, host_surface, &destRect);
-		SDL_UnlockMutex(sdl_update_video_mutex);
-		UNLOCK_PALETTE;
-		if (result != 0) return -1;
+		if (result != 0) {
+			SDL_UnlockMutex(sdl_update_video_mutex);
+			UNLOCK_PALETTE;
+			return -1;
+		}
 	}
+	UNLOCK_PALETTE;
 
 	// We're about to work with sdl_update_video_rect, so stop other threads from
 	// modifying it!
-	SDL_LockMutex(sdl_update_video_mutex);
+//	SDL_LockMutex(sdl_update_video_mutex);
 	
     // Update the host OS' texture
     void * srcPixels = (void *)((uint8_t *)host_surface->pixels +


### PR DESCRIPTION
Re #11, this is a minor adjustment to kanjitalk's mutex deadlock fix.  I think the buffer was at risk of changing during the comparison stage, which resulted in rare frame glitches.  I did more testing with a number of games and haven't found any issues, so I'm optimistic this fix will work.