### PR TITLE
Fix for autodetected physical cdroms in Windows

### DIFF
--- a/BasiliskII/src/cdrom.cpp
+++ b/BasiliskII/src/cdrom.cpp
@@ -303,15 +303,14 @@ void CDROMInit(void)
 	if (PrefsFindString("cdrom", 0) == NULL) {
 		SysAddCDROMPrefs();
 	}
-	else {
-		// Add drives specified in preferences
-		int index = 0;
-		const char *str;
-		while ((str = PrefsFindString("cdrom", index++)) != NULL) {
-			void *fh = Sys_open(str, true);
-			if (fh)
-				drives.push_back(cdrom_drive_info(fh));
-		}
+	
+	// Add drives specified in preferences
+	int index = 0;
+	const char *str;
+	while ((str = PrefsFindString("cdrom", index++)) != NULL) {
+		void *fh = Sys_open(str, true);
+		if (fh)
+			drives.push_back(cdrom_drive_info(fh));
 	}
 	
 	if (!drives.empty()) { // set to first drive by default


### PR DESCRIPTION
- actually use dynamically detected cdroms
- if read via `cdenable` doesn't work use the logical drive handle instead

Fixes kanjitalk755/macemu#55