### PR TITLE
Further fixes

### DIFF
--- a/BasiliskII/src/SDL/video_sdl.cpp
+++ b/BasiliskII/src/SDL/video_sdl.cpp
@@ -69,6 +69,9 @@
 #define DEBUG 0
 #include "debug.h"
 
+#define CODE_INVALID -1
+#define CODE_HOTKEY  -2
+
 // Supported video modes
 using std::vector;
 static vector<VIDEO_MODE> VideoModes;
@@ -874,7 +877,7 @@ static void keycode_init(void)
 
 		// Default translation table
 		for (int i=0; i<256; i++)
-			keycode_table[i] = -1;
+			keycode_table[i] = CODE_INVALID;
 
 		// Search for server vendor string, then read keycodes
 		char video_driver[256];
@@ -1658,8 +1661,8 @@ static int modify_opt_cmd(int code) {
 }
 
 /*
- *  Translate key event to Mac keycode, returns -1 if no keycode was found
- *  and -2 if the key was recognized as a hotkey
+ *  Translate key event to Mac keycode, returns CODE_INVALID if no keycode was found
+ *  and CODE_HOTKEY if the key was recognized as a hotkey
  */
 
 static int kc_decode(SDL_keysym const & ks, bool key_down)
@@ -1715,8 +1718,8 @@ static int kc_decode(SDL_keysym const & ks, bool key_down)
 	case SDLK_PERIOD: case SDLK_GREATER: return 0x2f;
 	case SDLK_SLASH: case SDLK_QUESTION: return 0x2c;
 
-	case SDLK_TAB: if (is_hotkey_down(ks)) {if (!key_down) drv->suspend(); return -2;} else return 0x30;
-	case SDLK_RETURN: if (is_hotkey_down(ks)) {if (!key_down) toggle_fullscreen = true; return -2;} else return 0x24;
+	case SDLK_TAB: if (is_hotkey_down(ks)) {if (!key_down) drv->suspend(); return CODE_HOTKEY;} else return 0x30;
+	case SDLK_RETURN: if (is_hotkey_down(ks)) {if (!key_down) toggle_fullscreen = true; return CODE_HOTKEY;} else return 0x24;
 	case SDLK_SPACE: return 0x31;
 	case SDLK_BACKSPACE: return 0x33;
 
@@ -1727,13 +1730,11 @@ static int kc_decode(SDL_keysym const & ks, bool key_down)
 	case SDLK_PAGEUP: return 0x74;
 	case SDLK_PAGEDOWN: return 0x79;
 
-	case SDLK_LCTRL: return 0x36;
-	case SDLK_RCTRL: return 0x36;
-	case SDLK_LSHIFT: return 0x38;
-	case SDLK_RSHIFT: return 0x38;
-	case SDLK_LALT: case SDLK_RALT: return 0x3a;
-	case SDLK_LMETA: case SDLK_RMETA: return 0x37;
-	case SDLK_LSUPER: case SDLK_RSUPER: return 0x37; // "Windows" key
+	case SDLK_LCTRL: case SDLK_RCTRL: ctrl_down = key_down; return 0x36;
+	case SDLK_LSHIFT: case SDLK_RSHIFT: return 0x38;
+	case SDLK_LALT: case SDLK_RALT: alt_down = key_down; return 0x3a;
+	case SDLK_LMETA: case SDLK_RMETA: super_down = key_down; return 0x37;
+	case SDLK_LSUPER: case SDLK_RSUPER: super_down = key_down; return 0x37; // "Windows" key
 	case SDLK_MENU: return 0x32;
 	case SDLK_CAPSLOCK: return 0x39;
 	case SDLK_NUMLOCK: return 0x47;
@@ -1743,13 +1744,13 @@ static int kc_decode(SDL_keysym const & ks, bool key_down)
 	case SDLK_LEFT: return 0x3b;
 	case SDLK_RIGHT: return 0x3c;
 
-	case SDLK_ESCAPE: if (is_hotkey_down(ks)) {if (!key_down) { quit_full_screen = true; emerg_quit = true; } return -2;} else return 0x35;
+	case SDLK_ESCAPE: if (is_hotkey_down(ks)) {if (!key_down) { quit_full_screen = true; emerg_quit = true; } return CODE_HOTKEY;} else return 0x35;
 
-	case SDLK_F1: if (is_hotkey_down(ks)) {if (!key_down) SysMountFirstFloppy(); return -2;} else return 0x7a;
+	case SDLK_F1: if (is_hotkey_down(ks)) {if (!key_down) SysMountFirstFloppy(); return CODE_HOTKEY;} else return 0x7a;
 	case SDLK_F2: return 0x78;
 	case SDLK_F3: return 0x63;
 	case SDLK_F4: return 0x76;
-	case SDLK_F5: if (is_hotkey_down(ks)) {if (!key_down) drv->toggle_mouse_grab(); return -2;} else return 0x60;
+	case SDLK_F5: if (is_hotkey_down(ks)) {if (!key_down) drv->toggle_mouse_grab(); return CODE_HOTKEY;} else return 0x60;
 	case SDLK_F6: return 0x61;
 	case SDLK_F7: return 0x62;
 	case SDLK_F8: return 0x64;
@@ -1781,7 +1782,7 @@ static int kc_decode(SDL_keysym const & ks, bool key_down)
 	case SDLK_KP_EQUALS: return 0x51;
 	}
 	D(bug("Unhandled SDL keysym: %d\n", ks.sym));
-	return -1;
+	return CODE_INVALID;
 }
 
 static int event2keycode(SDL_KeyboardEvent const &ev, bool key_down)
