### PR TITLE
Improved fix for resource forks not being created on APFS volumes

### DIFF
--- a/BasiliskII/src/MacOSX/extfs_macosx.cpp
+++ b/BasiliskII/src/MacOSX/extfs_macosx.cpp
@@ -252,7 +252,7 @@ static int open_rsrc(const char *path, int flag)
 	make_rsrc_path(path, rsrc_path);
 
 	int fd = open(rsrc_path, flag);
-	if (fd < 0 && flag == O_WRONLY) fd = open(rsrc_path, O_WRONLY | O_CREAT); // for APFS
+	if (fd < 0 && (flag == O_WRONLY || flag == O_RDWR)) fd = open(rsrc_path, flag | O_CREAT); // for APFS
 	return fd;
 }
 


### PR DESCRIPTION
APFS requires that the resource fork to be created. The existing fix was only doing that for files opened O_WRONLY, have modified the code to also do this for O_RDWR.

Fixes a problem I was seeing where the resource fork was not being created for files copied to the shared file system when it is an APFS file system.