### PR TITLE
Volume creation changes for the Unix GTK prefs editor.

### DIFF
--- a/BasiliskII/src/Unix/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk.cpp
@@ -581,7 +581,7 @@ static void create_volume_ok(GtkWidget *button, file_req_assoc *assoc)
 		delete assoc;
 		return;
 	}
-	int fd = open(file, O_CREAT | O_WRONLY | O_EXCL, S_IRUSR | S_IWUSR);
+	int fd = open(file, O_CREAT | O_WRONLY | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 	if (fd < 0 && errno == EEXIST) {
 		printf("File already exists, refusing to overwrite file.\n");
 	} else {

--- a/BasiliskII/src/Unix/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk.cpp
@@ -23,6 +23,7 @@
 #include <gtk/gtk.h>
 #include <stdlib.h>
 #include <dirent.h>
+#include <unistd.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
@@ -572,15 +573,22 @@ static void add_volume_ok(GtkWidget *button, file_req_assoc *assoc)
 static void create_volume_ok(GtkWidget *button, file_req_assoc *assoc)
 {
 	gchar *file = (gchar *)gtk_file_selection_get_filename(GTK_FILE_SELECTION(assoc->req));
-
 	const gchar *str = gtk_entry_get_text(GTK_ENTRY(assoc->entry));
-	int size = atoi(str);
-
-	char cmd[1024];
-	sprintf(cmd, "dd if=/dev/zero \"of=%s\" bs=1024k count=%d", file, size);
-	int ret = system(cmd);
-	if (ret == 0)
+	int disk_size = atoi(str);
+	if (disk_size < 1 || disk_size > 2000) {
+		printf("Disk size needs to be between 1 and 2000 MB.\n");
+		gtk_widget_destroy(GTK_WIDGET(assoc->req));
+		delete assoc;
+		return;
+	}
+	int fd = open(file, O_CREAT | O_WRONLY | O_EXCL, S_IRUSR | S_IWUSR);
+	if (fd < 0 && errno == EEXIST) {
+		printf("File already exists, refusing to overwrite file.\n");
+	} else {
+		ftruncate(fd, disk_size * 1024 * 1024);
 		gtk_clist_append(GTK_CLIST(volume_list), &file);
+	}
+	close(fd);
 	gtk_widget_destroy(GTK_WIDGET(assoc->req));
 	delete assoc;
 }

--- a/SheepShaver/src/Unix/prefs_editor_gtk.cpp
+++ b/SheepShaver/src/Unix/prefs_editor_gtk.cpp
@@ -510,7 +510,7 @@ static void create_volume_ok(GtkWidget *button, file_req_assoc *assoc)
 		delete assoc;
 		return;
 	}
-	int fd = open(file, O_CREAT | O_WRONLY | O_EXCL, S_IRUSR | S_IWUSR);
+	int fd = open(file, O_CREAT | O_WRONLY | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 	if (fd < 0 && errno == EEXIST) {
 		printf("File already exists, refusing to overwrite file.\n");
 	} else {


### PR DESCRIPTION
There were some issues in the GTK prefs editor for Unix. The file picker for disk creation overwrote files. It relied on the dd system utility to create the disks etc. There are still some issues left, but I hope to get to them later.