@@ -1864,23 +1865,16 @@ static void handle_events(void)
 
 			// Keyboard
 			case SDL_KEYDOWN: {
-				int code = -1;
-				if (use_keycodes && !is_modifier_key(event.key)) {
-					if (event2keycode(event.key, true) != -2)	// This is called to process the hotkeys
+				int code = CODE_INVALID;
+				// This is called to process the hotkeys
+				if (use_keycodes && !is_modifier_key(event.key) && event2keycode(event.key, true) != CODE_HOTKEY)
 						code = keycode_table[event.key.keysym.scancode & 0xff];
-				} else
+				if (code == CODE_INVALID)
 					code = event2keycode(event.key, true);
 				if (code >= 0) {
 					if (!emul_suspended) {
-						if (code == 0x36) {
-							ctrl_down = true;
-						} else if (code == 0x3a) {
-							alt_down = true;
-						    code = modify_opt_cmd(code);
-						} else if (code == 0x37) {
-							super_down = true;
-						    code = modify_opt_cmd(code);
-						}
+						if (code == 0x3a || code == 0x37)
+							code = modify_opt_cmd(code);
 						if (code == 0x39) {	// Caps Lock pressed
 							if (caps_on) {
 								ADBKeyUp(code);
@@ -1899,22 +1893,15 @@ static void handle_events(void)
 				break;
 			}
 			case SDL_KEYUP: {
-				int code = -1;
-				if (use_keycodes && !is_modifier_key(event.key)) {
-					if (event2keycode(event.key, false) != -2)	// This is called to process the hotkeys
+				int code = CODE_INVALID;
+				// This is called to process the hotkeys
+				if (use_keycodes && !is_modifier_key(event.key) && event2keycode(event.key, false) != CODE_HOTKEY)
 						code = keycode_table[event.key.keysym.scancode & 0xff];
-				} else
+				if (code == CODE_INVALID)
 					code = event2keycode(event.key, false);
 				if (code >= 0) {
-					if (code == 0x36) {
-						ctrl_down = false;
-					} else if (code == 0x3a) {
-						alt_down = false;
-					    code = modify_opt_cmd(code);
-					} else if (code == 0x37) {
-						super_down = false;
-					    code = modify_opt_cmd(code);
-					}
+					if (code == 0x3a ||code == 0x37)
+						code = modify_opt_cmd(code);
 					if (code == 0x39) {	// Caps Lock released
 						if (caps_on) {
 							ADBKeyUp(code);

--- a/BasiliskII/src/SDL/video_sdl.cpp
+++ b/BasiliskII/src/SDL/video_sdl.cpp
@@ -119,7 +119,9 @@ static bool use_vosf = false;						// Flag: VOSF enabled
 static const bool use_vosf = false;					// VOSF not possible
 #endif
 
-static bool ctrl_down = false;						// Flag: Ctrl key pressed
+static bool ctrl_down = false;						// Flag: Ctrl key pressed (for use with hotkeys)
+static bool alt_down = false;						// Flag: Alt/Opt key pressed (for use with hotkeys)
+static bool super_down = false;						// Flag: Super/Cmd/Win key pressed (for use with hotkeys)
 static bool caps_on = false;						// Flag: Caps Lock on
 static bool quit_full_screen = false;				// Flag: DGA close requested from redraw thread
 static bool emerg_quit = false;						// Flag: Ctrl-Esc pressed, emergency quit requested from MacOS thread
@@ -1631,11 +1633,29 @@ static bool is_modifier_key(SDL_KeyboardEvent const & e)
 	return false;
 }
 
-static bool is_ctrl_down(SDL_keysym const & ks)
+static bool is_hotkey_down(SDL_keysym const & ks)
 {
-	return ctrl_down || (ks.mod & KMOD_CTRL);
+	int hotkey = PrefsFindInt32("hotkey");
+	if (!hotkey) hotkey = 1;
+	return (ctrl_down || (ks.mod & KMOD_CTRL) || !(hotkey & 1)) &&
+			(alt_down || (ks.mod & KMOD_ALT) || !(hotkey & 2)) &&
+			(super_down || (ks.mod & KMOD_META) || !(hotkey & 4));
 }
 
+static int modify_opt_cmd(int code) {
+	static bool f, c;
+	if (!f) {
+		f = true;
+		c = PrefsFindBool("swap_opt_cmd");
+	}
+	if (c) {
+		switch (code) {
+			case 0x37: return 0x3a;
+			case 0x3a: return 0x37;
+		}
+	}
+	return code;
+}
 
 /*
  *  Translate key event to Mac keycode, returns -1 if no keycode was found
@@ -1695,8 +1715,8 @@ static int kc_decode(SDL_keysym const & ks, bool key_down)
 	case SDLK_PERIOD: case SDLK_GREATER: return 0x2f;
 	case SDLK_SLASH: case SDLK_QUESTION: return 0x2c;
 
-	case SDLK_TAB: if (is_ctrl_down(ks)) {if (!key_down) drv->suspend(); return -2;} else return 0x30;
-	case SDLK_RETURN: if (is_ctrl_down(ks)) {if (!key_down) toggle_fullscreen = true; return -2;} else return 0x24;
+	case SDLK_TAB: if (is_hotkey_down(ks)) {if (!key_down) drv->suspend(); return -2;} else return 0x30;
+	case SDLK_RETURN: if (is_hotkey_down(ks)) {if (!key_down) toggle_fullscreen = true; return -2;} else return 0x24;
 	case SDLK_SPACE: return 0x31;
 	case SDLK_BACKSPACE: return 0x33;
 
@@ -1711,19 +1731,9 @@ static int kc_decode(SDL_keysym const & ks, bool key_down)
 	case SDLK_RCTRL: return 0x36;
 	case SDLK_LSHIFT: return 0x38;
 	case SDLK_RSHIFT: return 0x38;
-#if (defined(__APPLE__) && defined(__MACH__))
-	case SDLK_LALT: return 0x3a;
-	case SDLK_RALT: return 0x3a;
-	case SDLK_LMETA: return 0x37;
-	case SDLK_RMETA: return 0x37;
-#else
-	case SDLK_LALT: return 0x37;
-	case SDLK_RALT: return 0x37;
-	case SDLK_LMETA: return 0x3a;
-	case SDLK_RMETA: return 0x3a;
-#endif
-	case SDLK_LSUPER: return 0x3a; // "Windows" key
-	case SDLK_RSUPER: return 0x3a;
+	case SDLK_LALT: case SDLK_RALT: return 0x3a;
+	case SDLK_LMETA: case SDLK_RMETA: return 0x37;
+	case SDLK_LSUPER: case SDLK_RSUPER: return 0x37; // "Windows" key
 	case SDLK_MENU: return 0x32;
 	case SDLK_CAPSLOCK: return 0x39;
 	case SDLK_NUMLOCK: return 0x47;
@@ -1733,13 +1743,13 @@ static int kc_decode(SDL_keysym const & ks, bool key_down)
 	case SDLK_LEFT: return 0x3b;
 	case SDLK_RIGHT: return 0x3c;
 
-	case SDLK_ESCAPE: if (is_ctrl_down(ks)) {if (!key_down) { quit_full_screen = true; emerg_quit = true; } return -2;} else return 0x35;
+	case SDLK_ESCAPE: if (is_hotkey_down(ks)) {if (!key_down) { quit_full_screen = true; emerg_quit = true; } return -2;} else return 0x35;
 
-	case SDLK_F1: if (is_ctrl_down(ks)) {if (!key_down) SysMountFirstFloppy(); return -2;} else return 0x7a;
+	case SDLK_F1: if (is_hotkey_down(ks)) {if (!key_down) SysMountFirstFloppy(); return -2;} else return 0x7a;
 	case SDLK_F2: return 0x78;
 	case SDLK_F3: return 0x63;
 	case SDLK_F4: return 0x76;
-	case SDLK_F5: if (is_ctrl_down(ks)) {if (!key_down) drv->toggle_mouse_grab(); return -2;} else return 0x60;
+	case SDLK_F5: if (is_hotkey_down(ks)) {if (!key_down) drv->toggle_mouse_grab(); return -2;} else return 0x60;
 	case SDLK_F6: return 0x61;
 	case SDLK_F7: return 0x62;
 	case SDLK_F8: return 0x64;
@@ -1862,6 +1872,15 @@ static void handle_events(void)
 					code = event2keycode(event.key, true);
 				if (code >= 0) {
 					if (!emul_suspended) {
+						if (code == 0x36) {
+							ctrl_down = true;
+						} else if (code == 0x3a) {
+							alt_down = true;
+						    code = modify_opt_cmd(code);
+						} else if (code == 0x37) {
+							super_down = true;
+						    code = modify_opt_cmd(code);
+						}
 						if (code == 0x39) {	// Caps Lock pressed
 							if (caps_on) {
 								ADBKeyUp(code);
@@ -1872,8 +1891,6 @@ static void handle_events(void)
 							}
 						} else
 							ADBKeyDown(code);
-						if (code == 0x36)
-							ctrl_down = true;
 					} else {
 						if (code == 0x31)
 							drv->resume();	// Space wakes us up
@@ -1889,6 +1906,15 @@ static void handle_events(void)
 				} else
 					code = event2keycode(event.key, false);
 				if (code >= 0) {
+					if (code == 0x36) {
+						ctrl_down = false;
+					} else if (code == 0x3a) {
+						alt_down = false;
+					    code = modify_opt_cmd(code);
+					} else if (code == 0x37) {
+						super_down = false;
+					    code = modify_opt_cmd(code);
+					}
 					if (code == 0x39) {	// Caps Lock released
 						if (caps_on) {
 							ADBKeyUp(code);
@@ -1899,8 +1925,6 @@ static void handle_events(void)
 						}
 					} else
 						ADBKeyUp(code);
-					if (code == 0x36)
-						ctrl_down = false;
 				}
 				break;
 			}

--- a/BasiliskII/src/SDL/video_sdl.cpp
+++ b/BasiliskII/src/SDL/video_sdl.cpp
@@ -120,8 +120,8 @@ static const bool use_vosf = false;					// VOSF not possible
 #endif
 
 static bool ctrl_down = false;						// Flag: Ctrl key pressed (for use with hotkeys)
-static bool alt_down = false;						// Flag: Alt/Opt key pressed (for use with hotkeys)
-static bool super_down = false;						// Flag: Super/Cmd/Win key pressed (for use with hotkeys)
+static bool opt_down = false;						// Flag: Opt/Alt key pressed (for use with hotkeys)
+static bool cmd_down = false;						// Flag: Cmd/Super/Win key pressed (for use with hotkeys)
 static bool caps_on = false;						// Flag: Caps Lock on
 static bool quit_full_screen = false;				// Flag: DGA close requested from redraw thread
 static bool emerg_quit = false;						// Flag: Ctrl-Esc pressed, emergency quit requested from MacOS thread
@@ -1638,8 +1638,8 @@ static bool is_hotkey_down(SDL_keysym const & ks)
 	int hotkey = PrefsFindInt32("hotkey");
 	if (!hotkey) hotkey = 1;
 	return (ctrl_down || (ks.mod & KMOD_CTRL) || !(hotkey & 1)) &&
-			(alt_down || (ks.mod & KMOD_ALT) || !(hotkey & 2)) &&
-			(super_down || (ks.mod & KMOD_META) || !(hotkey & 4));
+			(opt_down || (ks.mod & KMOD_ALT) || !(hotkey & 2)) &&
+			(cmd_down || (ks.mod & KMOD_META) || !(hotkey & 4));
 }
 
 static int modify_opt_cmd(int code) {
@@ -1875,10 +1875,10 @@ static void handle_events(void)
 						if (code == 0x36) {
 							ctrl_down = true;
 						} else if (code == 0x3a) {
-							alt_down = true;
+							opt_down = true;
 						    code = modify_opt_cmd(code);
 						} else if (code == 0x37) {
-							super_down = true;
+							cmd_down = true;
 						    code = modify_opt_cmd(code);
 						}
 						if (code == 0x39) {	// Caps Lock pressed
@@ -1909,10 +1909,10 @@ static void handle_events(void)
 					if (code == 0x36) {
 						ctrl_down = false;
 					} else if (code == 0x3a) {
-						alt_down = false;
+						opt_down = false;
 					    code = modify_opt_cmd(code);
 					} else if (code == 0x37) {
-						super_down = false;
+						cmd_down = false;
 					    code = modify_opt_cmd(code);
 					}
 					if (code == 0x39) {	// Caps Lock released

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -128,9 +128,9 @@ static bool use_vosf = false;						// Flag: VOSF enabled
 static const bool use_vosf = false;					// VOSF not possible
 #endif
 
-static bool ctrl_down = false;						// Flag: Ctrl key pressed (for use with hotkeys)
-static bool alt_down = false;						// Flag: Alt/Opt key pressed (for use with hotkeys)
-static bool super_down = false;						// Flag: Super/Cmd/Win key pressed (for use with hotkeys)
+static bool ctrl_down = false;						// Flag: Ctrl key pressed
+static bool opt_down = false;						// Flag: Opt key pressed
+static bool cmd_down = false;						// Flag: Cmd key pressed
 static bool quit_full_screen = false;				// Flag: DGA close requested from redraw thread
 static bool emerg_quit = false;						// Flag: Ctrl-Esc pressed, emergency quit requested from MacOS thread
 static bool emul_suspended = false;					// Flag: Emulator suspended
@@ -2053,8 +2053,8 @@ static bool is_hotkey_down(SDL_Keysym const & ks)
 	int hotkey = PrefsFindInt32("hotkey");
 	if (!hotkey) hotkey = 1;
 	return (ctrl_down || (ks.mod & KMOD_CTRL) || !(hotkey & 1)) &&
-			(alt_down || (ks.mod & KMOD_ALT) || !(hotkey & 2)) &&
-			(super_down || (ks.mod & KMOD_GUI) || !(hotkey & 4));
+			(opt_down || (ks.mod & KMOD_ALT) || !(hotkey & 2)) &&
+			(cmd_down || (ks.mod & KMOD_GUI) || !(hotkey & 4));
 }
 
 static int modify_opt_cmd(int code) {
@@ -2357,19 +2357,17 @@ static void handle_events(void)
 					code = event2keycode(event.key, true);
 				if (code >= 0) {
 					if (!emul_suspended) {
-						if (code == 0x36) {
-							ctrl_down = true;
-						} else if (code == 0x3a) {
-							alt_down = true;
-						    code = modify_opt_cmd(code);
-						} else if (code == 0x37) {
-							super_down = true;
-						    code = modify_opt_cmd(code);
-						}
-						if (code == 0x39) {
+						code = modify_opt_cmd(code);
+						if (code == 0x39)
 							(SDL_GetModState() & KMOD_CAPS ? ADBKeyDown : ADBKeyUp)(code);
 						} else
 							ADBKeyDown(code);
+						if (code == 0x36)
+							ctrl_down = true;
+						if (code == 0x3a)
+							opt_down = true;
+						if (code == 0x37)
+							cmd_down = true;
 						
 					} else {
 						if (code == 0x31)
@@ -2385,17 +2383,15 @@ static void handle_events(void)
 				if (code == CODE_INVALID)
 					code = event2keycode(event.key, false);
 				if (code >= 0) {
-					if (code == 0x36) {
-						ctrl_down = false;
-					} else if (code == 0x3a) {
-						alt_down = false;
-					    code = modify_opt_cmd(code);
-					} else if (code == 0x37) {
-						super_down = false;
-					    code = modify_opt_cmd(code);
-					}
+					code = modify_opt_cmd(code);
 					if (code != 0x39)
 						ADBKeyUp(code);
+					if (code == 0x36)
+						ctrl_down = false;
+					if (code == 0x3a)
+						opt_down = false;
+					if (code == 0x37)
+						cmd_down = false;
 				}
 				break;
 			}

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -128,9 +128,9 @@ static bool use_vosf = false;						// Flag: VOSF enabled
 static const bool use_vosf = false;					// VOSF not possible
 #endif
 
-static bool ctrl_down = false;						// Flag: Ctrl key pressed
-static bool alt_down = false;						// Flag: Alt/Opt key pressed (for use outside emulator)
-static bool super_down = false;						// Flag: Super/Cmd key pressed (for use outside emulator)
+static bool ctrl_down = false;						// Flag: Ctrl key pressed (for use with hotkeys)
+static bool alt_down = false;						// Flag: Alt/Opt key pressed (for use with hotkeys)
+static bool super_down = false;						// Flag: Super/Cmd/Win key pressed (for use with hotkeys)
 static bool quit_full_screen = false;				// Flag: DGA close requested from redraw thread
 static bool emerg_quit = false;						// Flag: Ctrl-Esc pressed, emergency quit requested from MacOS thread
 static bool emul_suspended = false;					// Flag: Emulator suspended
@@ -2357,16 +2357,18 @@ static void handle_events(void)
 					code = event2keycode(event.key, true);
 				if (code >= 0) {
 					if (!emul_suspended) {
-						if (code == 0x36)
+						if (code == 0x36) {
 							ctrl_down = true;
-						if (code == 0x3a)
+						} else if (code == 0x3a) {
 							alt_down = true;
-						if (code == 0x37)
+						    code = modify_opt_cmd(code);
+						} else if (code == 0x37) {
 							super_down = true;
-						code = modify_opt_cmd(code);
-						if (code == 0x39)
+						    code = modify_opt_cmd(code);
+						}
+						if (code == 0x39) {
 							(SDL_GetModState() & KMOD_CAPS ? ADBKeyDown : ADBKeyUp)(code);
-						else
+						} else
 							ADBKeyDown(code);
 						
 					} else {
@@ -2383,13 +2385,15 @@ static void handle_events(void)
 				if (code == CODE_INVALID)
 					code = event2keycode(event.key, false);
 				if (code >= 0) {
-					if (code == 0x36)
+					if (code == 0x36) {
 						ctrl_down = false;
-					if (code == 0x3a)
+					} else if (code == 0x3a) {
 						alt_down = false;
-					if (code == 0x37)
+					    code = modify_opt_cmd(code);
+					} else if (code == 0x37) {
 						super_down = false;
-					code = modify_opt_cmd(code);
+					    code = modify_opt_cmd(code);
+					}
 					if (code != 0x39)
 						ADBKeyUp(code);
 				}

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -128,9 +128,9 @@ static bool use_vosf = false;						// Flag: VOSF enabled
 static const bool use_vosf = false;					// VOSF not possible
 #endif
 
-static bool ctrl_down = false;						// Flag: Ctrl key pressed
-static bool opt_down = false;						// Flag: Opt key pressed
-static bool cmd_down = false;						// Flag: Cmd key pressed
+static bool ctrl_down = false;						// Flag: Ctrl key pressed (for use with hotkeys)
+static bool opt_down = false;						// Flag: Opt/Alt key pressed (for use with hotkeys)
+static bool cmd_down = false;						// Flag: Cmd/Super/Win key pressed (for use with hotkeys)
 static bool quit_full_screen = false;				// Flag: DGA close requested from redraw thread
 static bool emerg_quit = false;						// Flag: Ctrl-Esc pressed, emergency quit requested from MacOS thread
 static bool emul_suspended = false;					// Flag: Emulator suspended
@@ -2360,7 +2360,7 @@ static void handle_events(void)
 						code = modify_opt_cmd(code);
 						if (code == 0x39)
 							(SDL_GetModState() & KMOD_CAPS ? ADBKeyDown : ADBKeyUp)(code);
-						} else
+						else
 							ADBKeyDown(code);
 						if (code == 0x36)
 							ctrl_down = true;

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -2142,12 +2142,10 @@ static int kc_decode(SDL_Keysym const & ks, bool key_down)
 	case SDLK_PAGEUP: return 0x74;
 	case SDLK_PAGEDOWN: return 0x79;
 
-	case SDLK_LCTRL: return 0x36;
-	case SDLK_RCTRL: return 0x36;
-	case SDLK_LSHIFT: return 0x38;
-	case SDLK_RSHIFT: return 0x38;
-	case SDLK_LALT: case SDLK_RALT: return 0x3a;
-	case SDLK_LGUI: case SDLK_RGUI: return 0x37;
+	case SDLK_LCTRL: SDLK_RCTRL: ctrl_down = key_down; return 0x36;
+	case SDLK_LSHIFT: SDLK_RSHIFT: return 0x38;
+	case SDLK_LALT: case SDLK_RALT: alt_down = key_down; return 0x3a;
+	case SDLK_LGUI: case SDLK_RGUI: super_down = key_down; return 0x37;
 	case SDLK_MENU: return 0x32;
 	case SDLK_CAPSLOCK: return 0x39;
 	case SDLK_NUMLOCKCLEAR: return 0x47;
@@ -2357,24 +2355,15 @@ static void handle_events(void)
 					code = event2keycode(event.key, true);
 				if (code >= 0) {
 					if (!emul_suspended) {
-						if (code == 0x36) {
-							ctrl_down = true;
-						} else if (code == 0x3a) {
-							alt_down = true;
-						    code = modify_opt_cmd(code);
-						} else if (code == 0x37) {
-							super_down = true;
-						    code = modify_opt_cmd(code);
-						}
-						if (code == 0x39) {
+						if (code == 0x3a || code == 0x37)
+							code = modify_opt_cmd(code);
+						if (code == 0x39)
 							(SDL_GetModState() & KMOD_CAPS ? ADBKeyDown : ADBKeyUp)(code);
-						} else
+						else
 							ADBKeyDown(code);
 						
-					} else {
-						if (code == 0x31)
+					} else if (code == 0x31)
 							drv->resume();	// Space wakes us up
-					}
 				}
 				break;
 			}
@@ -2385,15 +2374,8 @@ static void handle_events(void)
 				if (code == CODE_INVALID)
 					code = event2keycode(event.key, false);
 				if (code >= 0) {
-					if (code == 0x36) {
-						ctrl_down = false;
-					} else if (code == 0x3a) {
-						alt_down = false;
-					    code = modify_opt_cmd(code);
-					} else if (code == 0x37) {
-						super_down = false;
-					    code = modify_opt_cmd(code);
-					}
+					if (code == 0x3a ||code == 0x37)
+						code = modify_opt_cmd(code);
 					if (code != 0x39)
 						ADBKeyUp(code);
 				}

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -2142,10 +2142,12 @@ static int kc_decode(SDL_Keysym const & ks, bool key_down)
 	case SDLK_PAGEUP: return 0x74;
 	case SDLK_PAGEDOWN: return 0x79;
 
-	case SDLK_LCTRL: SDLK_RCTRL: ctrl_down = key_down; return 0x36;
-	case SDLK_LSHIFT: SDLK_RSHIFT: return 0x38;
-	case SDLK_LALT: case SDLK_RALT: alt_down = key_down; return 0x3a;
-	case SDLK_LGUI: case SDLK_RGUI: super_down = key_down; return 0x37;
+	case SDLK_LCTRL: return 0x36;
+	case SDLK_RCTRL: return 0x36;
+	case SDLK_LSHIFT: return 0x38;
+	case SDLK_RSHIFT: return 0x38;
+	case SDLK_LALT: case SDLK_RALT: return 0x3a;
+	case SDLK_LGUI: case SDLK_RGUI: return 0x37;
 	case SDLK_MENU: return 0x32;
 	case SDLK_CAPSLOCK: return 0x39;
 	case SDLK_NUMLOCKCLEAR: return 0x47;
@@ -2355,15 +2357,24 @@ static void handle_events(void)
 					code = event2keycode(event.key, true);
 				if (code >= 0) {
 					if (!emul_suspended) {
-						if (code == 0x3a || code == 0x37)
-							code = modify_opt_cmd(code);
-						if (code == 0x39)
+						if (code == 0x36) {
+							ctrl_down = true;
+						} else if (code == 0x3a) {
+							alt_down = true;
+						    code = modify_opt_cmd(code);
+						} else if (code == 0x37) {
+							super_down = true;
+						    code = modify_opt_cmd(code);
+						}
+						if (code == 0x39) {
 							(SDL_GetModState() & KMOD_CAPS ? ADBKeyDown : ADBKeyUp)(code);
-						else
+						} else
 							ADBKeyDown(code);
 						
-					} else if (code == 0x31)
+					} else {
+						if (code == 0x31)
 							drv->resume();	// Space wakes us up
+					}
 				}
 				break;
 			}
@@ -2374,8 +2385,15 @@ static void handle_events(void)
 				if (code == CODE_INVALID)
 					code = event2keycode(event.key, false);
 				if (code >= 0) {
-					if (code == 0x3a ||code == 0x37)
-						code = modify_opt_cmd(code);
+					if (code == 0x36) {
+						ctrl_down = false;
+					} else if (code == 0x3a) {
+						alt_down = false;
+					    code = modify_opt_cmd(code);
+					} else if (code == 0x37) {
+						super_down = false;
+					    code = modify_opt_cmd(code);
+					}
 					if (code != 0x39)
 						ADBKeyUp(code);
 				}

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -129,8 +129,8 @@ static const bool use_vosf = false;					// VOSF not possible
 #endif
 
 static bool ctrl_down = false;						// Flag: Ctrl key pressed
-static bool opt_down = false;						// Flag: Opt key pressed
-static bool cmd_down = false;						// Flag: Cmd key pressed
+static bool alt_down = false;						// Flag: Alt/Opt key pressed (for use outside emulator)
+static bool super_down = false;						// Flag: Super/Cmd key pressed (for use outside emulator)
 static bool quit_full_screen = false;				// Flag: DGA close requested from redraw thread
 static bool emerg_quit = false;						// Flag: Ctrl-Esc pressed, emergency quit requested from MacOS thread
 static bool emul_suspended = false;					// Flag: Emulator suspended
@@ -2053,8 +2053,8 @@ static bool is_hotkey_down(SDL_Keysym const & ks)
 	int hotkey = PrefsFindInt32("hotkey");
 	if (!hotkey) hotkey = 1;
 	return (ctrl_down || (ks.mod & KMOD_CTRL) || !(hotkey & 1)) &&
-			(opt_down || (ks.mod & KMOD_ALT) || !(hotkey & 2)) &&
-			(cmd_down || (ks.mod & KMOD_GUI) || !(hotkey & 4));
+			(alt_down || (ks.mod & KMOD_ALT) || !(hotkey & 2)) &&
+			(super_down || (ks.mod & KMOD_GUI) || !(hotkey & 4));
 }
 
 static int modify_opt_cmd(int code) {
@@ -2357,17 +2357,17 @@ static void handle_events(void)
 					code = event2keycode(event.key, true);
 				if (code >= 0) {
 					if (!emul_suspended) {
+						if (code == 0x36)
+							ctrl_down = true;
+						if (code == 0x3a)
+							alt_down = true;
+						if (code == 0x37)
+							super_down = true;
 						code = modify_opt_cmd(code);
 						if (code == 0x39)
 							(SDL_GetModState() & KMOD_CAPS ? ADBKeyDown : ADBKeyUp)(code);
 						else
 							ADBKeyDown(code);
-						if (code == 0x36)
-							ctrl_down = true;
-						if (code == 0x3a)
-							opt_down = true;
-						if (code == 0x37)
-							cmd_down = true;
 						
 					} else {
 						if (code == 0x31)
@@ -2383,15 +2383,15 @@ static void handle_events(void)
 				if (code == CODE_INVALID)
 					code = event2keycode(event.key, false);
 				if (code >= 0) {
-					code = modify_opt_cmd(code);
-					if (code != 0x39)
-						ADBKeyUp(code);
 					if (code == 0x36)
 						ctrl_down = false;
 					if (code == 0x3a)
-						opt_down = false;
+						alt_down = false;
 					if (code == 0x37)
-						cmd_down = false;
+						super_down = false;
+					code = modify_opt_cmd(code);
+					if (code != 0x39)
+						ADBKeyUp(code);
 				}
 				break;
 			}

--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -1132,29 +1132,6 @@ AC_CACHE_CHECK([whether __PAGEZERO can be Low Memory area 0x0000-0x2000],
 AC_TRANSLATE_DEFINE(PAGEZERO_HACK, "$ac_cv_pagezero_hack",
   [Define if the __PAGEZERO Mach-O Low Memory Globals hack works on this system.])
 
-dnl Check if we can mmap 0x2000 bytes from 0x0000
-AC_CACHE_CHECK([whether we can map Low Memory area 0x0000-0x2000],
-  ac_cv_can_map_lm, [
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_RUN([
-    #include "../CrossPlatform/vm_alloc.cpp"
-    int main(void) { /* returns 0 if we could map the lowmem globals */
-      volatile char * lm = 0;
-      if (vm_init() < 0) exit(1);
-      if (vm_acquire_fixed(0, 0x2000) < 0) exit(1);
-      lm[0] = 'z';
-      if (vm_release((char *)lm, 0x2000) < 0) exit(1);
-      vm_exit(); exit(0);
-    }
-  ], ac_cv_can_map_lm=yes, ac_cv_can_map_lm=no,
-  dnl When cross-compiling, do not assume anything.
-  ac_cv_can_map_lm="$BII_CROSS_MAP_LOW_AREA"
-  )
-  AC_LANG_RESTORE
-  ]
-)
-
 dnl Check signal handlers need to be reinstalled
 AC_CACHE_CHECK([whether signal handlers need to be reinstalled],
   ac_cv_signal_need_reinstall, [
@@ -1438,10 +1415,6 @@ else
   for am in $ADDRESSING_TEST_ORDER; do
     case $am in
     real)
-      dnl Requires ability to mmap() Low Memory globals
-      if [[ "x$ac_cv_can_map_lm$ac_cv_pagezero_hack" = "xnono" ]]; then
-        continue
-      fi
       dnl Requires VOSF screen updates
       if [[ "x$CAN_VOSF" = "xno" ]]; then
         continue
@@ -1483,7 +1456,8 @@ fi
 
 dnl Banked Memory Addressing mode is not supported by the JIT compiler
 if [[ "x$WANT_JIT" = "xyes" -a "x$ADDRESSING_MODE" = "xmemory banks" ]]; then
-  AC_MSG_ERROR([Sorry, the JIT Compiler requires Direct Addressing, at least])
+  AC_MSG_WARN([The JIT Compiler requires Direct Addressing, disabling])
+  WANT_JIT="no"
 fi
 
 if [[ "x$OS_TYPE" = "xdarwin" ]]; then

--- a/BasiliskII/src/Unix/keycodes
+++ b/BasiliskII/src/Unix/keycodes
@@ -2,28 +2,695 @@
 #
 # Basilisk II (C) 1997-2005 Christian Bauer
 #
-# This file is used to translate the (server-specific) X11 keycodes to Mac
-# keycodes depending on the X11 server being used.
+# This file is used to translate the (server-specific) scancodes to
+# Mac keycodes depending on the window server being used.
 #
 # The format of this file is as follows:
 #
+# sdl <driver string>
+# <SDL scancode> <Mac keycode>
+# <SDL scancode> <Mac keycode>
+# <SDL scancode> <Mac keycode>
+# ...
 # <vendor string>
 # <X11 keycode> <Mac keycode>
 # <X11 keycode> <Mac keycode>
 # <X11 keycode> <Mac keycode>
 # ...
-# <vendor string>
-# <X11 keycode> <Mac keycode>
-# <X11 keycode> <Mac keycode>
-# ...
 #
-# The "vendor string" must match the first part of the X11 server vendor
-# description as reported by ServerVendor(). If a match is found, the keycode
-# translation table is constructed from the following lines. Each line
-# contains an X11 keycode followed by its associated Mac keycode. Both
-# keycodes have to be given in decimal. Lines beginning with "#" or ";" are
-# treated as comments and ignored.
+# The "driver string" must match the first part of the SDL driver
+# vendor description as reported by SDL_VideoDriverName(), while the
+# "vendor string" must match the first part of the X11 server vendor
+# description as reported by ServerVendor(). If a match is found,
+# the keycode translation table is constructed from the following
+# lines. Each line contains an SDL scancode or X11 keycode followed 
+# by its associated Mac keycode. Both keycodes have to be given in 
+# decimal. Lines beginning with "#" or ";" are treated as comments
+# and ignored.
 #
+
+#
+# X11 server
+# X.Org
+# Wayland
+#
+sdl x11
+sdl wayland
+sdl dga
+The X.Org Foundation
+9	53	# Esc
+67	122	# F1
+68	120	# F2
+69	99	# F3
+70	118	# F4
+71	96	# F5
+72	97	# F6
+73	98	# F7
+74	100	# F8
+75	101	# F9
+76	109	# F10
+95	103	# F11
+96	111	# F12
+111	105	# PrintScrn
+78	107	# Scroll Lock
+110	113	# Pause
+49	50	# `
+10	18	# 1
+11	19	# 2
+12	20	# 3
+13	21	# 4
+14	23	# 5
+15	22	# 6
+16	26	# 7
+17	28	# 8
+18	25	# 9
+19	29	# 0
+20	27	# -
+21	24	# =
+22	51	# Backspace
+106	114	# Insert
+97	115	# Home
+99	116	# Page Up
+77	71	# Num Lock
+112	75	# KP /
+63	67	# KP *
+82	78	# KP -
+23	48	# Tab
+24	12	# Q
+25	13	# W
+26	14	# E
+27	15	# R
+28	17	# T
+29	16	# Y
+30	32	# U
+31	34	# I
+32	31	# O
+33	35	# P
+34	33	# [
+35	30	# ]
+36	36	# Return
+107	117	# Delete
+103	119	# End
+105	121	# Page Down
+79	89	# KP 7
+80	91	# KP 8
+81	92	# KP 9
+86	69	# KP +
+66	57	# Caps Lock
+38	0	# A
+39	1	# S
+40	2	# D
+41	3	# F
+42	5	# G
+43	4	# H
+44	38	# J
+45	40	# K
+46	37	# L
+47	41	# ;
+48	39	# '
+83	86	# KP 4
+84	87	# KP 5
+85	88	# KP 6
+50	56	# Shift Left
+94	50	# International
+52	6	# Z
+53	7	# X
+54	8	# C
+55	9	# V
+56	11	# B
+57	45	# N
+58	46	# M
+59	43	# ,
+60	47	# .
+61	44	# /
+62	56	# Shift Right
+51	42	# \
+98	62	# Cursor Up
+87	83	# KP 1
+88	84	# KP 2
+89	85	# KP 3
+108	76	# KP Enter
+37	54	# Ctrl Left
+115	58	# Logo Left (-> Option)
+64	55	# Alt Left (-> Command)
+65	49	# Space
+113	55	# Alt Right (-> Command)
+116	58	# Logo Right (-> Option)
+117	50	# Menu (-> International)
+109	54	# Ctrl Right
+100	59	# Cursor Left
+104	61	# Cursor Down
+102	60	# Cursor Right
+90	82	# KP 0
+91	65	# KP .
+
+#
+# Linux Framebuffer Console
+#
+sdl fbcon
+1	53	# Esc
+59	122	# F1
+60	120	# F2
+61	99	# F3
+62	118	# F4
+63	96	# F5
+64	97	# F6
+65	98	# F7
+66	100	# F8
+67	101	# F9
+68	109	# F10
+87	103	# F11
+88	111	# F12
+99	105	# PrintScrn
+70	107	# Scroll Lock
+119	113	# Pause
+41	50	# `
+2	18	# 1
+3	19	# 2
+4	20	# 3
+5	21	# 4
+6	23	# 5
+7	22	# 6
+8	26	# 7
+9	28	# 8
+10	25	# 9
+11	29	# 0
+12	27	# -
+13	24	# =
+14	51	# Backspace
+110	114	# Insert
+102	115	# Home
+104	116	# Page Up
+69	71	# Num Lock
+98	75	# KP /
+55	67	# KP *
+74	78	# KP -
+15	48	# Tab
+16	12	# Q
+17	13	# W
+18	14	# E
+19	15	# R
+20	17	# T
+21	16	# Y
+22	32	# U
+23	34	# I
+24	31	# O
+25	35	# P
+26	33	# [
+27	30	# ]
+28	36	# Return
+111	117	# Delete
+107	119	# End
+109	121	# Page Down
+71	89	# KP 7
+72	91	# KP 8
+73	92	# KP 9
+78	69	# KP +
+58	57	# Caps Lock
+30	0	# A
+31	1	# S
+32	2	# D
+33	3	# F
+34	5	# G
+35	4	# H
+36	38	# J
+37	40	# K
+38	37	# L
+39	41	# ;
+40	39	# '
+75	86	# KP 4
+76	87	# KP 5
+77	88	# KP 6
+42	56	# Shift Left
+86	50	# International
+44	6	# Z
+45	7	# X
+46	8	# C
+47	9	# V
+48	11	# B
+49	45	# N
+50	46	# M
+51	43	# ,
+52	47	# .
+53	44	# /
+54	56	# Shift Right
+43	42	# \
+103	62	# Cursor Up
+79	83	# KP 1
+80	84	# KP 2
+81	85	# KP 3
+96	76	# KP Enter
+29	54	# Ctrl Left
+125	58	# Logo Left (-> Option)
+56	55	# Alt Left (-> Command)
+57	49	# Space
+100	55	# Alt Right (-> Command)
+126	58	# Logo Right (-> Option)
+97	54	# Ctrl Right
+105	59	# Cursor Left
+108	61	# Cursor Down
+106	60	# Cursor Right
+82	82	# KP 0
+83	65	# KP .
+
+#
+# Quartz (1:1 translation actually)
+#
+sdl Quartz
+53	53	# Esc
+122	122	# F1
+120	120	# F2
+99	99	# F3
+118	118	# F4
+96	96	# F5
+97	97	# F6
+98	98	# F7
+100	100	# F8
+101	101	# F9
+109	109	# F10
+103	103	# F11
+111	111	# F12
+105	105	# F13/PrintScrn
+107	107	# F14/Scroll Lock
+113	113	# F15/Pause
+10	10	# `
+18	18	# 1
+19	19	# 2
+20	20	# 3
+21	21	# 4
+23	23	# 5
+22	22	# 6
+26	26	# 7
+28	28	# 8
+25	25	# 9
+29	29	# 0
+27	27	# -
+24	24	# =
+51	51	# Backspace
+114	114	# Help/Insert
+115	115	# Home
+116	116	# Page Up
+71	71	# Num Lock
+81	81	# KP =
+75	75	# KP /
+67	67	# KP *
+48	48	# Tab
+12	12	# Q
+13	13	# W
+14	14	# E
+15	15	# R
+17	17	# T
+16	16	# Y
+32	32	# U
+34	34	# I
+31	31	# O
+35	35	# P
+33	33	# [
+30	30	# ]
+36	36	# Return
+117	117	# Delete
+119	119	# End
+121	121	# Page Down
+89	89	# KP 7
+91	91	# KP 8
+92	92	# KP 9
+78	78	# KP -
+57	57	# Caps Lock
+0	0	# A
+1	1	# S
+2	2	# D
+3	3	# F
+5	5	# G
+4	4	# H
+38	38	# J
+40	40	# K
+37	37	# L
+41	41	# ;
+39	39	# '
+42	42	# \
+86	86	# KP 4
+87	87	# KP 5
+88	88	# KP 6
+69	69	# KP +
+56	56	# Shift
+50	50	# International
+6	6	# Z
+7	7	# X
+8	8	# C
+9	9	# V
+11	11	# B
+45	45	# N
+46	46	# M
+43	43	# ,
+47	47	# .
+44	44	# /
+126	62	# Cursor Up
+123	59	# Cursor Left
+125	61	# Cursor Down
+124	60	# Cursor Right
+83	83	# KP 1
+84	84	# KP 2
+85	85	# KP 3
+76	76	# KP Enter
+54	54	# Ctrl
+58	58	# Option
+55	55	# Command
+54	54	# Ctrl Left
+49	49	# Space
+82	82	# KP 0
+65	65	# KP .
+
+#
+# cocoa (SDL2)
+#
+sdl cocoa
+41	53	# Esc
+58	122	# F1
+59	120	# F2
+60	99	# F3
+61	118	# F4
+62	96	# F5
+63	97	# F6
+64	98	# F7
+65	100	# F8
+66	101	# F9
+67	109	# F10
+68	103	# F11
+69	111	# F12
+70	105	# F13/PrintScrn
+71	107	# F14/Scroll Lock
+72	113	# F15/Pause
+53	10	# `
+30	18	# 1
+31	19	# 2
+32	20	# 3
+33	21	# 4
+34	23	# 5
+35	22	# 6
+36	26	# 7
+37	28	# 8
+38	25	# 9
+39	29	# 0
+45	27	# -
+46	24	# =
+42	51	# Backspace
+73	114	# Help/Insert
+74	115	# Home
+75	116	# Page Up
+83	71	# Num Lock
+103	81	# KP =
+84	75	# KP /
+85	67	# KP *
+43	48	# Tab
+20	12	# Q
+26	13	# W
+8	14	# E
+21	15	# R
+23	17	# T
+28	16	# Y
+24	32	# U
+12	34	# I
+18	31	# O
+19	35	# P
+47	33	# [
+48	30	# ]
+40	36	# Return
+76	117	# Delete
+77	119	# End
+78	121	# Page Down
+95	89	# KP 7
+96	91	# KP 8
+97	92	# KP 9
+86	78	# KP -
+57	57	# Caps Lock
+4	0	# A
+22	1	# S
+7	2	# D
+9	3	# F
+10	5	# G
+11	4	# H
+13	38	# J
+14	40	# K
+15	37	# L
+51	41	# ;
+52	39	# '
+49	42	# \
+92	86	# KP 4
+93	87	# KP 5
+94	88	# KP 6
+87	69	# KP +
+100	50	# International
+29	6	# Z
+27	7	# X
+6	8	# C
+25	9	# V
+5	11	# B
+17	45	# N
+16	46	# M
+54	43	# ,
+55	47	# .
+56	44	# /
+82	62	# Cursor Up
+80	59	# Cursor Left
+81	61	# Cursor Down
+79	60	# Cursor Right
+89	83	# KP 1
+90	84	# KP 2
+91	85	# KP 3
+88	76	# KP Enter
+225	56	# Shift Left
+224	54	# Ctrl Left
+226	58	# Option Left
+227	55	# Command Left
+44	49	# Space
+231	55	# Command Right
+230	58	# Option Right
+228	54	# Ctrl Right
+229	56	# Shift Right
+98	82	# KP 0
+99	65	# KP .
+
+#
+# Windows (SDL2)
+#
+sdl windows
+41	53	# Esc
+58	122	# F1
+59	120	# F2
+60	99	# F3
+61	118	# F4
+62	96	# F5
+63	97	# F6
+64	98	# F7
+65	100	# F8
+66	101	# F9
+67	109	# F10
+68	103	# F11
+69	111	# F12
+70	105	# F13/PrintScrn
+71	107	# F14/Scroll Lock
+72	113	# F15/Pause
+53	50	# `
+30	18	# 1
+31	19	# 2
+32	20	# 3
+33	21	# 4
+34	23	# 5
+35	22	# 6
+36	26	# 7
+37	28	# 8
+38	25	# 9
+39	29	# 0
+45	27	# -
+46	24	# =
+42	51	# Backspace
+73	114	# Help/Insert
+74	115	# Home
+75	116	# Page Up
+83	71	# Num Lock
+103	81	# KP =
+84	75	# KP /
+85	67	# KP *
+43	48	# Tab
+20	12	# Q
+26	13	# W
+8	14	# E
+21	15	# R
+23	17	# T
+28	16	# Y
+24	32	# U
+12	34	# I
+18	31	# O
+19	35	# P
+47	33	# [
+48	30	# ]
+40	36	# Return
+76	117	# Delete
+77	119	# End
+78	121	# Page Down
+95	89	# KP 7
+96	91	# KP 8
+97	92	# KP 9
+86	78	# KP -
+57	57	# Caps Lock
+4	0	# A
+22	1	# S
+7	2	# D
+9	3	# F
+10	5	# G
+11	4	# H
+13	38	# J
+14	40	# K
+15	37	# L
+51	41	# ;
+52	39	# '
+49	42	# \
+92	86	# KP 4
+93	87	# KP 5
+94	88	# KP 6
+87	69	# KP +
+100	50	# International
+29	6	# Z
+27	7	# X
+6	8	# C
+25	9	# V
+5	11	# B
+17	45	# N
+16	46	# M
+54	43	# ,
+55	47	# .
+56	44	# /
+82	62	# Cursor Up
+80	59	# Cursor Left
+81	61	# Cursor Down
+79	60	# Cursor Right
+89	83	# KP 1
+90	84	# KP 2
+91	85	# KP 3
+88	76	# KP Enter
+225	56	# Shift Left
+224	58	# Ctrl Left (--> Option)
+# 227		# Logo Left
+226	55	# Alt Left (--> Command)
+44	49	# Space
+230	58	# Alt Right (--> Option)
+# 231		# Logo Right
+101	50	# Menu (--> International)
+228	54	# Ctrl Right
+229	56	# Shift Right
+98	82	# KP 0
+99	65	# KP .
+
+#
+# Windows
+#
+sdl windib
+sdl directx
+1	53	# Esc
+59	122	# F1
+60	120	# F2
+61	99	# F3
+62	118	# F4
+63	96	# F5
+64	97	# F6
+65	98	# F7
+66	100	# F8
+67	101	# F9
+68	109	# F10
+87	103	# F11
+88	111	# F12
+183	105	# PrintScrn
+70	107	# Scroll Lock
+197	113	# Pause
+41	50	# `
+2	18	# 1
+3	19	# 2
+4	20	# 3
+5	21	# 4
+6	23	# 5
+7	22	# 6
+8	26	# 7
+9	28	# 8
+10	25	# 9
+11	29	# 0
+12	27	# -
+13	24	# =
+14	51	# Backspace
+210	114	# Insert
+199	115	# Home
+201	116	# Page Up
+69	71	# Num Lock
+181	75	# KP /
+55	67	# KP *
+74	78	# KP -
+15	48	# Tab
+16	12	# Q
+17	13	# W
+18	14	# E
+19	15	# R
+20	17	# T
+21	16	# Y
+22	32	# U
+23	34	# I
+24	31	# O
+25	35	# P
+26	33	# [
+27	30	# ]
+28	36	# Return
+211	117	# Delete
+207	119	# End
+209	121	# Page Down
+71	89	# KP 7
+72	91	# KP 8
+73	92	# KP 9
+78	69	# KP +
+58	57	# Caps Lock
+30	0	# A
+31	1	# S
+32	2	# D
+33	3	# F
+34	5	# G
+35	4	# H
+36	38	# J
+37	40	# K
+38	37	# L
+39	41	# ;
+40	39	# '
+75	86	# KP 4
+76	87	# KP 5
+77	88	# KP 6
+42	56	# Shift Left
+86	50	# International
+44	6	# Z
+45	7	# X
+46	8	# C
+47	9	# V
+48	11	# B
+49	45	# N
+50	46	# M
+51	43	# ,
+52	47	# .
+53	44	# /
+54	56	# Shift Right
+43	42	# \
+200	62	# Cursor Up
+79	83	# KP 1
+80	84	# KP 2
+81	85	# KP 3
+156	76	# KP Enter
+29	54	# Ctrl Left
+219	58	# Logo Left (-> Option)
+56	55	# Alt Left (-> Command)
+57	49	# Space
+184	55	# Alt Right (-> Command)
+220	58	# Logo Right (-> Option)
+221	50	# Menu (-> International)
+157	54	# Ctrl Right
+203	59	# Cursor Left
+208	61	# Cursor Down
+205	60	# Cursor Right
+82	82	# KP 0
+83	65	# KP .
 
 #
 # XFree86

--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -114,9 +114,9 @@ static bool use_vosf = true;						// Flag: VOSF enabled
 static const bool use_vosf = false;					// VOSF not possible
 #endif
 
-static bool ctrl_down = false;						// Flag: Ctrl key pressed
-static bool super_down = false;						// Flag: Super key pressed
-static bool alt_down = false;						// Flag: Alt key pressed
+static bool ctrl_down = false;						// Flag: Ctrl key pressed (for use with hotkeys)
+static bool opt_down = false;						// Flag: Opt/Alt key pressed (for use with hotkeys)
+static bool cmd_down = false;						// Flag: Cmd/Super/Win key pressed (for use with hotkeys)
 static bool caps_on = false;						// Flag: Caps Lock on
 static bool quit_full_screen = false;				// Flag: DGA close requested from redraw thread
 static bool emerg_quit = false;						// Flag: Ctrl-Esc pressed, emergency quit requested from MacOS thread
@@ -234,8 +234,8 @@ static bool is_hotkey_down()
 	int hotkey = PrefsFindInt32("hotkey");
 	if (!hotkey) hotkey = 1;
 	return (ctrl_down || !(hotkey & 1)) &&
-			(alt_down || !(hotkey & 2)) &&
-			(super_down || !(hotkey & 4));
+			(opt_down || !(hotkey & 2)) &&
+			(cmd_down || !(hotkey & 4));
 }
 
 static int modify_opt_cmd(int code) {
@@ -1028,9 +1028,9 @@ void driver_dga::suspend(void)
 	ADBKeyUp(0x36);
 	ctrl_down = false;
 	ADBKeyUp(0x37);
-	super_down = false;
+	cmd_down = false;
 	ADBKeyUp(0x3a);
-	alt_down = false;
+	opt_down = false;
 
 	// Lock frame buffer (this will stop the MacOS thread)
 	LOCK_FRAME_BUFFER;
@@ -2252,10 +2252,10 @@ static void handle_events(void)
 					if (code == 0x36) {
 						ctrl_down = true;
 					} else if (code == 0x3a) {
-						alt_down = true;
+						opt_down = true;
 					    code = modify_opt_cmd(code);
 					} else if (code == 0x37) {
-						super_down = true;
+						cmd_down = true;
 					    code = modify_opt_cmd(code);
 					}
 				}
@@ -2289,10 +2289,10 @@ static void handle_events(void)
 					if (code == 0x36) {
 						ctrl_down = false;
 					} else if (code == 0x3a) {
-						alt_down = false;
+						opt_down = false;
 					    code = modify_opt_cmd(code);
 					} else if (code == 0x37) {
-						super_down = false;
+						cmd_down = false;
 					    code = modify_opt_cmd(code);
 					}
 				}

--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -69,6 +69,9 @@
 #define DEBUG 0
 #include "debug.h"
 
+#define CODE_INVALID -1
+#define CODE_HOTKEY -2
+
 
 // Supported video modes
 static vector<video_mode> VideoModes;
@@ -478,15 +481,14 @@ static void set_window_name(Window w, int name)
 static void set_window_name(Window w, bool mouse_grabbed) {
 	const char *title = PrefsFindString("title");
 	std::string s = title ? title : GetString(STR_WINDOW_TITLE);
-    if (mouse_grabbed)
-    {
-        s += GetString(STR_WINDOW_TITLE_GRABBED_PRE);
+	if (mouse_grabbed) {
+		s += GetString(STR_WINDOW_TITLE_GRABBED_PRE);
 		int hotkey = PrefsFindInt32("hotkey");
 		hotkey = hotkey ? hotkey : 1;
 		if (hotkey & 1) s += GetString(STR_WINDOW_TITLE_GRABBED1);
-        if (hotkey & 2) s += GetString(STR_WINDOW_TITLE_GRABBED2);
-        if (hotkey & 4) s += GetString(STR_WINDOW_TITLE_GRABBED4);
-        s += GetString(STR_WINDOW_TITLE_GRABBED_POST);
+		if (hotkey & 2) s += GetString(STR_WINDOW_TITLE_GRABBED2);
+		if (hotkey & 4) s += GetString(STR_WINDOW_TITLE_GRABBED4);
+		s += GetString(STR_WINDOW_TITLE_GRABBED_POST);
 	}
 	XStoreName(x_display, w, s.c_str());
 	XSetIconName(x_display, w, GetString(STR_WINDOW_TITLE));
@@ -1468,7 +1470,7 @@ static void keycode_init(void)
 
 		// Default translation table
 		for (int i=0; i<256; i++)
-			keycode_table[i] = -1;
+			keycode_table[i] = CODE_INVALID;
 
 		// Search for server vendor string, then read keycodes
 		const char *vendor = ServerVendor(x_display);
@@ -1755,7 +1757,7 @@ bool VideoInit(bool classic)
 			default_width = -1; default_height = -1; // use entire screen
 #endif
 #ifdef ENABLE_XF86_DGA
-		} else if (has_dga & sscanf(mode_str, "dga/%d/%d", &default_width, &default_height) == 2) {
+		} else if (has_dga && sscanf(mode_str, "dga/%d/%d", &default_width, &default_height) == 2) {
 			display_type = DISPLAY_DGA;
 #endif
 		}
@@ -2013,8 +2015,8 @@ void X11_monitor_desc::switch_to_current_mode(void)
 
 
 /*
- *  Translate key event to Mac keycode, returns -1 if no keycode was found
- *  and -2 if the key was recognized as a hotkey
+ *  Translate key event to Mac keycode, returns CODE_INVALID if no keycode was found
+ *  and CODE_HOTKEY if the key was recognized as a hotkey
  */
 
 static int kc_decode(KeySym ks, bool key_down)
@@ -2070,7 +2072,7 @@ static int kc_decode(KeySym ks, bool key_down)
 		case XK_period: case XK_greater: return 0x2f;
 		case XK_slash: case XK_question: return 0x2c;
 
-		case XK_Tab: if (is_hotkey_down()) {if (key_down) drv->suspend(); return -2;} else return 0x30;
+		case XK_Tab: if (is_hotkey_down()) {if (key_down) drv->suspend(); return CODE_HOTKEY;} else return 0x30;
 		case XK_Return: return 0x24;
 		case XK_space: return 0x31;
 		case XK_BackSpace: return 0x33;
@@ -2087,14 +2089,10 @@ static int kc_decode(KeySym ks, bool key_down)
 		case XK_Page_Down: return 0x79;
 #endif
 
-		case XK_Control_L: return 0x36;
-		case XK_Control_R: return 0x36;
-		case XK_Shift_L: return 0x38;
-		case XK_Shift_R: return 0x38;
-		case XK_Alt_L: return 0x3a;
-		case XK_Alt_R: return 0x3a;
-		case XK_Meta_L: return 0x37;
-		case XK_Meta_R: return 0x37;
+		case XK_Control_L: case XK_Control_R: if (!emul_suspended) ctrl_down = key_down; return 0x36;
+		case XK_Shift_L: case XK_Shift_R: return 0x38;
+		case XK_Alt_L: case XK_Alt_R: if (!emul_suspended) alt_down = key_down; return 0x3a;
+		case XK_Meta_L: case XK_Meta_R: if (!emul_suspended) super_down = key_down; return 0x37;
 		case XK_Menu: return 0x32;
 		case XK_Caps_Lock: return 0x39;
 		case XK_Num_Lock: return 0x47;
@@ -2104,13 +2102,13 @@ static int kc_decode(KeySym ks, bool key_down)
 		case XK_Left: return 0x3b;
 		case XK_Right: return 0x3c;
 
-		case XK_Escape: if (is_hotkey_down()) {if (key_down) { quit_full_screen = true; emerg_quit = true; } return -2;} else return 0x35;
+		case XK_Escape: if (is_hotkey_down()) {if (key_down) { quit_full_screen = true; emerg_quit = true; } return CODE_HOTKEY;} else return 0x35;
 
-		case XK_F1: if (is_hotkey_down()) {if (key_down) SysMountFirstFloppy(); return -2;} else return 0x7a;
+		case XK_F1: if (is_hotkey_down()) {if (key_down) SysMountFirstFloppy(); return CODE_HOTKEY;} else return 0x7a;
 		case XK_F2: return 0x78;
 		case XK_F3: return 0x63;
 		case XK_F4: return 0x76;
-		case XK_F5: if (is_hotkey_down()) {if (key_down) drv->toggle_mouse_grab(); return -2;} else return 0x60;
+		case XK_F5: if (is_hotkey_down()) {if (key_down) drv->toggle_mouse_grab(); return CODE_HOTKEY;} else return 0x60;
 		case XK_F6: return 0x61;
 		case XK_F7: return 0x62;
 		case XK_F8: return 0x64;
@@ -2155,7 +2153,7 @@ static int kc_decode(KeySym ks, bool key_down)
 		case XK_KP_Enter: return 0x4c;
 		case XK_KP_Equal: return 0x51;
 	}
-	return -1;
+	return CODE_INVALID;
 }
 
 static int event2keycode(XKeyEvent &ev, bool key_down)
