### PR TITLE
Avoid segfault if SDL did not init successfully

### DIFF
--- a/BasiliskII/src/SDL/video_sdl.cpp
+++ b/BasiliskII/src/SDL/video_sdl.cpp
@@ -723,6 +723,7 @@ void driver_base::adapt_to_video_mode() {
 	ADBSetRelMouseMode(false);
 
 	// Init blitting routines
+	if (!s) return;
 	SDL_PixelFormat *f = s->format;
 	VisualFormat visualFormat;
 	visualFormat.depth = sdl_depth_of_video_depth(VIDEO_MODE_DEPTH);

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -1107,6 +1107,7 @@ void driver_base::adapt_to_video_mode() {
 	ADBSetRelMouseMode(mouse_grabbed);
 
 	// Init blitting routines
+	if (!s) return;
 	SDL_PixelFormat *f = s->format;
 	VisualFormat visualFormat;
 	visualFormat.depth = sdl_depth_of_video_depth(VIDEO_MODE_DEPTH);

--- a/BasiliskII/src/SDL/video_sdl3.cpp
+++ b/BasiliskII/src/SDL/video_sdl3.cpp
@@ -1101,6 +1101,7 @@ void driver_base::adapt_to_video_mode() {
 	ADBSetRelMouseMode(mouse_grabbed);
 
 	// Init blitting routines
+	if (!s) return;
 	const SDL_PixelFormatDetails *f = SDL_GetPixelFormatDetails(s->format);
 	VisualFormat visualFormat;
 	visualFormat.depth = sdl_depth_of_video_depth(VIDEO_MODE_DEPTH);


### PR DESCRIPTION
Avoid segfault on uninitialized SDL surface in `driver_base::adapt_to_video_mode()` if SDL did not init successfully