### PR TITLE
bin/cue: Implement MOTOROLA keyword for big-endian audio data

### DIFF
--- a/BasiliskII/src/bincue.cpp
+++ b/BasiliskII/src/bincue.cpp
@@ -306,7 +306,7 @@ static bool ParseCueSheet(FILE *fh, CueSheet *cs, const char *cuefile)
 				filename = strtok(NULL, "\"\t\n\r");
 				filetype = strtok(NULL, " \"\t\n\r");
 				if (strcmp("BINARY", filetype) && strcmp("MOTOROLA", filetype)) {
-					D(bug("Not binary file %s", filetype));
+					D(bug("Not binary file %s\n", filetype));
 					goto fail;
 				}
 				else {
@@ -1036,10 +1036,12 @@ static void OpenPlayerStream(CDPlayer * player) {
 	// audio stream handles converting cd audio to destination output
 	D(bug("Opening player stream\n"))
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_AudioSpec src = { SDL_AUDIO_S16LE, 2, 44100 }, dst = { (SDL_AudioFormat)o.format, o.channels, o.freq };
+	SDL_AudioSpec src = { player->cs->big_endian_audio? SDL_AUDIO_S16BE : SDL_AUDIO_S16LE, 2, 44100 };
+	SDL_AudioSpec dst = { (SDL_AudioFormat)o.format, o.channels, o.freq };
 	player->stream = SDL_CreateAudioStream(&src, &dst);
 #else
-	player->stream = SDL_NewAudioStream(AUDIO_S16LSB, 2, 44100, o.format, o.channels, o.freq);
+	player->stream = SDL_NewAudioStream(player->cs->big_endian_audio? AUDIO_S16MSB : AUDIO_S16LSB, 2, 44100,
+										o.format, o.channels, o.freq);
 #endif
 	if (player->stream == NULL) {
 		D(bug("Failed to open CD player audio stream using SDL!\n"));


### PR DESCRIPTION
The current code expects `FILE` with `BINARY` to have little-endian CD audio data for `AUDIO` tracks.

Add support for `MOTOROLA` keyword to support big-endian audio data for `AUDIO` tracks:
```
FILE "foo.bin" MOTOROLA
  TRACK 01 MODE1/2352
    INDEX 01 00:00:00
  TRACK 02 AUDIO
    INDEX 00 38:12:26
    INDEX 01 38:14:26
...
```
 (See https://wiki.hydrogenaud.io/index.php?title=Cue_sheet#Most_often_used)

Motivation:

Although little-endian audio data in `.bin` files is not uncommon, there are tools such as `sox` and `cdrdao` which consider big-endian the default for CD audio files (a.k.a. `cdda`), and for instance `cdrdao` by default produces `FILE` with `BINARY` lines in the `.cue` files and then puts big-endian audio data in the `.bin` file for audio tracks (as you will see if you create a `.bin`/`.cue` from a CD with some audio following the instruction at the top of `bincue.cpp`).  This change at least lets you cope with such things by editing the `.cue` file with a text editor.