@@ -2168,11 +2166,11 @@ static int event2keycode(XKeyEvent &ev, bool key_down)
 		int as = kc_decode(ks, key_down);
 		if (as >= 0)
 			return as;
-		if (as == -2)
+		if (as == CODE_HOTKEY)
 			return as;
 	} while (ks != NoSymbol);
 
-	return -1;
+	return CODE_INVALID;
 }
 
 
@@ -2247,22 +2245,10 @@ static void handle_events(void)
 			// Keyboard
 			case KeyPress: {
 				int code = event2keycode(event.xkey, true);
-				if(!emul_suspended)
-				{
-					if (code == 0x36) {
-						ctrl_down = true;
-					} else if (code == 0x3a) {
-						alt_down = true;
-					    code = modify_opt_cmd(code);
-					} else if (code == 0x37) {
-						super_down = true;
-					    code = modify_opt_cmd(code);
-					}
-				}
-				if (use_keycodes) {
-					if (code != -2)	// This is called to process the hotkeys
-						code = keycode_table[event.xkey.keycode & 0xff];
-				}
+				if (use_keycodes && code != CODE_HOTKEY)	// This is called to process the hotkeys
+					code = keycode_table[event.xkey.keycode & 0xff];
+				if (code == 0x3a || code == 0x37)
+					code = modify_opt_cmd(code);
 				if (code >= 0) {
 					if (!emul_suspended) {
 						if (code == 0x39) {	// Caps Lock pressed
@@ -2284,25 +2270,12 @@ static void handle_events(void)
 			}
 			case KeyRelease: {
 				int code = event2keycode(event.xkey, false);
-				if(!emul_suspended)
-				{
-					if (code == 0x36) {
-						ctrl_down = false;
-					} else if (code == 0x3a) {
-						alt_down = false;
-					    code = modify_opt_cmd(code);
-					} else if (code == 0x37) {
-						super_down = false;
-					    code = modify_opt_cmd(code);
-					}
-				}
-				if (use_keycodes) {
-					if (code != -2)	// This is called to process the hotkeys
-						code = keycode_table[event.xkey.keycode & 0xff];
-				}
-				if (code >= 0 && code != 0x39) {	// Don't propagate Caps Lock releases
+				if (use_keycodes && code != CODE_HOTKEY)	// This is called to process the hotkeys
+					code = keycode_table[event.xkey.keycode & 0xff];
+				if (code == 0x3a || code == 0x37)
+					code = modify_opt_cmd(code);
+				if (code >= 0 && code != 0x39)  // Don't propagate Caps Lock releases
 					ADBKeyUp(code);
-				}
 				break;
 			}
 

--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -1208,7 +1208,7 @@ driver_fbdev::driver_fbdev(X11_monitor_desc &m) : driver_dga(m)
 		&wattr);
 
 	// Set window name/class
-	set_window_name(w, mouse_grabbed);
+	set_window_name(w, false);
 
 	// Indicate that we want keyboard input
 	set_window_focus(w);

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -997,36 +997,11 @@ AC_CACHE_CHECK([whether __PAGEZERO can be Low Memory area 0x0000-0x3000],
   case $target_os:$target_cpu in
   darwin*:x86_64)
     ac_cv_pagezero_hack=yes
-    dnl might as well skip the test for mmap-able low memory
-    ac_cv_can_map_lm=no
     ;;
   esac
 ])
 AC_TRANSLATE_DEFINE(PAGEZERO_HACK, "$ac_cv_pagezero_hack",
   [Define if the __PAGEZERO Mach-O Low Memory Globals hack works on this system.])
