### PR TITLE
Use SDL2 dynamic library on Windows

### DIFF
--- a/BasiliskII/src/Windows/Makefile.in
+++ b/BasiliskII/src/Windows/Makefile.in
@@ -118,7 +118,7 @@ VPATH :=
 VPATH += $(addprefix :, $(subst  ,:, $(filter-out $($(subst, :, ,$(VPATH))), $(SRC_PATHS))))
 
 $(APP): $(XPLATSRCS) $(OBJ_DIR) $(OBJS)
-	$(CXX) -o $@ $(LDFLAGS) $(OBJS) $(LIBS) $(SDL_LIBS)
+	$(CXX) -o $@ $(LDFLAGS) $(OBJS) $(LIBS) -Wl,-Bdynamic $(SDL_LIBS) -Wl,-Bstatic
 
 $(UI_APP): $(XPLATSRCS) $(OBJ_DIR) $(UI_OBJS)
 	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) -Wl,-Bdynamic $(GTK_LIBS) -Wl,-Bstatic -mwindows -static-libgcc

--- a/SheepShaver/src/Windows/Makefile.in
+++ b/SheepShaver/src/Windows/Makefile.in
@@ -130,7 +130,7 @@ VPATH :=
 VPATH += $(addprefix :, $(subst  ,:, $(filter-out $($(subst, :, ,$(VPATH))), $(SRC_PATHS))))
 
 $(APP): $(XPLATSRCS) $(OBJ_DIR) $(OBJS)
-	$(CXX) -o $(APP) $(LDFLAGS) $(OBJS) $(LIBS) $(SDL_LIBS)
+	$(CXX) -o $(APP) $(LDFLAGS) $(OBJS) $(LIBS) -Wl,-Bdynamic $(SDL_LIBS) -Wl,-Bstatic
 
 $(UI_APP): $(XPLATSRCS) $(OBJ_DIR) $(UI_OBJS)
 	$(CXX) -o $@ $(LDFLAGS) $(UI_OBJS) $(LIBS) -Wl,-Bdynamic $(GTK_LIBS) -Wl,-Bstatic -mwindows -static-libgcc


### PR DESCRIPTION
Specifying to use dynamic libraries for the `$(SDL_LIBS)` portion of the linker command line, as was already done for GTK in the GUIs, makes the linking problem with the MSYS2 packaged SDL2 2.0.12-4 go away.

Fixes #49.