### PR TITLE
mingw32: Fix truncated extfs volume name, crash due to icon date issue

### DIFF
--- a/BasiliskII/src/Windows/user_strings_windows.cpp
+++ b/BasiliskII/src/Windows/user_strings_windows.cpp
@@ -20,7 +20,7 @@
 
 #include "sysdeps.h"
 #include "user_strings.h"
-
+#include "util_windows.h"
 
 // Platform-specific string definitions
 user_string_def platform_strings[] = {
@@ -81,7 +81,11 @@ static const char *get_volume_name(void)
 	HKEY hHelpKey;
 	DWORD key_type, cbData;
 
-	static char volume[256];
+	#ifdef _UNICODE
+	static char out_volume[256];
+	#endif
+
+	static TCHAR volume[256];
 	memset(volume, 0, sizeof(volume));
 
 	// Try Windows 2000 key first
@@ -118,14 +122,20 @@ static const char *get_volume_name(void)
 	}
 
 	// Fix the error that some "tweak" apps do.
-	if (_stricmp(volume, "%USERNAME% on %COMPUTER%") == 0)
-		volume[0] = '\0';
+	if (_tcsicmp(volume, TEXT("%USERNAME% on %COMPUTER%")) == 0)
+		volume[0] = TEXT('\0');
 
 	// No volume name found, default to "My Computer"
 	if (volume[0] == 0)
-		strcpy(volume, "My Computer");
+		_tcscpy(volume, TEXT("My Computer"));
 
+
+	#ifdef _UNICODE
+	strlcpy(out_volume, volume, 256);
+	return out_volume;
+	#else
 	return volume;
+	#endif
 }
 
 

--- a/BasiliskII/src/macos_util.cpp
+++ b/BasiliskII/src/macos_util.cpp
@@ -133,6 +133,13 @@ uint32 TimeToMacTime(time_t t)
 	// This code is taken from glibc 2.2
 
 	// Convert to number of seconds elapsed since 1-Jan-1904
+
+	#ifdef WIN32
+	if (t == -1) {
+		// failsafe as this will segfault
+		return 0;
+	}
+	#endif
 	struct tm *local = localtime(&t);
 	const int TM_EPOCH_YEAR = 1900;
 	const int MAC_EPOCH_YEAR = 1904;

--- a/SheepShaver/src/Windows/user_strings_windows.cpp
+++ b/SheepShaver/src/Windows/user_strings_windows.cpp
@@ -20,7 +20,7 @@
 
 #include "sysdeps.h"
 #include "user_strings.h"
-
+#include "util_windows.h"
 
 // Platform-specific string definitions
 user_string_def platform_strings[] = {
@@ -86,7 +86,11 @@ static const char *get_volume_name(void)
 	HKEY hHelpKey;
 	DWORD key_type, cbData;
 
-	static char volume[256];
+	#ifdef _UNICODE
+	static char out_volume[256];
+	#endif
+
+	static TCHAR volume[256];
 	memset(volume, 0, sizeof(volume));
 
 	// Try Windows 2000 key first
@@ -123,14 +127,19 @@ static const char *get_volume_name(void)
 	}
 
 	// Fix the error that some "tweak" apps do.
-	if (stricmp(volume, "%USERNAME% on %COMPUTER%") == 0)
-		volume[0] = '\0';
+	if (_tcsicmp(volume, TEXT("%USERNAME% on %COMPUTER%")) == 0)
+		volume[0] = TEXT('\0');
 
 	// No volume name found, default to "My Computer"
 	if (volume[0] == 0)
-		strcpy(volume, "My Computer");
+		_tcscpy(volume, TEXT("My Computer"));
 
+	#ifdef _UNICODE
+	strlcpy(out_volume, volume, 256);
+	return out_volume;
+	#else
 	return volume;
+	#endif
 }
 
 

--- a/SheepShaver/src/macos_util.cpp
+++ b/SheepShaver/src/macos_util.cpp
@@ -327,6 +327,10 @@ uint32 TimeToMacTime(time_t t)
 
 	// Convert to number of seconds elapsed since 1-Jan-1904
 #ifdef WIN32
+	if (t == -1) {
+		// failsafe as this will segfault
+		return 0;
+	}
 	struct tm *local = localtime(&t);
 #else
 	struct tm result;


### PR DESCRIPTION
Fixes the truncated name showing up for the extfs volume in Windows.

The data returned by `RegQueryValueEx` for a string registry value becomes `wchar_t` in the `_UNICODE` case, leading to the extfs volume showing up with just the first letter of the name.

It seems this was missed in the earlier changes for Unicode in `user_strings_windows.cpp`.

This fix unmasked another problem: the logic in `posix_emu` for creating the `Icon\r` file for the extfs volume when the `Virtual Desktop` directory is created left the file with a zeroed-out mtime and ctime (incidentally from values read out of bounds); which when the Mac did `fs_get_file_info` on the `Icon\r` file this led to the time conversion doing `localtime(-1)`, which segfaults on Windows.

I've included a fix for the time issue of the `Icon\r` file on Windows, as well as a safeguard to avoid doing `localtime(-1)` on Windows in the time conversion.