### PR TITLE
SDL 3 audio, bin/cue: interim fix for CD audio volume controls

### DIFF
--- a/BasiliskII/src/SDL/audio_sdl3.cpp
+++ b/BasiliskII/src/SDL/audio_sdl3.cpp
@@ -117,7 +117,7 @@ static bool open_sdl_audio(void)
 	main_open_sdl_stream = stream;
 	silence_byte = SDL_GetSilenceValueForFormat(audio_spec.format);
 #if defined(BINCUE)
-	OpenAudio_bincue(audio_spec.freq, audio_spec.format, audio_spec.channels, silence_byte, get_audio_volume());
+	OpenAudio_bincue(audio_spec.freq, audio_spec.format, audio_spec.channels, silence_byte, (int)(get_audio_volume()*128));
 #endif
 
 	printf("Using SDL/%s audio output\n", SDL_GetCurrentAudioDriver());

--- a/BasiliskII/src/bincue.cpp
+++ b/BasiliskII/src/bincue.cpp
@@ -974,7 +974,7 @@ void MixAudio_bincue(uint8 *stream, int stream_len, int volume)
 				extern SDL_AudioSpec audio_spec;
 				uint8 converted[stream_len];
 				SDL_GetAudioStreamData(player->stream, converted, stream_len);
-				SDL_MixAudio(stream, converted, audio_spec.format, stream_len, player->volume_mono);
+				SDL_MixAudio(stream, converted, audio_spec.format, stream_len, (float)player->volume_mono/128);
 			}
 #else
 			if (buf)


### PR DESCRIPTION
This fixes the volume passing to and from bin/cue support when using SDL 3 audio.

I have left `OpenAudio_bincue` still using integer volume values 0-128 inclusive that the old SDL audio still uses.