### PR TITLE
Include scancode when reservewindowskey is enabled

### DIFF
--- a/BasiliskII/src/Windows/main_windows.cpp
+++ b/BasiliskII/src/Windows/main_windows.cpp
@@ -749,6 +749,7 @@ static LRESULT CALLBACK low_level_keyboard_hook(int nCode, WPARAM wParam, LPARAM
 					memset(&e, 0, sizeof(e));
 					e.type = (wParam == WM_KEYDOWN) ? SDL_KEYDOWN : SDL_KEYUP;
 					e.key.keysym.sym = (p->vkCode == VK_LWIN) ? SDLK_LGUI : SDLK_RGUI;
+					e.key.keysym.scancode = (p->vkCode == VK_LWIN) ? SDL_SCANCODE_LGUI : SDL_SCANCODE_RGUI;
 					SDL_PushEvent(&e);
 					return 1;
 				}

--- a/SheepShaver/src/Windows/main_windows.cpp
+++ b/SheepShaver/src/Windows/main_windows.cpp
@@ -877,6 +877,7 @@ static LRESULT CALLBACK low_level_keyboard_hook(int nCode, WPARAM wParam, LPARAM
 					memset(&e, 0, sizeof(e));
 					e.type = (wParam == WM_KEYDOWN) ? SDL_KEYDOWN : SDL_KEYUP;
 					e.key.keysym.sym = (p->vkCode == VK_LWIN) ? SDLK_LGUI : SDLK_RGUI;
+					e.key.keysym.scancode = (p->vkCode == VK_LWIN) ? SDL_SCANCODE_LGUI : SDL_SCANCODE_RGUI;
 					SDL_PushEvent(&e);
 					return 1;
 				}


### PR DESCRIPTION
I made a mistake with the implementation of the new reservewindowskey option. I was only filling in keysym.sym when generating the SDL key event, but Basilisk and SheepShaver also care about keysym.scancode. This caused a problem with some keycodes files not working correctly.

See discussion:
https://www.emaculation.com/forum/viewtopic.php?p=72685