-
-dnl Check if we can mmap 0x3000 bytes from 0x0000
-AC_CACHE_CHECK([whether we can map Low Memory area 0x0000-0x3000],
-  ac_cv_can_map_lm, [
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_RUN([
-    #include "../CrossPlatform/vm_alloc.cpp"
-    int main(void) { /* returns 0 if we could map the lowmem globals */
-      volatile char * lm = 0;
-      if (vm_init() < 0) exit(1);
-      if (vm_acquire_fixed(0, 0x2000) < 0) exit(1);
-      lm[0] = 'z';
-      if (vm_release((char *)lm, 0x2000) < 0) exit(1);
-      vm_exit(); exit(0);
-    }
-  ], ac_cv_can_map_lm=yes, ac_cv_can_map_lm=no,
-  dnl When cross-compiling, do not assume anything.
-  ac_cv_can_map_lm="guessing no"
-  )
-  AC_LANG_RESTORE
-  ]
-)
 
 dnl Check signal handlers need to be reinstalled
 AC_CACHE_CHECK([whether signal handlers need to be reinstalled],

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -697,6 +697,12 @@ static bool init_sdl()
 	assert(sdl_flags != 0);
 
 #ifdef USE_SDL_VIDEO
+#if REAL_ADDRESSING
+	// Needed to fix a crash when using Wayland
+	// Forces use of XWayland instead
+	setenv("SDL_VIDEODRIVER", "x11", true);
+#endif
+
 	// Don't let SDL block the screensaver
 	setenv("SDL_VIDEO_ALLOW_SCREENSAVER", "1", true);
 

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -92,6 +92,7 @@
 #include <sys/stat.h>
 #include <sys/param.h>
 #include <signal.h>
+#include <string>
 
 #include "sysdeps.h"
 #include "main.h"
@@ -124,7 +125,6 @@
 
 #ifdef USE_SDL
 #include <SDL.h>
-#include <string>
 #endif
 
 #ifndef USE_SDL_VIDEO
@@ -857,7 +857,8 @@ int main(int argc, char **argv)
 	// Read preferences
 	PrefsInit(vmdir, argc, argv);
 
-#if __MACOSX__ && SDL_VERSION_ATLEAST(2,0,0)
+#ifdef __MACOSX__
+#if SDL_VERSION_ATLEAST(2,0,0)
 	// On Mac OS X hosts, SDL2 will create its own menu bar.  This is mostly OK,
 	// except that it will also install keyboard shortcuts, such as Command + Q,
 	// which can interfere with keyboard shortcuts in the guest OS.
@@ -866,6 +867,7 @@ int main(int argc, char **argv)
 	// menu bar in-place.
 	extern void disable_SDL2_macosx_menu_bar_keyboard_shortcuts();
 	disable_SDL2_macosx_menu_bar_keyboard_shortcuts();
+#endif
 #endif
 	
 	// Any command line arguments left?

--- a/SheepShaver/src/Unix/video_x.cpp
+++ b/SheepShaver/src/Unix/video_x.cpp
@@ -2249,6 +2249,10 @@ void video_set_palette(void)
 	UNLOCK_PALETTE;
 }
 
