### PR TITLE
B2: Enable high precision timer for POSIX

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -596,7 +596,7 @@ fi
 
 dnl Checks for library functions.
 AC_CHECK_FUNCS(strdup strerror cfmakeraw)
-AC_CHECK_FUNCS(clock_gettime timer_create)
+AC_CHECK_FUNCS(clock_gettime clock_nanosleep timer_create)
 AC_CHECK_FUNCS(sigaction signal)
 AC_CHECK_FUNCS(mmap mprotect munmap)
 AC_CHECK_FUNCS(vm_allocate vm_deallocate vm_protect)

--- a/BasiliskII/src/timer.cpp
+++ b/BasiliskII/src/timer.cpp
@@ -27,6 +27,7 @@
 #ifdef PRECISE_TIMING_POSIX
 #include <pthread.h>
 #include <semaphore.h>
+#include <signal.h>
 #endif
 
 #ifdef PRECISE_TIMING_MACH


### PR DESCRIPTION
I see the high precision event code from SheepShaver is now there for Basilisk II, including the `sysdeps.h` test to enable it for POSIX:
https://github.com/kanjitalk755/macemu/blob/1bedfac618b0b381b305d6515467372b8522d6be/BasiliskII/src/Unix/sysdeps.h#L502

It just doesn't have the last things brought over from SheepShaver to take effect:
- autoconf check for `clock_nanosleep()`
- `signal.h` include needed for `timer.cpp` for that case (since B2 doesn't include it in `sysdeps.h` like SheepShaver)