### PR TITLE
Handle SDL drag-and-drop in main thread

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -2289,6 +2289,12 @@ static int SDLCALL on_sdl_event_generated(void *userdata, SDL_Event * event)
 			}
 		} break;
 			
+		case SDL_DROPFILE:
+			CDROMDrop(event->drop.file);
+			SDL_free(event->drop.file);
+			return EVENT_DROP_FROM_QUEUE;
+			break;
+
 		case SDL_WINDOWEVENT: {
 			switch (event->window.event) {
 				case SDL_WINDOWEVENT_RESIZED: {
@@ -2444,15 +2450,9 @@ static void handle_events(void)
 					case SDL_WINDOWEVENT_RESTORED:
 						force_complete_window_refresh();
 						break;
-					
 				}
 				break;
 			}
-
-			case SDL_DROPFILE:
-				CDROMDrop(event.drop.file);
-				SDL_free(event.drop.file);
-				break;
 
 			// Window "close" widget clicked
 			case SDL_QUIT:

--- a/BasiliskII/src/SDL/video_sdl3.cpp
+++ b/BasiliskII/src/SDL/video_sdl3.cpp
@@ -2270,6 +2270,11 @@ static bool SDLCALL on_sdl_event_generated(void *userdata, SDL_Event *event)
 				} break;
 			}
 		} break;
+
+		case SDL_EVENT_DROP_FILE:
+			CDROMDrop(event->drop.data);
+			return EVENT_DROP_FROM_QUEUE;
+			break;
 	}
 	
 	return EVENT_ADD_TO_QUEUE;
@@ -2405,10 +2410,6 @@ static void handle_events(void)
 			case SDL_EVENT_WINDOW_RESTORED:
 				// Force a complete window refresh when activating, to avoid redraw artifacts otherwise.
 				force_complete_window_refresh();
-				break;
-
-			case SDL_EVENT_DROP_FILE:
-				CDROMDrop(event.drop.data);
 				break;
 
 			// Window "close" widget clicked


### PR DESCRIPTION
Move the SDL drag-and-drop handling out of the SDL redraw thread into the main thread.

While dealing with the bin/cue support I took a look at its threading situation:  Most functions are called from the main thread which takes care of most possible concurrency issues between those, with the obvious exception of `MixAudio_bincue` is called from the SDL callback in an `SDLAudioP`_n_ thread.

But there is another: The disk image drag-and-drop handling was happening directly in the SDL redraw thread, and in the case of a dropped '.cue' lead to `bincue_open()`.

I haven't identified any specific crashes or misbehaviour that results from this, but presumably not holding up the redraw thread for whatever disk I/O happens at initial disk image opening time is good, and just not avoiding a special case where some opens happen in the main thread and others don't seems good.