+void video_set_gamma(int n_colors)
+{
+    // Not implemented
+}
 
 /*
  *  Can we set the MacOS cursor image into the window?

--- a/SheepShaver/src/Unix/video_x.cpp
+++ b/SheepShaver/src/Unix/video_x.cpp
@@ -104,6 +104,8 @@ static const bool use_vosf = false;			// VOSF not possible
 
 static bool palette_changed = false;		// Flag: Palette changed, redraw thread must update palette
 static bool ctrl_down = false;				// Flag: Ctrl key pressed
+static bool super_down = false;				// Flag: Super key pressed
+static bool alt_down = false;				// Flag: Alt key pressed
 static bool caps_on = false;				// Flag: Caps Lock on
 static bool quit_full_screen = false;		// Flag: DGA close requested from redraw thread
 static volatile bool quit_full_screen_ack = false;	// Acknowledge for quit_full_screen
@@ -223,6 +225,29 @@ extern void ClipboardSelectionRequest(XSelectionRequestEvent *);
 /*
  *  Utility functions
  */
+static bool is_hotkey_down()
+{
+	int hotkey = PrefsFindInt32("hotkey");
+	if (!hotkey) hotkey = 1;
+	return (ctrl_down || !(hotkey & 1)) &&
+			(alt_down || !(hotkey & 2)) &&
+			(super_down || !(hotkey & 4));
+}
+
+static int modify_opt_cmd(int code) {
+	static bool f, c;
+	if (!f) {
+		f = true;
+		c = PrefsFindBool("swap_opt_cmd");
+	}
+	if (c) {
+		switch (code) {
+			case 0x37: return 0x3a;
+			case 0x3a: return 0x37;
+		}
+	}
+	return code;
+}
 
 // Get current video mode
 static inline int get_current_mode(void)
