### PR TITLE
bin/cue: prevent CDPlay_bincue of data track

### DIFF
--- a/BasiliskII/src/bincue.cpp
+++ b/BasiliskII/src/bincue.cpp
@@ -821,7 +821,9 @@ bool CDPlay_bincue(void *fh, uint8 start_m, uint8 start_s, uint8 start_f,
 		SDL_UnlockAudio();
 #endif
 
-		if (player->audio_enabled) {
+		if (cs->tracks[track].tcf != AUDIO) {
+			D(bug("CDPlay_bincue: not playing data track %d!\n", track));
+		} else if (player->audio_enabled) {
 			player->audiostatus = CDROM_AUDIO_PLAY;
 #ifdef OSX_CORE_AUDIO
 			D(bug("starting os x sound"));


### PR DESCRIPTION
Sometimes I encountered Mac software that uses CD audio (for instance Descent II for Mac) starting audio playback in the data track, usually setting the playback start position to frame 0.

As a precaution, I added a check so that we don't start audio playback in a data track.