### PR TITLE
Remove call to XInitThreads

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -916,9 +916,6 @@ if [[ "x$WANT_SDL_VIDEO" = "xyes" ]]; then
       EXTRASYSSRCS="$EXTRASYSSRCS ../dummy/clip_dummy.cpp"
       ;;
     esac
-    if [[ "$WANT_GTK" != "no" ]]; then
-      LIBS="$LIBS -lX11"
-    fi
   fi
 elif [[ "x$WANT_MACOSX_GUI" != "xyes" ]]; then
   VIDEOSRCS="video_x.cpp"

--- a/BasiliskII/src/Unix/main_unix.cpp
+++ b/BasiliskII/src/Unix/main_unix.cpp
@@ -67,9 +67,6 @@ struct sigstate {
 #ifdef ENABLE_GTK
 # include <gtk/gtk.h>
 # include <gdk/gdk.h>
-# if !defined(GDK_WINDOWING_QUARTZ) && !defined(GDK_WINDOWING_WAYLAND)
-#  include <X11/Xlib.h>
-# endif
 # if GTK_CHECK_VERSION(3, 14, 0)
 #  define ENABLE_GTK3
 # endif
@@ -455,9 +452,6 @@ int main(int argc, char **argv)
 #ifdef ENABLE_GTK3
 	GtkApplication *app = NULL;
 	int ret;
-#endif
-#if defined(ENABLE_GTK) && !defined(GDK_WINDOWING_QUARTZ) && !defined(GDK_WINDOWING_WAYLAND)
-	XInitThreads();
 #endif
 	const char *vmdir = NULL;
 	char str[256];

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -790,9 +790,6 @@ if [[ "x$WANT_SDL_VIDEO" = "xyes" ]]; then
     CPPFLAGS="$CPPFLAGS -I../MacOSX"
   else
     EXTRASYSSRCS="$EXTRASYSSRCS ../dummy/clip_dummy.cpp"
-    if [[ "$WANT_GTK" != "no" ]]; then
-      LIBS="$LIBS -lX11"
-    fi
   fi
 else
   VIDEOSRCS="video_x.cpp"

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -141,9 +141,6 @@
 #ifdef ENABLE_GTK
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
-#if !defined(GDK_WINDOWING_QUARTZ) && !defined(GDK_WINDOWING_WAYLAND)
-#include <X11/Xlib.h>
-#endif
 #if GTK_CHECK_VERSION(3, 14, 0)
 #define ENABLE_GTK3
 #endif
@@ -794,9 +791,6 @@ int main(int argc, char **argv)
 #ifdef ENABLE_GTK3
 	GtkApplication *app = NULL;
 	int ret;
-#endif
-#if defined(ENABLE_GTK) && !defined(GDK_WINDOWING_QUARTZ) && !defined(GDK_WINDOWING_WAYLAND)
-	XInitThreads();
 #endif
 	char str[256];
 	bool memory_mapped_from_zero, ram_rom_areas_contiguous;


### PR DESCRIPTION
It turns out this fix is no longer needed, as SDL now gets initialized first and calls XInitThreads before any other Xlib functions. I tested on Debian 10 to verify that the segfault reported in #24 no longer happens.