@@ -1732,6 +1757,10 @@ static void suspend_emul(void)
 		// Release ctrl key
 		ADBKeyUp(0x36);
 		ctrl_down = false;
+		ADBKeyUp(0x3a);
+		alt_down = false;
+		ADBKeyUp(0x37);
+		super_down = false;
 
 		// Lock frame buffer (this will stop the MacOS thread)
 		LOCK_FRAME_BUFFER;
@@ -1894,7 +1923,7 @@ static int kc_decode(KeySym ks)
 		case XK_period: case XK_greater: return 0x2f;
 		case XK_slash: case XK_question: return 0x2c;
 
-		case XK_Tab: if (ctrl_down) {suspend_emul(); return -1;} else return 0x30;
+		case XK_Tab: if (is_hotkey_down()) {suspend_emul(); return -1;} else return 0x30;
 		case XK_Return: return 0x24;
 		case XK_space: return 0x31;
 		case XK_BackSpace: return 0x33;
@@ -1915,10 +1944,10 @@ static int kc_decode(KeySym ks)
 		case XK_Control_R: return 0x36;
 		case XK_Shift_L: return 0x38;
 		case XK_Shift_R: return 0x38;
-		case XK_Alt_L: return 0x37;
-		case XK_Alt_R: return 0x37;
-		case XK_Meta_L: return 0x3a;
-		case XK_Meta_R: return 0x3a;
+		case XK_Alt_L: return 0x3a;
+		case XK_Alt_R: return 0x3a;
+		case XK_Meta_L: return 0x37;
+		case XK_Meta_R: return 0x37;
 		case XK_Menu: return 0x32;
 		case XK_Caps_Lock: return 0x39;
 		case XK_Num_Lock: return 0x47;
