### PR TITLE
Add FP frsqrte instruction emulation

### DIFF
--- a/SheepShaver/src/Unix/dyngen_precompiled/ppc-execute-impl.cpp
+++ b/SheepShaver/src/Unix/dyngen_precompiled/ppc-execute-impl.cpp
@@ -57,6 +57,7 @@ template void powerpc_cpu::execute_fp_arith<double, op_fnmadds, operand_fp_RD, o
 template void powerpc_cpu::execute_fp_arith<double, op_fnmsub, operand_fp_RD, operand_fp_RA, operand_fp_RC, operand_fp_RB, RC_BIT_G, true>(uint32);
 template void powerpc_cpu::execute_fp_arith<double, op_fnmsubs, operand_fp_RD, operand_fp_RA, operand_fp_RC, operand_fp_RB, RC_BIT_G, true>(uint32);
 template void powerpc_cpu::execute_fp_round<RC_BIT_G>(uint32);
+template void powerpc_cpu::execute_fp_arith<double, op_frsqrte, operand_fp_RD, operand_fp_RB, operand_fp_NONE, operand_fp_NONE, RC_BIT_G, false>(uint32);
 template void powerpc_cpu::execute_fp_arith<double, op_fsel, operand_fp_RD, operand_fp_RA, operand_fp_RC, operand_fp_RB, RC_BIT_G, false>(uint32);
 template void powerpc_cpu::execute_fp_arith<double, op_fsub, operand_fp_RD, operand_fp_RA, operand_fp_RB, operand_fp_NONE, RC_BIT_G, true>(uint32);
 template void powerpc_cpu::execute_fp_arith<float, op_fsub, operand_fp_RD, operand_fp_RA, operand_fp_RB, operand_fp_NONE, RC_BIT_G, true>(uint32);
@@ -258,7 +259,7 @@ template void powerpc_cpu::execute_vector_arith<op_frsiz, operand_vD_V4SF, opera
 template void powerpc_cpu::execute_vector_arith<op_vrl<uint8>, operand_vD_V16QI, operand_vA_V16QI, operand_vB_V16QI, operand_vC_NONE, fake_bit_field< bool, false >, 0 >(uint32);
 template void powerpc_cpu::execute_vector_arith<op_vrl<uint16>, operand_vD_V8HI, operand_vA_V8HI, operand_vB_V8HI, operand_vC_NONE, fake_bit_field< bool, false >, 0 >(uint32);
 template void powerpc_cpu::execute_vector_arith<op_vrl<uint32>, operand_vD_V4SI, operand_vA_V4SI, operand_vB_V4SI, operand_vC_NONE, fake_bit_field< bool, false >, 0 >(uint32);
-template void powerpc_cpu::execute_vector_arith<op_frsqrt, operand_vD_V4SF, operand_vA_NONE, operand_vB_V4SF, operand_vC_NONE, fake_bit_field< bool, false >, 0 >(uint32);
+template void powerpc_cpu::execute_vector_arith<op_frsqrte, operand_vD_V4SF, operand_vA_NONE, operand_vB_V4SF, operand_vC_NONE, fake_bit_field< bool, false >, 0 >(uint32);
 template void powerpc_cpu::execute_vector_arith<op_vsel, operand_vD_V4SI, operand_vA_V4SI, operand_vB_V4SI, operand_vC_V4SI, fake_bit_field< bool, false >, 0 >(uint32);
 template void powerpc_cpu::execute_vector_shift<-1>(uint32);
 template void powerpc_cpu::execute_vector_arith<op_vsl<uint8>, operand_vD_V16QI, operand_vA_V16QI, operand_vB_V16QI, operand_vC_NONE, fake_bit_field< bool, false >, 0 >(uint32);

--- a/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-decode.cpp
+++ b/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-decode.cpp
@@ -475,6 +475,11 @@ const powerpc_cpu::instr_info_t powerpc_cpu::powerpc_ii_table[] = {
 	  PPC_I(FRSP),
 	  X_form, 63, 12, CFLOW_NORMAL
 	},
+	{ "frsqrte",
+	  EXECUTE_FP_ARITH(double, frsqrte, RD, RB, NONE, NONE, RC_BIT_G, false),
+	  PPC_I(FRSQRTE),
+	  A_form, 63, 26, CFLOW_NORMAL
+	},
 	{ "fsel",
 	  EXECUTE_FP_ARITH(double, fsel, RD, RA, RC, RB, RC_BIT_G, false),
 	  PPC_I(FSEL),
@@ -1551,7 +1556,7 @@ const powerpc_cpu::instr_info_t powerpc_cpu::powerpc_ii_table[] = {
 	  VX_form, 4, 132, CFLOW_NORMAL
 	},
 	{ "vrsqrtefp",
-	  EXECUTE_VECTOR_ARITH(frsqrt, V4SF, NONE, V4SF, NONE),
+	  EXECUTE_VECTOR_ARITH(frsqrte, V4SF, NONE, V4SF, NONE),
 	  PPC_I(VRSQRTEFP),
 	  VX_form, 4, 330, CFLOW_NORMAL
 	},

--- a/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-dyngen-ops.cpp
+++ b/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-dyngen-ops.cpp
@@ -481,6 +481,7 @@ DEFINE_OP(fmov_FD_F2, FD_dw = F2_dw);
 DEFINE_OP(fabs_FD_F0, FD = do_fabs(F0));
 DEFINE_OP(fneg_FD_F0, FD = do_fneg(F0));
 DEFINE_OP(fnabs_FD_F0, FD = do_fnabs(F0));
+DEFINE_OP(frsqrte_FD_F0, FD = do_frsqrte(F0));
 
 DEFINE_OP(fadd_FD_F0_F1, FD = do_fadd(F0, F1));
 DEFINE_OP(fsub_FD_F0_F1, FD = do_fsub(F0, F1));

--- a/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-instructions.hpp
+++ b/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-instructions.hpp
@@ -100,6 +100,7 @@ enum powerpc_instruction {
 	PPC_I(FNMSUB),
 	PPC_I(FNMSUBS),
 	PPC_I(FRSP),
+	PPC_I(FRSQRTE),
 	PPC_I(FSEL),
 	PPC_I(FSUB),
 	PPC_I(FSUBS),

--- a/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-operations.hpp
+++ b/SheepShaver/src/kpx_cpu/src/cpu/ppc/ppc-operations.hpp
@@ -153,7 +153,7 @@ DEFINE_OP2(fsubs, float, x - y);
 DEFINE_OP1(exp2, float, exp2f(x));
 DEFINE_OP1(log2, float, log2f(x));
 DEFINE_OP1(fres, float, 1 / x);
-DEFINE_OP1(frsqrt, float, 1 / sqrt(x));
+DEFINE_OP1(frsqrte, float, 1 / sqrt(x));
 DEFINE_OP1(frsim, float, floorf(x));
 DEFINE_OP1(frsin, float, roundf(x));
 DEFINE_OP1(frsip, float, ceilf(x));


### PR DESCRIPTION
Also renamed the frsqrt opcode to frsqrte to match the manuals (the vector
version is also an estimate)