### PR TITLE
cast address pointer passed to getsockname

### DIFF
--- a/BasiliskII/src/slirp/tcp_subr.c
+++ b/BasiliskII/src/slirp/tcp_subr.c
@@ -1012,7 +1012,7 @@ do_prompt:
 				/* local side address of control conn */
 				struct sockaddr_in addr;
 				socklen_t addrlen = sizeof(struct sockaddr_in);
-				if (getsockname(control_so->s, &addr, &addrlen) == 0) {
+				if (getsockname(control_so->s, (struct sockaddr *)&addr, &addrlen) == 0) {
 					laddr = ntohl(addr.sin_addr.s_addr);
 				} else {
 					/* fall back to whatever we have for our address generally */


### PR DESCRIPTION
This cast (which is also being done for ident https://github.com/kanjitalk755/macemu/blob/79f2e7e8e4069bd2472aeb45b9f0725e38395d38/BasiliskII/src/slirp/tcp_subr.c#L676) appears to be necessary to get through the Windows build