### PR TITLE
Update depend targets for single obj build directory

### DIFF
--- a/BasiliskII/src/Unix/Makefile.in
+++ b/BasiliskII/src/Unix/Makefile.in
@@ -188,7 +188,9 @@ distclean: clean
 	rm -f Darwin/lowmem Darwin/pagezero
 
 depend dep:
-	makedepend $(CPPFLAGS) -Y. $(SRCS) 2>/dev/null
+	makedepend $(CPPFLAGS)  # Truncate out previous rules
+	# Manually process emitted obj targets to take out extra directory layers
+	makedepend $(CPPFLAGS) -pobj/ -Y. $(SRCS) -f- 2>/dev/null | sed 's#^obj/.*/\(.*\.o\):#obj/\1:#' >> Makefile
 
 $(OBJ_DIR)/SDLMain.o : SDLMain.m
 	$(CC) $(CPPFLAGS) $(DEFS) $(CFLAGS) -c $< -o $@

--- a/BasiliskII/src/Windows/Makefile.in
+++ b/BasiliskII/src/Windows/Makefile.in
@@ -138,7 +138,9 @@ distclean: clean
 	rm -f config.cache config.log config.status config.h
 
 depend dep:
-	makedepend $(CPPFLAGS) -Y. $(SRCS) 2>/dev/null
+	makedepend $(CPPFLAGS)  # Truncate out previous rules
+	# Manually process emitted obj targets to take out extra directory layers
+	makedepend $(CPPFLAGS) -pobj/ -Y. $(SRCS) -f- 2>/dev/null | sed 's#^obj/.*/\(.*\.o\):#obj/\1:#' >> Makefile
 
 $(OBJ_DIR)/%.ho : %.c
 	$(HOST_CC) $(CPPFLAGS) $(DEFS) $(HOST_CFLAGS) -c $< -o $@

--- a/SheepShaver/src/Unix/Makefile.in
+++ b/SheepShaver/src/Unix/Makefile.in
@@ -192,7 +192,9 @@ distclean: clean
 	rm -f ../MacOSX/Info.plist
 
 depend dep:
-	makedepend $(CPPFLAGS) -Y. $(SRCS) 2>/dev/null
+	makedepend $(CPPFLAGS)  # Truncate out previous rules
+	# Manually process emitted obj targets to take out extra directory layers
+	makedepend $(CPPFLAGS) -pobj/ -Y. $(SRCS) -f- 2>/dev/null | sed 's#^obj/.*/\(.*\.o\):#obj/\1:#' >> Makefile
 
 $(OBJ_DIR)/SDLMain.o : SDLMain.m
 	$(CC) $(CPPFLAGS) $(DEFS) $(CFLAGS) -c $< -o $@

--- a/SheepShaver/src/Windows/Makefile.in
+++ b/SheepShaver/src/Windows/Makefile.in
@@ -151,7 +151,9 @@ distclean: clean
 	rm -f config.cache config.log config.status config.h
 
 depend dep:
-	makedepend $(CPPFLAGS) -Y. $(SRCS) 2>/dev/null
+	makedepend $(CPPFLAGS)  # Truncate out previous rules
+	# Manually process emitted obj targets to take out extra directory layers
+	makedepend $(CPPFLAGS) -pobj/ -Y. $(SRCS) -f- 2>/dev/null | sed 's#^obj/.*/\(.*\.o\):#obj/\1:#' >> Makefile
 
 $(OBJ_DIR)/%.ho : %.c
 	$(HOST_CC) $(CPPFLAGS) $(DEFS) $(HOST_CFLAGS) -c $< -o $@


### PR DESCRIPTION
Running the `depend`/`dep` targets generates `make` rules for dependencies for object files corresponding to the header file inclusions of the source files, using the X11/Athena `makedepend` tool.

Previously the `macemu` builds put object files at the same location as the source code files, and this is what the `depend`/`dep` targets' previous `makedepend` run was creating rules for.  To support the current project organization where all object files are put in a single flat `obj/` directory, which `makedepend` doesn't support directly, the emitted rules are instead passed through some `sed` filtering before being concatenated to the `Makefile`.

This was tested with `makedepend` 1.0.5 from Xorg 7.7 in Debian's `xutils-dev` `1:7.7+6.2` package and GNU `sed` 4.9.