@@ -1928,9 +1957,9 @@ static int kc_decode(KeySym ks)
 		case XK_Left: return 0x3b;
 		case XK_Right: return 0x3c;
 
-		case XK_Escape: if (ctrl_down) {quit_full_screen = true; emerg_quit = true; return -1;} else return 0x35;
+		case XK_Escape: if (is_hotkey_down()) {quit_full_screen = true; emerg_quit = true; return -1;} else return 0x35;
 
-		case XK_F1: if (ctrl_down) {SysMountFirstFloppy(); return -1;} else return 0x7a;
+		case XK_F1: if (is_hotkey_down()) {SysMountFirstFloppy(); return -1;} else return 0x7a;
 		case XK_F2: return 0x78;
 		case XK_F3: return 0x63;
 		case XK_F4: return 0x76;
@@ -2067,12 +2096,23 @@ static void handle_events(void)
 
 			// Keyboard
 			case KeyPress: {
-				int code = -1;
+				int code = event2keycode(event.xkey, true);
+				if(!emul_suspended)
+				{
+					if (code == 0x36) {
+						ctrl_down = true;
+					} else if (code == 0x3a) {
+						alt_down = true;
+					    code = modify_opt_cmd(code);
+					} else if (code == 0x37) {
+						super_down = true;
+					    code = modify_opt_cmd(code);
+					}
+				}
 				if (use_keycodes) {
-					if (event2keycode(event.xkey, true) != -2)	// This is called to process the hotkeys
+					if (code != -2)	// This is called to process the hotkeys
 						code = keycode_table[event.xkey.keycode & 0xff];
-				} else
-					code = event2keycode(event.xkey, true);
+				}
 				if (code >= 0) {
 					if (!emul_suspended) {
 						if (code == 0x39) {	// Caps Lock pressed
@@ -2085,8 +2125,6 @@ static void handle_events(void)
 							}
 						} else
 							ADBKeyDown(code);
-						if (code == 0x36)
-							ctrl_down = true;
 					} else {
 						if (code == 0x31)
 							resume_emul();	// Space wakes us up
@@ -2095,16 +2133,25 @@ static void handle_events(void)
 				break;
 			}
 			case KeyRelease: {
-				int code = -1;
+				int code = event2keycode(event.xkey, false);
+				if(!emul_suspended)
+				{
+					if (code == 0x36) {
+						ctrl_down = false;
+					} else if (code == 0x3a) {
+						alt_down = false;
+					    code = modify_opt_cmd(code);
+					} else if (code == 0x37) {
+						super_down = false;
+					    code = modify_opt_cmd(code);
+					}
+				}
 				if (use_keycodes) {
-					if (event2keycode(event.xkey, false) != -2)	// This is called to process the hotkeys
+					if (code != -2)	// This is called to process the hotkeys
 						code = keycode_table[event.xkey.keycode & 0xff];
-				} else
-					code = event2keycode(event.xkey, false);
+				}
 				if (code >= 0 && code != 0x39) {	// Don't propagate Caps Lock releases
 					ADBKeyUp(code);
-					if (code == 0x36)
-						ctrl_down = false;
 				}
 				break;
 			}

