### PR TITLE
SDL 3 audio: avoid underrun when only bin/cue is playing

### DIFF
--- a/BasiliskII/src/SDL/audio_sdl3.cpp
+++ b/BasiliskII/src/SDL/audio_sdl3.cpp
@@ -299,6 +299,13 @@ static void SDLCALL stream_func(void *, SDL_AudioStream *stream, int stream_len,
 	if (bytes_available > stream_len) {
 		// push any extra bytes, up to the target number, right away
 		stream_len = std::min(bytes_available, target_queue_size);
+	} else if (bytes_available == 0) {
+#if defined(BINCUE)
+		if (HaveAudioToMix_bincue()) {
+			// we are driving the rate entirely on behalf of the CD audio
+			stream_len = target_queue_size;
+		}
+#endif
 	}
 
 	uint8 src[stream_len], dst[stream_len];

--- a/BasiliskII/src/bincue.cpp
+++ b/BasiliskII/src/bincue.cpp
@@ -958,6 +958,11 @@ static uint8 *fill_buffer(int stream_len, CDPlayer* player)
 
 
 #ifdef USE_SDL_AUDIO
+
+bool HaveAudioToMix_bincue() {
+	return currently_playing != NULL;
+}
+
 void MixAudio_bincue(uint8 *stream, int stream_len, int volume)
 {
 	if (currently_playing) {

--- a/BasiliskII/src/include/bincue.h
+++ b/BasiliskII/src/include/bincue.h
@@ -40,6 +40,7 @@ extern void CDGetVol_bincue(void *, uint8 *, uint8 *);
 
 #ifdef USE_SDL_AUDIO
 extern void OpenAudio_bincue(int, int, int, uint8, int);
+extern bool HaveAudioToMix_bincue(void);
 extern void MixAudio_bincue(uint8 *, int, int);
 #endif
 


### PR DESCRIPTION
Apply the increased audio pushing from #230 when only bin/cue CD audio is playing, to avoid the same kind of audio crackling due to underruns.