### PR TITLE
Fixes for cursor warping in "hardcursor" mode on Windows

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -2029,7 +2029,7 @@ void video_set_cursor(void)
 					if (cursor_in_window) {
 						int x, y;
 						SDL_GetMouseState(&x, &y);
-						printf("WarpMouse to {%d,%d} via video_set_cursor\n", x, y);
+						D(bug("WarpMouse to {%d,%d} via video_set_cursor\n", x, y));
 						SDL_WarpMouseInWindow(sdl_window, x, y);
 					}
 				}


### PR DESCRIPTION
On Windows, in windowed mode, when the `"hardcursor"` pref is set to `true`, cursor image setting with `video_set_cursor` also repositions the host cursor to the position of the emulated Mac cursor. However it does this when the cursor is not being used in the emulator, effectively stealing focus, and it moves it to the wrong place, off by the offset of the window within the screen.

- Fix for moving the cursor to the wrong place (window-relative coordinates should be used with a window-relative mouse warp)
- Added checks so the cursor is not warped in windowed mode in situations where it would interfere with other host system use
  - When the window is not focused
  - When the window is focused but the host cursor is not in the bounds of the window
- Make the debug message when this happens actually a debug message and not a `printf`