### PR TITLE
Windows: when prefs window is closed, do not run the emulator

### DIFF
--- a/BasiliskII/src/Windows/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Windows/prefs_editor_gtk.cpp
@@ -396,6 +396,7 @@ static GtkWidget *make_combobox(GtkWidget *top, int label_id, const char *defaul
 // Window closed
 static gint window_closed(void)
 {
+	start_clicked = false;
 	return FALSE;
 }
 


### PR DESCRIPTION
Fixes #254