### PR TITLE
Fix for SDL3 include autoconf

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -335,7 +335,7 @@ if [[ "x$WANT_SDL" = "xyes" ]]; then
     if [[ "x$TEMP_WANT_SDL_VERSION_MAJOR" = "x3" ]]; then
       PKG_CHECK_MODULES([sdl3], [sdl3 >= 3.0], [
         CXXFLAGS="$CXXFLAGS $sdl3_CFLAGS"
-        CXXFLAGS+=`echo " $sdl3_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`
+        CXXFLAGS="$CXXFLAGS `echo " $sdl3_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`"
         LIBS="$LIBS $sdl3_LIBS"
         WANT_SDL_VERSION_MAJOR=3
       ], [

--- a/BasiliskII/src/Windows/configure.ac
+++ b/BasiliskII/src/Windows/configure.ac
@@ -561,7 +561,7 @@ CPUSRCS="../uae_cpu/basilisk_glue.cpp ../uae_cpu/memory.cpp ../uae_cpu/newcpu.cp
 dnl We really want SDL for now
 if [[ "x$WANT_SDL_VERSION_MAJOR" = "x3" ]]; then
   SDL_CFLAGS=`pkg-config sdl3 --cflags`
-  SDL_CFLAGS+=`echo " $SDL_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`
+  SDL_CFLAGS="$SDL_CFLAGS `echo " $SDL_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`"
   SDL_LIBS=`pkg-config sdl3 --libs | sed -e 's/-lSDL3/-lSDL3.dll/'`
 else
   SDL_CFLAGS=`sdl2-config --cflags`

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -224,7 +224,7 @@ if [[ "x$WANT_SDL" = "xyes" ]]; then
     if [[ "x$TEMP_WANT_SDL_VERSION_MAJOR" = "x3" ]]; then
       PKG_CHECK_MODULES([sdl3], [sdl3 >= 3.0], [
         CXXFLAGS="$CXXFLAGS $sdl3_CFLAGS"
-        CXXFLAGS+=`echo " $sdl3_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`
+        CXXFLAGS="$CXXFLAGS `echo " $sdl3_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`"
         LIBS="$LIBS $sdl3_LIBS"
         WANT_SDL_VERSION_MAJOR=3
       ], [

--- a/SheepShaver/src/Windows/configure.ac
+++ b/SheepShaver/src/Windows/configure.ac
@@ -278,7 +278,7 @@ CPUSRCS="$CPUSRCS ../dummy/prefs_dummy.cpp"
 dnl We really want SDL for now
 if [[ "x$WANT_SDL_VERSION_MAJOR" = "x3" ]]; then
   SDL_CFLAGS=`pkg-config sdl3 --cflags`
-  SDL_CFLAGS+=`echo " $SDL_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`
+  SDL_CFLAGS="$SDL_CFLAGS `echo " $SDL_CFLAGS" | sed -e 's/\(-I.*include\)/\1\/SDL3/'`"
   SDL_LIBS=`pkg-config sdl3 --libs | sed -e 's/-lSDL3/-lSDL3.dll/'`
 else
   SDL_CFLAGS=`sdl2-config --cflags`


### PR DESCRIPTION
Fix so that the autoconf modification of the SDL3 include path works on systems where the default shell is not `bash` (or other shell that has this `+=` operator)