### PR TITLE
extfs file time fixes

### DIFF
--- a/BasiliskII/src/Windows/posix_emu.cpp
+++ b/BasiliskII/src/Windows/posix_emu.cpp
@@ -1135,6 +1135,11 @@ int my_write( int fd, const void *buffer, unsigned int count )
 
 static FILETIME get_file_time(time_t time) {
 	FILETIME ft;
+	if (time == -1) {
+		ft.dwHighDateTime = 0;
+		ft.dwLowDateTime = 0;
+		return ft;
+	}
 	unsigned long long result = 11644473600LL;
 	result += time;
 	result *= 10000000LL;

--- a/BasiliskII/src/Windows/posix_emu.cpp
+++ b/BasiliskII/src/Windows/posix_emu.cpp
@@ -1149,9 +1149,9 @@ int my_utime( const char *path, struct my_utimbuf * my_times )
 	LPCTSTR p = MRP(tpath.get());
 	HANDLE f = CreateFile(p, FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 	if (f != INVALID_HANDLE_VALUE) {
-		FILETIME crTime = get_file_time(my_times->actime);
+		FILETIME acTime = get_file_time(my_times->actime);
 		FILETIME modTime = get_file_time(my_times->modtime);
-		SetFileTime(f, &crTime, NULL, &modTime);
+		SetFileTime(f, NULL, &acTime, &modTime);
 		CloseHandle(f);
 		return 0;
 	}

--- a/BasiliskII/src/macos_util.cpp
+++ b/BasiliskII/src/macos_util.cpp
@@ -190,7 +190,10 @@ time_t MacTimeToTime(uint32 t)
 	local.tm_sec = 0;
 	local.tm_isdst = -1;
 	out = mktime(&local);
-	if (out == -1) return -1;
+	if (out == -1) {
+		D(bug("MacTimeToTime: mktime() can't convert local time starting point\n"));
+		return -1;
+	}
 
 #if MKTIME_START_LATER
 	// Then, if necessary, subtract from 1971 to go back to 1904

--- a/BasiliskII/src/macos_util.cpp
+++ b/BasiliskII/src/macos_util.cpp
@@ -226,12 +226,12 @@ time_t MacTimeToTime(uint32 t)
 		}
 	}
 
+	#if DEBUG
 	uint32 round_trip_val = TimeToMacTime(out);
 	D(bug("MacTimeToTime: round trip %u -> %ld -> %u\n", t, out, round_trip_val));
 
-	#if DEBUG
 	struct tm * show = localtime(&out);
-	D(bug("%s", asctime(show)));
+	D(bug("      %s", asctime(show)));
 	if (t != round_trip_val) {
 		D(bug("MacTimeToTime: Round-Trip Value Disagrees\n"));
 	}

--- a/BasiliskII/src/macos_util.cpp
+++ b/BasiliskII/src/macos_util.cpp
@@ -203,6 +203,26 @@ time_t MacTimeToTime(uint32 t)
 	// Now we want the time t seconds after the starting point
 	out += (time_t) t;
 
+	// Apply offset prefs
+	int32 yearofs = PrefsFindInt32("yearofs");
+	int32 dayofs = PrefsFindInt32("dayofs");
+	if (dayofs != 0 || yearofs != 0) {
+#ifdef WIN32
+		struct tm *out_tm = localtime(&out);
+#else
+		struct tm result;
+		localtime_r(&out, &result);
+		struct tm *out_tm = &result;
+#endif
+		if (out_tm) {
+			out_tm->tm_year -= yearofs;
+			out_tm->tm_mday -= dayofs;
+			out = mktime(out_tm);
+		} else {
+			D(bug("MacTimeToTime: error applying offsets\n"));
+		}
+	}
+
 	uint32 round_trip_val = TimeToMacTime(out);
 	D(bug("MacTimeToTime: round trip %u -> %ld -> %u\n", t, out, round_trip_val));
 

--- a/BasiliskII/src/macos_util.cpp
+++ b/BasiliskII/src/macos_util.cpp
@@ -165,6 +165,33 @@ uint32 TimeToMacTime(time_t t)
 
 time_t MacTimeToTime(uint32 t)
 {
-	// simply subtract number of seconds between 1.1.1904 and 1.1.1970
-	return t - 2082826800;
+	time_t out;
+
+	// Find the time_t time of 1904-Jan-1 0:00 local time
+	struct tm local;
+	local.tm_year = 4;
+	local.tm_mon = 0;
+	local.tm_mday = 1;
+	local.tm_hour = 0;
+	local.tm_min = 0;
+	local.tm_sec = 0;
+	local.tm_isdst = -1;
+	out = mktime(&local);
+	if (out == -1) return -1;
+
+	// We want the time t seconds after
+	out += (time_t) t;
+
+	uint32 round_trip_val = TimeToMacTime(out);
+	D(bug("MacTimeToTime: round trip %u -> %ld -> %u\n", t, out, round_trip_val));
+
+	#if DEBUG
+	struct tm * show = localtime(&out);
+	D(bug("%s", asctime(show)));
+	if (t != round_trip_val) {
+		D(bug("MacTimeToTime: Round-Trip Value Disagrees\n"));
+	}
+	#endif
+
+	return out;
 }

