### PR TITLE
VOSF full screen video problem fixes

### DIFF
--- a/BasiliskII/src/CrossPlatform/video_vosf.h
+++ b/BasiliskII/src/CrossPlatform/video_vosf.h
@@ -541,26 +541,6 @@ static void update_display_window_vosf(VIDEO_DRV_WIN_INIT)
 #ifndef TEST_VOSF_PERFORMANCE
 #if REAL_ADDRESSING || DIRECT_ADDRESSING
 
-static uint32 get_chunk_size_for_depth(const uint32 mode, const uint32 n_pixels) {
-	assert(n_pixels % 8 == 0);
-	switch(mode) {
-		case APPLE_1_BIT:
-			return n_pixels / 8;
-		case APPLE_2_BIT:
-			return n_pixels / 4;
-		case APPLE_4_BIT:
-			return n_pixels / 2;
-		case APPLE_8_BIT:
-			return n_pixels;
-		case APPLE_16_BIT:
-			return n_pixels * 2;
-		case APPLE_32_BIT:
-			return n_pixels * 4;
-		default:
-			assert(false);
-	}
-}
-
 static void update_display_dga_vosf(VIDEO_DRV_DGA_INIT)
 {
 	VIDEO_MODE_INIT;
@@ -595,8 +575,8 @@ static void update_display_dga_vosf(VIDEO_DRV_DGA_INIT)
 	const uint32 n_pixels = 64;
 	const uint32 n_chunks = VIDEO_MODE_X / n_pixels;
 	const uint32 n_pixels_left = VIDEO_MODE_X - (n_chunks * n_pixels);
-	const uint32 src_chunk_size = get_chunk_size_for_depth(VIDEO_MODE_DEPTH, n_pixels);
-	const uint32 dst_chunk_size = get_chunk_size_for_depth(DepthModeForPixelDepth(VIDEO_DRV_DEPTH), n_pixels);
+	const uint32 src_chunk_size = TrivialBytesPerRow(n_pixels, VIDEO_MODE_DEPTH);
+	const uint32 dst_chunk_size = TrivialBytesPerRow(n_pixels, DepthModeForPixelDepth(VIDEO_DRV_DEPTH));
 	assert(src_chunk_size * n_chunks <= src_bytes_per_row);
 	assert(dst_chunk_size * n_chunks <= dst_bytes_per_row);
 	const uint32 src_chunk_size_left = src_bytes_per_row - (n_chunks * src_chunk_size);

--- a/BasiliskII/src/CrossPlatform/video_vosf.h
+++ b/BasiliskII/src/CrossPlatform/video_vosf.h
@@ -597,8 +597,8 @@ static void update_display_dga_vosf(VIDEO_DRV_DGA_INIT)
 	const uint32 n_pixels_left = VIDEO_MODE_X - (n_chunks * n_pixels);
 	const uint32 src_chunk_size = get_chunk_size_for_depth(VIDEO_MODE_DEPTH, n_pixels);
 	const uint32 dst_chunk_size = get_chunk_size_for_depth(DepthModeForPixelDepth(VIDEO_DRV_DEPTH), n_pixels);
-	assert(src_chunk_size <= src_bytes_per_row);
-	assert(dst_chunk_size <= dst_bytes_per_row);
+	assert(src_chunk_size * n_chunks <= src_bytes_per_row);
+	assert(dst_chunk_size * n_chunks <= dst_bytes_per_row);
 	const uint32 src_chunk_size_left = src_bytes_per_row - (n_chunks * src_chunk_size);
 	const uint32 dst_chunk_size_left = dst_bytes_per_row - (n_chunks * dst_chunk_size);
 
@@ -666,8 +666,6 @@ static void update_display_dga_vosf(VIDEO_DRV_DGA_INIT)
 					memcpy(the_buffer_copy + i1, the_buffer + i1, src_chunk_size_left);
 					Screen_blit(the_host_buffer + i2, the_buffer + i1, src_chunk_size_left);
 				}
-				i1 += src_chunk_size_left;
-				i2 += dst_chunk_size_left;
 #ifdef USE_SDL_VIDEO
 				const int x = n_chunks * n_pixels;
 				if (x < bb[bbi].x) {
@@ -681,7 +679,8 @@ static void update_display_dga_vosf(VIDEO_DRV_DGA_INIT)
 					bb[bbi].w  = x + n_pixels_left - bb[bbi].x;
 #endif
 			}
-			i2 += scr_bytes_left;
+			i1 += src_chunk_size_left;
+			i2 += dst_chunk_size_left + scr_bytes_left;
 #ifdef USE_SDL_VIDEO
 			bb[bbi].h++;
 			if (bb[bbi].w && (j == y1 || j == y2 - 1 || j == y2)) {

--- a/BasiliskII/src/CrossPlatform/video_vosf.h
+++ b/BasiliskII/src/CrossPlatform/video_vosf.h
@@ -540,6 +540,27 @@ static void update_display_window_vosf(VIDEO_DRV_WIN_INIT)
 
 #ifndef TEST_VOSF_PERFORMANCE
 #if REAL_ADDRESSING || DIRECT_ADDRESSING
+
+static uint32 get_chunk_size_for_depth(const uint32 mode, const uint32 n_pixels) {
+	assert(n_pixels % 8 == 0);
+	switch(mode) {
+		case APPLE_1_BIT:
+			return n_pixels / 8;
+		case APPLE_2_BIT:
+			return n_pixels / 4;
+		case APPLE_4_BIT:
+			return n_pixels / 2;
+		case APPLE_8_BIT:
+			return n_pixels;
+		case APPLE_16_BIT:
+			return n_pixels * 2;
+		case APPLE_32_BIT:
+			return n_pixels * 4;
+		default:
+			assert(false);
+	}
+}
+
 static void update_display_dga_vosf(VIDEO_DRV_DGA_INIT)
 {
 	VIDEO_MODE_INIT;
@@ -574,8 +595,10 @@ static void update_display_dga_vosf(VIDEO_DRV_DGA_INIT)
 	const uint32 n_pixels = 64;
 	const uint32 n_chunks = VIDEO_MODE_X / n_pixels;
 	const uint32 n_pixels_left = VIDEO_MODE_X - (n_chunks * n_pixels);
-	const uint32 src_chunk_size = src_bytes_per_row / n_chunks;
-	const uint32 dst_chunk_size = dst_bytes_per_row / n_chunks;
+	const uint32 src_chunk_size = get_chunk_size_for_depth(VIDEO_MODE_DEPTH, n_pixels);
+	const uint32 dst_chunk_size = get_chunk_size_for_depth(DepthModeForPixelDepth(VIDEO_DRV_DEPTH), n_pixels);
+	assert(src_chunk_size <= src_bytes_per_row);
+	assert(dst_chunk_size <= dst_bytes_per_row);
 	const uint32 src_chunk_size_left = src_bytes_per_row - (n_chunks * src_chunk_size);
 	const uint32 dst_chunk_size_left = dst_bytes_per_row - (n_chunks * dst_chunk_size);
 


### PR DESCRIPTION
Some fixes for video issues in full screen mode in VOSF builds
- Vertical oddly-coloured pinstripes or bands in 800x600 in millions/thousands rakslice/macemu#46
- Skew within updates in low colour modes in resolutions with unaligned widths rakslice/macemu#51