### PR TITLE
SDL 3 audio fixes

### DIFF
--- a/BasiliskII/src/SDL/audio_sdl3.cpp
+++ b/BasiliskII/src/SDL/audio_sdl3.cpp
@@ -429,7 +429,7 @@ static int play_startup(void *arg) {
 	SDL_AudioSpec wav_spec;
 	Uint8 *wav_buffer;
 	Uint32 wav_length;
-	if (!playing_startup && !SDL_LoadWAV("startup.wav", &wav_spec, &wav_buffer, &wav_length)) {
+	if (!playing_startup && SDL_LoadWAV("startup.wav", &wav_spec, &wav_buffer, &wav_length)) {
 		SDL_AudioStream *stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &wav_spec, NULL, NULL);
 		if (stream) {
 			SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(stream));


### PR DESCRIPTION
- Push a bit more audio to SDL in each callback and don't hit the audio interrupt in a loop for no reason. Fixes #228 
- When closing audio, don't de-init the whole SDL audio system, just close the main stream so that it can be reopened again. This fixes the changing the audio parameters (mono/stereo, sample rate, bit depth) in the Sound control panel in System 7 in Basilisk.
- The routine that plays the startup sound was always erroring and didn't play the sound file when it was present, because the return value of `SDL_LoadWAV` was being flipped 