### PR TITLE
Invalidate cached ethernet allocation when system is reset

### DIFF
--- a/BasiliskII/src/ether.cpp
+++ b/BasiliskII/src/ether.cpp
@@ -186,9 +186,13 @@ void EtherExit(void)
  *  Reset
  */
 
+
+void EtherResetCachedAllocation();
+
 void EtherReset(void)
 {
 	udp_protocols.clear();
+    EtherResetCachedAllocation();
 	ether_reset();
 }
 
@@ -457,6 +461,10 @@ void ether_udp_read(uint32 packet, int length, struct sockaddr_in *from)
 static uint32 ether_packet = 0;			// Ethernet packet (cached allocation)
 static uint32 n_ether_packets = 0;		// Number of ethernet packets allocated so far (should be at most 1)
 
+void EtherResetCachedAllocation() {
+    ether_packet = 0;
+}
+
 EthernetPacket::EthernetPacket()
 {
 	++n_ether_packets;
@@ -485,4 +493,6 @@ EthernetPacket::~EthernetPacket()
 		bug("WARNING: Nested allocation of ethernet packets!\n");
 	}
 }
+#else
+void EtherResetCachedAllocation() { }
 #endif

--- a/SheepShaver/src/emul_op.cpp
+++ b/SheepShaver/src/emul_op.cpp
@@ -289,6 +289,8 @@ void EmulOp(M68kRegisters *r, uint32 pc, int selector)
 			CDROMRemount(); // for System 7.x
 			TimerReset();
 			MacOSUtilReset();
+			EtherResetCachedAllocation();
+			ether_reset();
 			AudioReset();
 #ifdef USE_SDL_AUDIO
 			PlayStartupSound();

--- a/SheepShaver/src/ether.cpp
+++ b/SheepShaver/src/ether.cpp
@@ -1716,6 +1716,10 @@ static void DLPI_unit_data(DLPIStream *the_stream, queue_t *q, mblk_t *mp)
 static uint32 ether_packet = 0;			// Ethernet packet (cached allocation)
 static uint32 n_ether_packets = 0;		// Number of ethernet packets allocated so far (should be at most 1)
 
+void EtherResetCachedAllocation() {
+    ether_packet = 0;
+}
+
 EthernetPacket::EthernetPacket()
 {
 	++n_ether_packets;
@@ -1739,4 +1743,6 @@ EthernetPacket::~EthernetPacket()
 		bug("WARNING: Nested allocation of ethernet packets!\n");
 	}
 }
+#else
+void EtherResetCachedAllocation() { }
 #endif

--- a/SheepShaver/src/include/ether.h
+++ b/SheepShaver/src/include/ether.h
@@ -37,6 +37,7 @@ extern int ether_rsrv(queue_t *q);
 extern void EtherInit(void);
 extern void EtherExit(void);
 
+extern void ether_reset(void);
 extern void EtherIRQ(void);
 
 extern void AO_get_ethernet_address(uint32 addr);
@@ -50,6 +51,8 @@ extern void OTLeaveInterrupt(void);
 
 extern void ether_dispatch_packet(uint32 p, uint32 length);
 extern void ether_packet_received(mblk_t *mp);
+
+extern void EtherResetCachedAllocation(void);
 
 extern bool ether_driver_opened;
 


### PR DESCRIPTION
Invalidate the cached Ethernet guest memory allocation at guest restart.

- Includes Basilisk II, SheepShaver
- Should cover all platforms in the `SIZEOF_VOID_P != 4 || REAL_ADDRESSING == 0` case where the guest memory allocation is used

Fixes #224.