### PR TITLE
Add "sdl_vsync" pref in Windows (SDL_Renderer)

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -793,8 +793,15 @@ static SDL_Surface * init_sdl_video(int width, int height, int bpp, Uint32 flags
 #else
 			SDL_SetHint(SDL_HINT_RENDER_DRIVER, "");
 #endif
+	    }
+
+		bool sdl_vsync = PrefsFindBool("sdl_vsync");
+		if (sdl_vsync) {
+			SDL_SetHint(SDL_HINT_RENDER_VSYNC, "1");
 		}
+
 		sdl_renderer = SDL_CreateRenderer(sdl_window, -1, 0);
+
 		if (!sdl_renderer) {
 			shutdown_sdl_video();
 			return NULL;

--- a/SheepShaver/src/Windows/prefs_windows.cpp
+++ b/SheepShaver/src/Windows/prefs_windows.cpp
@@ -56,6 +56,7 @@ prefs_desc platform_prefs_items[] = {
 	{"portfile1", TYPE_STRING, false,               "output file for serial port 1"},
 #ifdef USE_SDL_VIDEO
 	{"sdlrender", TYPE_STRING, false,      "SDL_Renderer driver (\"auto\", \"software\" (may be faster), etc.)"},
+	{"sdl_vsync", TYPE_BOOLEAN, false,     "Make SDL_Renderer vertical sync frames to host (eg. with software renderer)"},
 #endif
 
 	{NULL, TYPE_END, false, NULL} // End of list

--- a/SheepShaver/src/Windows/prefs_windows.cpp
+++ b/SheepShaver/src/Windows/prefs_windows.cpp
@@ -141,4 +141,8 @@ void AddPlatformPrefsDefaults(void)
 	PrefsReplaceString("serialb", "COM2");
 	PrefsReplaceString("portfile0", "C:\\B2TEMP0.OUT");
 	PrefsReplaceString("portfile1", "C:\\B2TEMP1.OUT");
+#ifdef USE_SDL_VIDEO
+	PrefsReplaceString("sdlrender", "software");
+	PrefsReplaceBool("sdl_vsync", false);
+#endif
 }


### PR DESCRIPTION
Add option to perform vertical sync with SDL_Renderer eg. for Windows hosts using default Software renderer (as it ignores OS & display adapter settings). Make option default visible in config file along with "sdlrender"