--- a/SheepShaver/src/Unix/video_x.cpp
+++ b/SheepShaver/src/Unix/video_x.cpp
@@ -103,9 +103,9 @@ static const bool use_vosf = false;			// VOSF not possible
 #endif
 
 static bool palette_changed = false;		// Flag: Palette changed, redraw thread must update palette
-static bool ctrl_down = false;				// Flag: Ctrl key pressed
-static bool super_down = false;				// Flag: Super key pressed
-static bool alt_down = false;				// Flag: Alt key pressed
+static bool ctrl_down = false;				// Flag: Ctrl key pressed (for use with hotkeys)
+static bool opt_down = false;				// Flag: Opt/Alt key pressed (for use with hotkeys)
+static bool cmd_down = false;				// Flag: Cmd/Super/Win key pressed (for use with hotkeys)
 static bool caps_on = false;				// Flag: Caps Lock on
 static bool quit_full_screen = false;		// Flag: DGA close requested from redraw thread
 static volatile bool quit_full_screen_ack = false;	// Acknowledge for quit_full_screen
@@ -230,8 +230,8 @@ static bool is_hotkey_down()
 	int hotkey = PrefsFindInt32("hotkey");
 	if (!hotkey) hotkey = 1;
 	return (ctrl_down || !(hotkey & 1)) &&
-			(alt_down || !(hotkey & 2)) &&
-			(super_down || !(hotkey & 4));
+			(opt_down || !(hotkey & 2)) &&
+			(cmd_down || !(hotkey & 4));
 }
 
 static int modify_opt_cmd(int code) {
@@ -1758,9 +1758,9 @@ static void suspend_emul(void)
 		ADBKeyUp(0x36);
 		ctrl_down = false;
 		ADBKeyUp(0x3a);
-		alt_down = false;
+		opt_down = false;
 		ADBKeyUp(0x37);
-		super_down = false;
+		cmd_down = false;
 
 		// Lock frame buffer (this will stop the MacOS thread)
 		LOCK_FRAME_BUFFER;
@@ -2102,10 +2102,10 @@ static void handle_events(void)
 					if (code == 0x36) {
 						ctrl_down = true;
 					} else if (code == 0x3a) {
-						alt_down = true;
+						opt_down = true;
 					    code = modify_opt_cmd(code);
 					} else if (code == 0x37) {
-						super_down = true;
+						cmd_down = true;
 					    code = modify_opt_cmd(code);
 					}
 				}
@@ -2139,10 +2139,10 @@ static void handle_events(void)
 					if (code == 0x36) {
 						ctrl_down = false;
 					} else if (code == 0x3a) {
-						alt_down = false;
+						opt_down = false;
 					    code = modify_opt_cmd(code);
 					} else if (code == 0x37) {
-						super_down = false;
+						cmd_down = false;
 					    code = modify_opt_cmd(code);
 					}
 				}

--- a/SheepShaver/src/emul_op.cpp
+++ b/SheepShaver/src/emul_op.cpp
@@ -286,8 +286,9 @@ void EmulOp(M68kRegisters *r, uint32 pc, int selector)
 			TimerReset();
 			MacOSUtilReset();
 			AudioReset();
+#ifdef USE_SDL_AUDIO
 			PlayStartupSound();
-
+#endif
 			// Enable DR emulator (disabled for now)
 			if (PrefsFindBool("jit68k") && 0) {
 				D(bug("DR activated\n"));


### PR DESCRIPTION
Hi again. I've made some more fixes for the hotkey commands in SDL 1.2, as well as a change to stop SheepShaver from using the SDL Wayland video driver to work around a crash on Fedora 36. Finally I made some fixes to allow the emulators to be built with X11 video instead of SDL. This works OK in Basilisk II but SheepShaver has some problems that make it unusable at the moment, so it would need further work if anyone wanted to use it. Tested on Fedora 36 and Debian 10.