### PR TITLE
More pre-c++11 compatibility changes

### DIFF
--- a/BasiliskII/src/Unix/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk.cpp
@@ -525,9 +525,9 @@ bool PrefsEditor(void)
 	gtk_widget_show(notebook);
 
 	static const opt_desc buttons[] = {
-		{STR_START_BUTTON, G_CALLBACK(cb_start)},
-		{STR_QUIT_BUTTON, G_CALLBACK(cb_quit)},
-		{0, NULL}
+		opt_desc(STR_START_BUTTON, G_CALLBACK(cb_start)),
+		opt_desc(STR_QUIT_BUTTON, G_CALLBACK(cb_quit)),
+		opt_desc(0, NULL)
 	};
 	make_button_box(box, 4, buttons);
 
@@ -982,10 +982,10 @@ static void create_volumes_pane(GtkWidget *top)
 	gtk_box_pack_start(GTK_BOX(box), scroll, TRUE, TRUE, 0);
 
 	static const opt_desc buttons[] = {
-		{STR_ADD_VOLUME_BUTTON, G_CALLBACK(cb_add_volume)},
-		{STR_CREATE_VOLUME_BUTTON, G_CALLBACK(cb_create_volume)},
-		{STR_REMOVE_VOLUME_BUTTON, G_CALLBACK(cb_remove_volume), &volume_remove_button},
-		{0, NULL},
+		opt_desc(STR_ADD_VOLUME_BUTTON, G_CALLBACK(cb_add_volume)),
+		opt_desc(STR_CREATE_VOLUME_BUTTON, G_CALLBACK(cb_create_volume)),
+		opt_desc(STR_REMOVE_VOLUME_BUTTON, G_CALLBACK(cb_remove_volume), &volume_remove_button),
+		opt_desc(0, NULL),
 	};
 	make_button_box(box, 0, buttons);
 	gtk_widget_set_sensitive(volume_remove_button, FALSE);

--- a/BasiliskII/src/bincue.cpp
+++ b/BasiliskII/src/bincue.cpp
@@ -126,8 +126,8 @@ typedef struct CDPlayer {
 	uint8 volume_right;			// CD player volume (right)
 	uint8 volume_mono;			// CD player single-channel volume
 	loff_t fileoffset;			// offset from file beginning to audiostart
-	bool audio_enabled = false; // audio initialized for this player?
-	bool scanning = false;      // is there currently scanning in progress
+	bool audio_enabled;			// audio initialized for this player?
+	bool scanning;				// is there currently scanning in progress
 	int reverse;                // for scanning, 0=forward, 1=reverse
 #ifdef OSX_CORE_AUDIO
 	OSXsoundOutput soundoutput;
@@ -529,6 +529,8 @@ void *open_bincue(const char *name)
 		player->volume_left = 0;
 		player->volume_right = 0;
 		player->volume_mono = 0;
+		player->audio_enabled = false;
+		player->scanning = false;
 #ifdef OSX_CORE_AUDIO
 		player->audio_enabled = true;
 #endif

--- a/BasiliskII/src/cdrom.cpp
+++ b/BasiliskII/src/cdrom.cpp
@@ -125,8 +125,8 @@ static const uint8 bcd2bin[256] = {
 
 // Struct for each drive
 struct cdrom_drive_info {
-	cdrom_drive_info() : num(0), fh(NULL), start_byte(0), status(0), drop(false), init_null(false) {}
-	cdrom_drive_info(void *fh_) : num(0), fh(fh_), start_byte(0), status(0), drop(false), init_null(false) {}
+	cdrom_drive_info() : num(0), fh(NULL), start_byte(0), status(0), drop(false), init_null(false), driver_reference_number(0) {}
+	cdrom_drive_info(void *fh_) : num(0), fh(fh_), start_byte(0), status(0), drop(false), init_null(false), driver_reference_number(0) {}
 	
 	void close_fh(void) { SysAllowRemoval(fh); Sys_close(fh); }
 	
@@ -150,7 +150,7 @@ struct cdrom_drive_info {
 	uint32 status;		// Mac address of drive status record
 	bool drop;  		// Disc image mounted by drag-and-drop
 	bool init_null;		// Init even if null
-	uint16 driver_reference_number = 0;  // The driver reference number to use for this drive's entry in the unit table
+	uint16 driver_reference_number;  // The driver reference number to use for this drive's entry in the unit table
 };
 
 // List of drives handled by this driver


### PR DESCRIPTION
Pre-c++11 initialization compatibility changes for stuff I've added recently.

The initializer lists of `opt_desc` when it has a constructor don't even compile in old clang (~ Xcode 9).