--- a/BasiliskII/src/macos_util.cpp
+++ b/BasiliskII/src/macos_util.cpp
@@ -217,7 +217,10 @@ time_t MacTimeToTime(uint32 t)
 		if (out_tm) {
 			out_tm->tm_year -= yearofs;
 			out_tm->tm_mday -= dayofs;
-			out = mktime(out_tm);
+			time_t offset_adjusted = mktime(out_tm);
+			if (offset_adjusted != -1) {
+				out = offset_adjusted;
+			}
 		} else {
 			D(bug("MacTimeToTime: error applying offsets\n"));
 		}

--- a/SheepShaver/src/macos_util.cpp
+++ b/SheepShaver/src/macos_util.cpp
@@ -463,6 +463,26 @@ time_t MacTimeToTime(uint32 t)
 	// Now we want the time t seconds after the starting point
 	out += (time_t) t;
 
+	// Apply offset prefs
+	int32 yearofs = PrefsFindInt32("yearofs");
+	int32 dayofs = PrefsFindInt32("dayofs");
+	if (dayofs != 0 || yearofs != 0) {
+#ifdef WIN32
+		struct tm *out_tm = localtime(&out);
+#else
+		struct tm result;
+		localtime_r(&out, &result);
+		struct tm *out_tm = &result;
+#endif
+		if (out_tm) {
+			out_tm->tm_year -= yearofs;
+			out_tm->tm_mday -= dayofs;
+			out = mktime(out_tm);
+		} else {
+			D(bug("MacTimeToTime: error applying offsets\n"));
+		}
+	}
+
 	uint32 round_trip_val = TimeToMacTime(out);
 	D(bug("MacTimeToTime: round trip %u -> %ld -> %u\n", t, out, round_trip_val));
 

--- a/SheepShaver/src/macos_util.cpp
+++ b/SheepShaver/src/macos_util.cpp
@@ -477,7 +477,10 @@ time_t MacTimeToTime(uint32 t)
 		if (out_tm) {
 			out_tm->tm_year -= yearofs;
 			out_tm->tm_mday -= dayofs;
-			out = mktime(out_tm);
+			time_t offset_adjusted = mktime(out_tm);
+			if (offset_adjusted != -1) {
+				out = offset_adjusted;
+			}
 		} else {
 			D(bug("MacTimeToTime: error applying offsets\n"));
 		}

--- a/SheepShaver/src/macos_util.cpp
+++ b/SheepShaver/src/macos_util.cpp
@@ -486,12 +486,12 @@ time_t MacTimeToTime(uint32 t)
 		}
 	}
 
+	#if DEBUG
 	uint32 round_trip_val = TimeToMacTime(out);
 	D(bug("MacTimeToTime: round trip %u -> %ld -> %u\n", t, out, round_trip_val));
 
-	#if DEBUG
 	struct tm * show = localtime(&out);
-	D(bug("%s", asctime(show)));
+	D(bug("      %s", asctime(show)));
 	if (t != round_trip_val) {
 		D(bug("MacTimeToTime: Round-Trip Value Disagrees\n"));
 	}

--- a/SheepShaver/src/macos_util.cpp
+++ b/SheepShaver/src/macos_util.cpp
@@ -419,14 +419,62 @@ uint32 TimeToMacTime(time_t t)
 }
 
 
+#ifdef WIN32
+// mktime() here can't produce negative values so we have to start later
+#define MKTIME_START_LATER 1
+#else
+#define MKTIME_START_LATER 0
+#endif
+
 /*
  *  Convert MacOS time to time_t (seconds since 1.1.1970)
  */
 
 time_t MacTimeToTime(uint32 t)
 {
-	// simply subtract number of seconds between 1.1.1904 and 1.1.1970
-	return t - 2082826800;
+	time_t out;
+
+	// Find the time_t time of our local time starting point 1904-Jan-1 0:00 local time
+	struct tm local;
+#if MKTIME_START_LATER
+	// If we need to start later for mktime(),
+	// first find 1971-Jan-1 0:00 local time
+	local.tm_year = 71;
+#else
+	local.tm_year = 4;
+#endif
+	local.tm_mon = 0;
+	local.tm_mday = 1;
+	local.tm_hour = 0;
+	local.tm_min = 0;
+	local.tm_sec = 0;
+	local.tm_isdst = -1;
+	out = mktime(&local);
+	if (out == -1) {
+		D(bug("MacTimeToTime: mktime() can't convert local time starting point\n"));
+		return -1;
+	}
+
+#if MKTIME_START_LATER
+	// Then, if necessary, subtract from 1971 to go back to 1904
+	out -= 2114380800; // Seconds between 1904 and 1971
+#endif
+
+	// Now we want the time t seconds after the starting point
+	out += (time_t) t;
+
+	uint32 round_trip_val = TimeToMacTime(out);
+	D(bug("MacTimeToTime: round trip %u -> %ld -> %u\n", t, out, round_trip_val));
+
+	#if DEBUG
+	struct tm * show = localtime(&out);
+	D(bug("%s", asctime(show)));
+	if (t != round_trip_val) {
+		D(bug("MacTimeToTime: Round-Trip Value Disagrees\n"));
+	}
+	#endif
+
+	return out;
 }
 
 


### PR DESCRIPTION
- Fixed an issue with extfs on Windows where the file timestamps update in `utime()` resulting from `set_finfo()` wrote the access time as the creation time
- Re-implemented `MacTimeToTime()` using `mktime()` so that those timestamps updates write the correct times, considering the difference between UTC and local time
- Added a check for the Windows so that we aren't overwriting timestamps in the case of invalid `time_t` (`-1`) values

Fixes #258 