### PR TITLE
Fix header search paths for kpx_cpu

### DIFF
--- a/SheepShaver/src/MacOSX/SheepShaver_Xcode8.xcodeproj/project.pbxproj
+++ b/SheepShaver/src/MacOSX/SheepShaver_Xcode8.xcodeproj/project.pbxproj
@@ -1126,7 +1126,7 @@
 					_REENTRANT,
 				);
 				HEADER_SEARCH_PATHS = (
-					/Library/Frameworks/SDL.framework/Versions/A/Headers/,
+					/Library/Frameworks/SDL2.framework/Headers/,
 					./config/,
 					../Unix,
 					../MacOSX/Launcher,
@@ -1163,7 +1163,7 @@
 					_REENTRANT,
 				);
 				HEADER_SEARCH_PATHS = (
-					/Library/Frameworks/SDL.framework/Versions/A/Headers/,
+					/Library/Frameworks/SDL2.framework/Headers/,
 					./config/,
 					../Unix,
 					../MacOSX/Launcher,


### PR DESCRIPTION
They were still pointing to SDL.framework, not SDL2.