### PR TITLE
bin/cue: opening/closing and fixes

### DIFF
--- a/BasiliskII/src/SDL/audio_sdl.cpp
+++ b/BasiliskII/src/SDL/audio_sdl.cpp
@@ -182,6 +182,9 @@ void AudioInit(void)
 static void close_audio(void)
 {
 	// Close audio device
+#if defined(BINCUE)
+	CloseAudio_bincue();
+#endif
 	SDL_CloseAudio();
 	free(audio_mix_buf);
 	audio_mix_buf = NULL;

--- a/BasiliskII/src/bincue.cpp
+++ b/BasiliskII/src/bincue.cpp
@@ -538,14 +538,14 @@ void close_bincue(void *fh)
 	CueSheet *cs = (CueSheet *) fh;
 	CDPlayer *player = CSToPlayer(cs);
 
-	if (player == currently_playing) {
-		CDStop_bincue(fh);
-		assert(currently_playing == NULL);
-	}
-
-	players.remove(player);
-
 	if (cs && player) {
+		if (player == currently_playing) {
+			CDStop_bincue(fh);
+			assert(currently_playing == NULL);
+		}
+
+		players.remove(player);
+
 		free(cs);
 #ifdef USE_SDL_AUDIO
 		ClosePlayerStream(player);

--- a/BasiliskII/src/cdrom.cpp
+++ b/BasiliskII/src/cdrom.cpp
@@ -587,6 +587,7 @@ int16 CDROMControl(uint32 pb, uint32 dce)
 			return writErr;
 			
 		case 7:			// EjectTheDisc
+			D(bug("CDROMControl EjectTheDisc\n"));
 			if (ReadMacInt8(info->status + dsDiskInPlace) > 0) {
 				if (info->drop) {
 					SysAllowRemoval(info->fh);
@@ -595,7 +596,14 @@ int16 CDROMControl(uint32 pb, uint32 dce)
 					info->close_fh();
 					info->drop = false;
 				}
-				else remount_map.insert(std::make_pair(ReadMacInt16(pb + ioVRefNum), info->fh));
+				else {
+					remount_map.insert(std::make_pair(ReadMacInt16(pb + ioVRefNum), info->fh));
+
+					D(bug("At least stop cd playback if it's some kind of CD %d,%d,%d\n",
+						info->lead_out[0], info->lead_out[1], info->lead_out[2]));
+					SysCDStop(info->fh, info->lead_out[0], info->lead_out[1], info->lead_out[2]);
+				}
+
 				info->fh = NULL;
 				WriteMacInt8(info->status + dsDiskInPlace, 0);
 				return noErr;

--- a/BasiliskII/src/include/bincue.h
+++ b/BasiliskII/src/include/bincue.h
@@ -40,7 +40,9 @@ extern void CDGetVol_bincue(void *, uint8 *, uint8 *);
 
 #ifdef USE_SDL_AUDIO
 extern void OpenAudio_bincue(int, int, int, uint8, int);
+extern bool HaveAudioToMix_bincue(void);
 extern void MixAudio_bincue(uint8 *, int, int);
+extern void CloseAudio_bincue(void);
 #endif
 
 #endif

--- a/BasiliskII/src/include/bincue.h
+++ b/BasiliskII/src/include/bincue.h
@@ -40,7 +40,6 @@ extern void CDGetVol_bincue(void *, uint8 *, uint8 *);
 
 #ifdef USE_SDL_AUDIO
 extern void OpenAudio_bincue(int, int, int, uint8, int);
-extern bool HaveAudioToMix_bincue(void);
 extern void MixAudio_bincue(uint8 *, int, int);
 extern void CloseAudio_bincue(void);
 #endif


### PR DESCRIPTION
This cleans up the opening/closing mess in `bincue.cpp` and some other fixes around this.

- Refactored bin/cue CD player SDL streams' opening and closing out of `OpenAudio_bincue()` and closing out of `close_bincue()` to `OpenPlayerStream`/`ClosePlayerStream`.
  * Added `CloseAudio_bincue` which closes CD player streams and leaves them in a state for `OpenAudio_bincue` to open the stream again without error
  * Save audio settings of most recent `OpenAudio_bincue` so that any new bin/cues opened later have their streams opened right away
- When bincue is being closed remove the pointer to its now freed CDPlayer from the collection (changed it to a list), to avoid a crash
- When a bin/cue that is currently playing is closed, stop it first, to avoid a crash
- When a preconfigured `cdrom` (which isn't closed when ejecting) is ejected, stop it first to avoid an uncontrollable audio stream continuing in the case of a bin/cue