### PR TITLE
Fix security related compiler error.

### DIFF
--- a/BasiliskII/src/Unix/main_unix.cpp
+++ b/BasiliskII/src/Unix/main_unix.cpp
@@ -1681,7 +1681,7 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 	                                           GTK_MESSAGE_WARNING,
 	                                           GTK_BUTTONS_NONE,
 	                                           GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);

--- a/BasiliskII/src/Unix/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk.cpp
@@ -1955,7 +1955,7 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 	                                           GTK_MESSAGE_WARNING,
 	                                           GTK_BUTTONS_NONE,
 	                                           GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);

--- a/BasiliskII/src/Unix/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk.cpp
@@ -42,9 +42,11 @@
 #define DEBUG 0
 #include "debug.h"
 
+
 // Global variables
-static GtkWidget *win;			   // Preferences window
-static bool start_clicked = false; // Return value of PrefsEditor() function
+static GtkWidget *win;				// Preferences window
+static bool start_clicked = false;	// Return value of PrefsEditor() function
+
 
 // Prototypes
 static void create_volumes_pane(GtkWidget *top);
@@ -55,30 +57,29 @@ static void create_serial_pane(GtkWidget *top);
 static void create_memory_pane(GtkWidget *top);
 static void create_jit_pane(GtkWidget *top);
 static void read_settings(void);
-static void add_volume_entry_with_type(const char *filename, bool cdrom);
-static void add_volume_entry_guessed(const char *filename);
+static void add_volume_entry_with_type(const char * filename, bool cdrom);
+static void add_volume_entry_guessed(const char * filename);
+
 
 /*
  *  Utility functions
  */
 
-#if !GLIB_CHECK_VERSION(2, 0, 0)
-#define G_OBJECT(obj) GTK_OBJECT(obj)
-#define g_object_get_data(obj, key) gtk_object_get_data((obj), (key))
-#define g_object_set_data(obj, key, data) gtk_object_set_data((obj), (key), (data))
+#if ! GLIB_CHECK_VERSION(2,0,0)
+#define G_OBJECT(obj)							GTK_OBJECT(obj)
+#define g_object_get_data(obj, key)				gtk_object_get_data((obj), (key))
+#define g_object_set_data(obj, key, data)		gtk_object_set_data((obj), (key), (data))
 #endif
 
-struct opt_desc
-{
-	opt_desc(int l, GCallback f, GtkWidget **s = NULL) : label_id(l), func(f), save_ref(s) {}
+struct opt_desc {
+	opt_desc(int l, GCallback f, GtkWidget **s=NULL) : label_id(l), func(f), save_ref(s) {}
 
 	int label_id;
 	GtkSignalFunc func;
-	GtkWidget **save_ref;
+	GtkWidget ** save_ref;
 };
 
-struct combo_desc
-{
+struct combo_desc {
 	int label_id;
 };
 
@@ -88,22 +89,22 @@ static void cb_browse_response(GtkWidget *chooser, int response, GtkEntry *entry
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
 		gchar *filename;
-		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
+		filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (chooser));
 		gtk_entry_set_text(GTK_ENTRY(entry), filename);
-		g_free(filename);
+		g_free (filename);
 	}
-	gtk_widget_destroy(chooser);
+	gtk_widget_destroy (chooser);
 }
 
 // Open the file chooser dialog to select a file
 static void cb_browse(GtkWidget *button, GtkWidget *entry)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_BROWSE_TITLE),
-													 GTK_WINDOW(win),
-													 GTK_FILE_CHOOSER_ACTION_OPEN,
-													 "Cancel", GTK_RESPONSE_CANCEL,
-													 "Open", GTK_RESPONSE_ACCEPT,
-													 NULL);
+							GTK_WINDOW(win),
+							GTK_FILE_CHOOSER_ACTION_OPEN,
+							"Cancel", GTK_RESPONSE_CANCEL,
+							"Open", GTK_RESPONSE_ACCEPT,
+							NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_path_get_dirname(gtk_entry_get_text(GTK_ENTRY(entry))));
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
@@ -116,11 +117,11 @@ static void cb_browse(GtkWidget *button, GtkWidget *entry)
 static void cb_browse_dir(GtkWidget *button, GtkWidget *entry)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_BROWSE_FOLDER_TITLE),
-													 GTK_WINDOW(win),
-													 GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
-													 "Cancel", GTK_RESPONSE_CANCEL,
-													 "Select", GTK_RESPONSE_ACCEPT,
-													 NULL);
+							GTK_WINDOW(win),
+							GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+							"Cancel", GTK_RESPONSE_CANCEL,
+							"Select", GTK_RESPONSE_ACCEPT,
+							NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), gtk_entry_get_text(GTK_ENTRY(entry)));
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
@@ -176,14 +177,12 @@ static GtkWidget *make_button_box(GtkWidget *top, int border, const opt_desc *bu
 	gtk_button_box_set_spacing(GTK_BUTTON_BOX(bb), 4);
 	gtk_box_pack_start(GTK_BOX(top), bb, FALSE, FALSE, 0);
 
-	while (buttons->label_id)
-	{
+	while (buttons->label_id) {
 		button = gtk_button_new_with_label(GetString(buttons->label_id));
 		gtk_widget_show(button);
-		g_signal_connect_object(button, "clicked", buttons->func, NULL, (GConnectFlags)0);
+		g_signal_connect_object(button, "clicked", buttons->func, NULL, (GConnectFlags) 0);
 		gtk_box_pack_start(GTK_BOX(bb), button, TRUE, TRUE, 0);
-		if (buttons->save_ref)
-		{
+		if (buttons->save_ref) {
 			*(buttons->save_ref) = button;
 		}
 		buttons++;
@@ -208,8 +207,8 @@ static GtkWidget *make_table(GtkWidget *top, int x, int y)
 }
 
 static GtkWidget *table_make_option_menu(GtkWidget *table, int row, int label_id,
-										 const combo_desc *options, GCallback func,
-										 int active)
+                                         const combo_desc *options, GCallback func,
+                                         int active)
 {
 	GtkWidget *label, *combo;
 
@@ -220,8 +219,7 @@ static GtkWidget *table_make_option_menu(GtkWidget *table, int row, int label_id
 	combo = gtk_combo_box_new_text();
 	gtk_widget_show(combo);
 
-	while (options->label_id)
-	{
+	while (options->label_id) {
 		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(options->label_id));
 		options++;
 	}
@@ -241,13 +239,13 @@ static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, c
 
 	combo = gtk_combo_box_entry_new_text();
 	gtk_widget_show(combo);
-	while (list)
+	while(list)
 	{
-		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), ((gchar *)list->data));
+		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), ((gchar *) list->data));
 		list = list->next;
 	}
 
-	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo))), pref);
+	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN (combo))), pref);
 	gtk_table_attach(GTK_TABLE(table), combo, 1, 2, row, row + 1, (GtkAttachOptions)(GTK_FILL | GTK_EXPAND), (GtkAttachOptions)0, 4, 4);
 
 	return combo;
@@ -256,8 +254,7 @@ static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, c
 static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, const char *default_value, const combo_desc *options)
 {
 	GList *glist = NULL;
-	while (options->label_id)
-	{
+	while (options->label_id) {
 		glist = g_list_append(glist, (void *)GetString(options->label_id));
 		options++;
 	}
@@ -307,8 +304,7 @@ static GtkWidget *make_option_menu(GtkWidget *top, int label_id, const combo_des
 	combo = gtk_combo_box_new_text();
 	gtk_widget_show(combo);
 
-	while (options->label_id)
-	{
+	while (options->label_id) {
 		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(options->label_id));
 		options++;
 	}
@@ -339,7 +335,7 @@ static GtkWidget *make_file_entry(GtkWidget *top, int label_id, const char *pref
 	button = make_browse_button(entry, only_dirs);
 
 	gtk_widget_show(entry);
-#if GLIB_CHECK_VERSION(2, 26, 0)
+#if GLIB_CHECK_VERSION(2,26,0)
 	g_object_bind_property(entry, "sensitive", button, "sensitive", G_BINDING_SYNC_CREATE);
 #endif
 	gtk_box_pack_start(GTK_BOX(box), entry, TRUE, TRUE, 0);
@@ -359,7 +355,7 @@ static GtkWidget *make_checkbox(GtkWidget *top, int label_id, const char *prefs_
 	gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(button), PrefsFindBool(prefs_item));
 	g_signal_connect(button, "toggled", func, NULL);
 	if (top)
-		gtk_box_pack_start(GTK_BOX(top), button, FALSE, FALSE, 0);
+	    gtk_box_pack_start(GTK_BOX(top), button, FALSE, FALSE, 0);
 	return button;
 }
 
@@ -380,18 +376,18 @@ static GtkWidget *make_combobox(GtkWidget *top, int label_id, const char *prefs_
 	gtk_widget_show(combo);
 	gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
 
-	while (options->label_id)
-	{
-		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), (gchar *)GetString(options->label_id));
+	while (options->label_id) {
+		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), (gchar *) GetString(options->label_id));
 		options++;
 	}
 
 	sprintf(str, "%d", PrefsFindInt32(prefs_item));
-	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo))), str);
+	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN (combo))), str);
 	gtk_box_pack_start(GTK_BOX(box), combo, TRUE, TRUE, 0);
 
 	return combo;
 }
+
 
 /*
  *  Show preferences editor
@@ -457,19 +453,20 @@ static void mn_about(...)
 		"Lauri Pesonen",
 		"Bernd Schmidt",
 		"and others",
-		NULL};
+		NULL
+	};
 	char version[64];
 	sprintf(version, "%d.%d", VERSION_MAJOR, VERSION_MINOR);
 	gtk_show_about_dialog(GTK_WINDOW(win), "version", version,
-						  "copyright", GetString(STR_ABOUT_COPYRIGHT),
-						  "authors", authors,
-						  "comments", GetString(STR_ABOUT_COMMENTS),
-						  "website", GetString(STR_ABOUT_WEBSITE),
-						  "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
-						  "license", GetString(STR_ABOUT_LICENSE),
-						  "wrap-license", true,
-						  "logo-icon-name", "BasiliskII",
-						  NULL);
+	                     "copyright", GetString(STR_ABOUT_COPYRIGHT),
+	                     "authors", authors,
+	                     "comments", GetString(STR_ABOUT_COMMENTS),
+	                     "website", GetString(STR_ABOUT_WEBSITE),
+	                     "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
+	                     "license", GetString(STR_ABOUT_LICENSE),
+	                     "wrap-license", true,
+	                     "logo-icon-name", "BasiliskII",
+	                     NULL);
 }
 
 // "Zap PRAM" selected
@@ -480,14 +477,15 @@ static void mn_zap_pram(...)
 
 // Menu item descriptions
 static GtkItemFactoryEntry menu_items[] = {
-	{(gchar *)GetString(STR_PREFS_MENU_FILE_GTK), NULL, NULL, 0, "<Branch>"},
-	{(gchar *)GetString(STR_PREFS_ITEM_START_GTK), "<control>S", G_CALLBACK(cb_start), 0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_SAVE_GTK), NULL, G_CALLBACK(cb_save), 0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_ZAP_PRAM_GTK), NULL, G_CALLBACK(mn_zap_pram), 0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_SEPL_GTK), NULL, NULL, 0, "<Separator>"},
-	{(gchar *)GetString(STR_PREFS_ITEM_QUIT_GTK), "<control>Q", G_CALLBACK(cb_quit), 0, NULL},
-	{(gchar *)GetString(STR_HELP_MENU_GTK), NULL, NULL, 0, "<LastBranch>"},
-	{(gchar *)GetString(STR_HELP_ITEM_ABOUT_GTK), NULL, G_CALLBACK(mn_about), 0, NULL}};
+	{(gchar *)GetString(STR_PREFS_MENU_FILE_GTK),		NULL,			NULL,							0, "<Branch>"},
+	{(gchar *)GetString(STR_PREFS_ITEM_START_GTK),		"<control>S",	G_CALLBACK(cb_start),		0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_SAVE_GTK),		NULL,			G_CALLBACK(cb_save),		0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_ZAP_PRAM_GTK),	NULL,			G_CALLBACK(mn_zap_pram),	0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_SEPL_GTK),		NULL,			NULL,							0, "<Separator>"},
+	{(gchar *)GetString(STR_PREFS_ITEM_QUIT_GTK),		"<control>Q",	G_CALLBACK(cb_quit),		0, NULL},
+	{(gchar *)GetString(STR_HELP_MENU_GTK),				NULL,			NULL,							0, "<LastBranch>"},
+	{(gchar *)GetString(STR_HELP_ITEM_ABOUT_GTK),		NULL,			G_CALLBACK(mn_about),		0, NULL}
+};
 
 bool PrefsEditor(void)
 {
@@ -529,7 +527,8 @@ bool PrefsEditor(void)
 	static const opt_desc buttons[] = {
 		opt_desc(STR_START_BUTTON, G_CALLBACK(cb_start)),
 		opt_desc(STR_QUIT_BUTTON, G_CALLBACK(cb_quit)),
-		opt_desc(0, NULL)};
+		opt_desc(0, NULL)
+	};
 	make_button_box(box, 4, buttons);
 
 	// Show window and enter main loop
@@ -537,6 +536,7 @@ bool PrefsEditor(void)
 	gtk_main();
 	return start_clicked;
 }
+
 
 /*
  *  "Volumes" pane
@@ -547,37 +547,34 @@ static GtkListStore *volume_list_model;
 static GtkWidget *volume_remove_button;
 
 // Volume list selection changed
-static void cl_selected(GtkTreeSelection *selection, gpointer user_data)
-{
-	if (selection)
-	{
+static void cl_selected(GtkTreeSelection * selection, gpointer user_data) {
+	if (selection) {
 		bool have_selection = gtk_tree_selection_get_selected(selection, NULL, NULL);
 
 		gtk_widget_set_sensitive(GTK_WIDGET(volume_remove_button), have_selection);
 	}
 }
 
+
 // Process proposed drop
-gboolean volume_list_drag_motion(GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time,
-								 gpointer user_data)
+gboolean volume_list_drag_motion (GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time,
+                                            gpointer user_data)
 {
 	GtkTreePath *path;
 	GtkTreeViewDropPosition pos;
 	// Don't allow tree-style drops onto, only list-style drops between
-	if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x, y, &path, &pos))
-	{
-		switch (pos)
-		{
-		case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
-			gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_AFTER);
-			break;
-		case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
-			gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_BEFORE);
-			break;
-		case GTK_TREE_VIEW_DROP_BEFORE:
-		case GTK_TREE_VIEW_DROP_AFTER:
-			// these are ok, no change
-			break;
+	if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x,y, &path, &pos)) {
+		switch (pos) {
+			case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
+				gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_AFTER);
+				break;
+			case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
+				gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_BEFORE);
+				break;
+			case GTK_TREE_VIEW_DROP_BEFORE:
+			case GTK_TREE_VIEW_DROP_AFTER:
+				// these are ok, no change
+				break;
 		}
 		gdk_drag_status(drag_context, drag_context->suggested_action, time);
 		return TRUE;
@@ -585,59 +582,50 @@ gboolean volume_list_drag_motion(GtkWidget *widget, GdkDragContext *drag_context
 	return FALSE;
 }
 
+
 // Something dropped on volume list
 static void drag_data_received(GtkWidget *list, GdkDragContext *drag_context, gint x, gint y, GtkSelectionData *data,
-							   guint info, guint time, gpointer user_data)
+	guint info, guint time, gpointer user_data)
 {
 	// reordering drags have already been handled by clist
-	if (data->type == gdk_atom_intern("gtk-clist-drag-reorder", true))
-	{
+	if (data->type == gdk_atom_intern("gtk-clist-drag-reorder", true)) {
 		return;
 	}
 
 	// get URIs from the drag selection data and add them
-	gchar **uris = g_strsplit((gchar *)(data->data), "\r\n", -1);
-	for (gchar **uri = uris; *uri != NULL; uri++)
-	{
-		if (strlen(*uri) < 7)
-			continue;
-		if (strncmp("file://", *uri, 7) != 0)
-			continue;
+	gchar ** uris = g_strsplit((gchar *)(data->data), "\r\n", -1);
+	for (gchar ** uri = uris; *uri != NULL; uri++) {
+		if (strlen(*uri) < 7) continue;
+		if (strncmp("file://", *uri, 7) != 0) continue;
 
-		gchar *filename = g_filename_from_uri(*uri, NULL, NULL);
-		if (filename)
-		{
+		gchar * filename = g_filename_from_uri(*uri, NULL, NULL);
+		if (filename) {
 			add_volume_entry_guessed(filename);
 
 			// figure out where in the list they dropped
 			GtkTreePath *path;
 			GtkTreeViewDropPosition pos;
-			if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x, y, &path, &pos))
-			{
+			if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x,y, &path, &pos)) {
 				GtkTreeIter dest_iter;
-				if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &dest_iter, path))
-				{
+				if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &dest_iter, path)) {
 
 					// Find the item we just added and put it in place
 					GtkTreeIter last;
 					GtkTreeIter cur;
-					if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(volume_list_model), &cur))
-					{
-						do
-						{
+					if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(volume_list_model), &cur)) {
+						do {
 							last = cur;
 						} while (gtk_tree_model_iter_next(GTK_TREE_MODEL(volume_list_model), &cur));
 					}
-					switch (pos)
-					{
-					case GTK_TREE_VIEW_DROP_AFTER:
-					case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
-						gtk_list_store_move_after(volume_list_model, &last, &dest_iter);
-						break;
-					case GTK_TREE_VIEW_DROP_BEFORE:
-					case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
-						gtk_list_store_move_before(volume_list_model, &last, &dest_iter);
-						break;
+					switch (pos) {
+						case GTK_TREE_VIEW_DROP_AFTER:
+						case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
+							gtk_list_store_move_after(volume_list_model, &last, &dest_iter);
+							break;
+						case GTK_TREE_VIEW_DROP_BEFORE:
+						case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
+							gtk_list_store_move_before(volume_list_model, &last, &dest_iter);
+							break;
 					}
 				}
 			}
@@ -649,7 +637,7 @@ static void drag_data_received(GtkWidget *list, GdkDragContext *drag_context, gi
 }
 
 // Volume selected for addition
-static void cb_add_volume_response(GtkWidget *chooser, int response)
+static void cb_add_volume_response (GtkWidget *chooser, int response)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
@@ -660,7 +648,7 @@ static void cb_add_volume_response(GtkWidget *chooser, int response)
 }
 
 // Volume selected for creation
-static void cb_create_volume_response(GtkWidget *chooser, int response, GtkEntry *size_entry)
+static void cb_create_volume_response (GtkWidget *chooser, int response, GtkEntry *size_entry)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
@@ -670,10 +658,10 @@ static void cb_create_volume_response(GtkWidget *chooser, int response, GtkEntry
 		if (disk_size < 1 || disk_size > 2000)
 		{
 			GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-													   (GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
-													   GTK_MESSAGE_WARNING,
-													   GTK_BUTTONS_CLOSE,
-													   "Enter a valid size", NULL);
+							(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+							GTK_MESSAGE_WARNING,
+							GTK_BUTTONS_CLOSE,
+							"Enter a valid size", NULL);
 			gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "The volume size should be between 1 and 2000.");
 			gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(chooser));
 			g_signal_connect(dialog, "response", G_CALLBACK(dl_quit), NULL);
@@ -681,29 +669,26 @@ static void cb_create_volume_response(GtkWidget *chooser, int response, GtkEntry
 			return; // Don't close the file chooser dialog
 		}
 		int fd = open(file, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
-		if (fd < 0)
-		{
+		if (fd < 0) {
 			fprintf(stderr, "Could not create %s (%s)\n", file, strerror(errno));
-		}
-		else
-		{
+		} else {
 			ftruncate(fd, disk_size * 1024 * 1024);
 			// A created empty volume is always a new disk
 			add_volume_entry_with_type(file, false);
 		}
 	}
-	gtk_widget_destroy(chooser);
+	gtk_widget_destroy (chooser);
 }
 
 // "Add Volume" button clicked
-static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_ADD_VOLUME_TITLE),
-													 GTK_WINDOW(win),
-													 GTK_FILE_CHOOSER_ACTION_OPEN,
-													 "Cancel", GTK_RESPONSE_CANCEL,
-													 "Add", GTK_RESPONSE_ACCEPT,
-													 NULL);
+							GTK_WINDOW(win),
+							GTK_FILE_CHOOSER_ACTION_OPEN,
+							"Cancel", GTK_RESPONSE_CANCEL,
+							"Add", GTK_RESPONSE_ACCEPT,
+							NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_get_home_dir());
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_modal(GTK_WINDOW(chooser), true);
@@ -712,14 +697,14 @@ static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer u
 }
 
 // "Create Hardfile" button clicked
-static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_CREATE_VOLUME_TITLE),
-													 GTK_WINDOW(win),
-													 GTK_FILE_CHOOSER_ACTION_SAVE,
-													 "Cancel", GTK_RESPONSE_CANCEL,
-													 "Create", GTK_RESPONSE_ACCEPT,
-													 NULL);
+							GTK_WINDOW(win),
+							GTK_FILE_CHOOSER_ACTION_SAVE,
+							"Cancel", GTK_RESPONSE_CANCEL,
+							"Create", GTK_RESPONSE_ACCEPT,
+							NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_get_home_dir());
 	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(chooser), TRUE);
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
@@ -747,11 +732,9 @@ static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointe
 static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(volume_list));
-	if (sel)
-	{
+	if (sel) {
 		GtkTreeIter row;
-		if (gtk_tree_selection_get_selected(sel, NULL, &row))
-		{
+		if (gtk_tree_selection_get_selected(sel, NULL, &row)) {
 			gtk_list_store_remove(volume_list_model, &row);
 		}
 	}
@@ -773,35 +756,32 @@ static void tb_nocdrom(GtkWidget *widget)
 }
 
 // Data source for the volumes list
-enum
-{
+enum {
 	VOLUME_LIST_FILENAME = 0,
 	VOLUME_LIST_CDROM,
 	VOLUME_LIST_SIZE_DESC,
 	NUM_VOLUME_LIST_FIELDS
 };
 
-static void init_volume_model()
-{
+static void init_volume_model() {
 	volume_list_model = gtk_list_store_new(NUM_VOLUME_LIST_FIELDS,
-										   G_TYPE_STRING,  // filename
-										   G_TYPE_BOOLEAN, // is CD-ROM
-										   G_TYPE_STRING   // size desc
-	);
+		G_TYPE_STRING,	// filename
+		G_TYPE_BOOLEAN,	// is CD-ROM
+		G_TYPE_STRING	// size desc
+		);
 }
 
-static void toggle_cdrom_val(GtkTreeIter *row)
-{
+static void toggle_cdrom_val(GtkTreeIter *row) {
 	gboolean cdrom;
 	gtk_tree_model_get(GTK_TREE_MODEL(volume_list_model), row,
-					   VOLUME_LIST_CDROM, &cdrom,
-					   -1);
+		VOLUME_LIST_CDROM, &cdrom,
+		-1);
 
 	cdrom = !cdrom;
 
 	gtk_list_store_set(volume_list_model, row,
-					   VOLUME_LIST_CDROM, cdrom,
-					   -1);
+		VOLUME_LIST_CDROM, cdrom,
+		-1);
 }
 
 // Read settings from widgets and set preferences
@@ -812,13 +792,11 @@ static void read_volumes_settings(void)
 	while (PrefsFindString("cdrom"))
 		PrefsRemoveItem("cdrom");
 
-	GtkTreeModel *m = GTK_TREE_MODEL(volume_list_model);
+	GtkTreeModel * m = GTK_TREE_MODEL(volume_list_model);
 
 	GtkTreeIter row;
-	if (gtk_tree_model_get_iter_first(m, &row))
-	{
-		do
-		{
+	if (gtk_tree_model_get_iter_first(m, &row)) {
+		do {
 			GValue filename = G_VALUE_INIT, is_cdrom = G_VALUE_INIT;
 
 			gtk_tree_model_get_value(m, &row, VOLUME_LIST_FILENAME, &filename);
@@ -826,7 +804,7 @@ static void read_volumes_settings(void)
 
 			D(bug("handling %d: %s\n", g_value_get_boolean(&is_cdrom), g_value_get_string(&filename)));
 
-			const char *pref_name = g_value_get_boolean(&is_cdrom) ? "cdrom" : "disk";
+			const char * pref_name = g_value_get_boolean(&is_cdrom) ? "cdrom": "disk";
 			PrefsAddString(pref_name, g_value_get_string(&filename));
 
 			g_value_unset(&filename);
@@ -839,11 +817,10 @@ static void read_volumes_settings(void)
 }
 
 // Gets the size of the volume as a pretty string
-static const char *get_file_size(const char *filename)
+static const char* get_file_size (const char * filename)
 {
 	std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
-	if (in.is_open())
-	{
+	if (in.is_open()) {
 		uint64_t size = in.tellg();
 		in.close();
 		char *sizestr = g_format_size_full(size, G_FORMAT_SIZE_IEC_UNITS);
@@ -855,53 +832,48 @@ static const char *get_file_size(const char *filename)
 	}
 }
 
-static bool volume_in_list(const char *filename)
-{
+
+static bool volume_in_list(const char * filename) {
 	bool found = false;
 
-	GtkTreeModel *m = GTK_TREE_MODEL(volume_list_model);
+	GtkTreeModel * m = GTK_TREE_MODEL(volume_list_model);
 
 	GtkTreeIter row;
-	if (gtk_tree_model_get_iter_first(m, &row))
-	{
-		do
-		{
+	if (gtk_tree_model_get_iter_first(m, &row)) {
+		do {
 			GValue cur_filename = G_VALUE_INIT;
 
 			gtk_tree_model_get_value(m, &row, VOLUME_LIST_FILENAME, &cur_filename);
 
-			if (strcmp(g_value_get_string(&cur_filename), filename) == 0)
-			{
+			if (strcmp(g_value_get_string(&cur_filename), filename) == 0) {
 				found = true;
 			}
 
 			g_value_unset(&cur_filename);
 
-			if (found)
-				break;
+			if (found) break;
 		} while (gtk_tree_model_iter_next(GTK_TREE_MODEL(volume_list_model), &row));
 	}
 
 	return found;
 }
 
+
 // Add a volume file as the given type
-static void add_volume_entry_with_type(const char *filename, bool cdrom)
-{
-	if (volume_in_list(filename))
-		return;
+static void add_volume_entry_with_type(const char * filename, bool cdrom) {
+	if (volume_in_list(filename)) return;
 
 	GtkTreeIter row;
 	gtk_list_store_append(GTK_LIST_STORE(volume_list_model), &row);
 	// set the values for the new row
 	gtk_list_store_set(GTK_LIST_STORE(volume_list_model), &row,
-					   VOLUME_LIST_FILENAME, filename,
-					   VOLUME_LIST_CDROM, cdrom,
-					   VOLUME_LIST_SIZE_DESC, get_file_size(filename),
-					   -1);
+		VOLUME_LIST_FILENAME, filename,
+		VOLUME_LIST_CDROM, cdrom,
+		VOLUME_LIST_SIZE_DESC, get_file_size(filename),
+		-1);
 }
 
-static bool has_file_ext(const char *str, const char *ext)
+static bool has_file_ext (const char * str, const char *ext)
 {
 	char *file_ext = g_utf8_strrchr(str, 255, '.');
 	if (!file_ext)
@@ -909,32 +881,30 @@ static bool has_file_ext(const char *str, const char *ext)
 	return (g_strcmp0(file_ext, ext) == 0);
 }
 
-static bool guess_if_file_is_cdrom(const char *volume)
-{
+static bool guess_if_file_is_cdrom(const char * volume) {
 	return has_file_ext(volume, ".iso") ||
 #ifdef BINCUE
-		   has_file_ext(volume, ".cue") ||
+		has_file_ext(volume, ".cue") ||
 #endif
-		   has_file_ext(volume, ".toast");
+		has_file_ext(volume, ".toast");
 }
 
 // Add a volume file and guess the type
-static void add_volume_entry_guessed(const char *filename)
-{
+static void add_volume_entry_guessed(const char * filename) {
 	add_volume_entry_with_type(filename, guess_if_file_is_cdrom(filename));
 }
 
 // CD-ROM checkbox changed
-static void cb_cdrom(GtkCellRendererToggle *cell, char *path_str, gpointer data)
+static void cb_cdrom (GtkCellRendererToggle *cell, char *path_str, gpointer data)
 {
 	GtkTreeIter iter;
-	GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
-	if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &iter, path))
-	{
+	GtkTreePath *path = gtk_tree_path_new_from_string (path_str);
+	if (gtk_tree_model_get_iter (GTK_TREE_MODEL(volume_list_model), &iter, path)) {
 		toggle_cdrom_val(&iter);
 	}
-	gtk_tree_path_free(path);
+	gtk_tree_path_free (path);
 }
+
 
 // Create "Volumes" pane
 static void create_volumes_pane(GtkWidget *top)
@@ -970,8 +940,8 @@ static void create_volumes_pane(GtkWidget *top)
 	gtk_tree_view_column_set_title(column, GetString(STR_VOL_HEADING_CDROM));
 	gtk_tree_view_append_column(GTK_TREE_VIEW(volume_list), column);
 	renderer = gtk_cell_renderer_toggle_new();
-	g_signal_connect(renderer, "toggled",
-					 G_CALLBACK(cb_cdrom), NULL);
+	g_signal_connect (renderer, "toggled",
+	                  G_CALLBACK (cb_cdrom), NULL);
 	gtk_tree_view_column_set_alignment(column, 0.5);
 
 	gtk_tree_view_column_pack_start(column, renderer, TRUE);
@@ -999,12 +969,10 @@ static void create_volumes_pane(GtkWidget *top)
 
 	char *str;
 	int32 index;
-	const char *types[] = {"disk", "cdrom", NULL};
-	for (const char **type = types; *type != NULL; type++)
-	{
+	const char * types[] = {"disk", "cdrom", NULL};
+	for (const char ** type = types; *type != NULL; type++) {
 		index = 0;
-		while ((str = const_cast<char *>(PrefsFindString(*type, index))) != NULL)
-		{
+		while ((str = const_cast<char *>(PrefsFindString(*type, index))) != NULL) {
 			bool is_cdrom = strcmp(*type, "cdrom") == 0;
 			add_volume_entry_with_type(str, is_cdrom);
 			index++;
@@ -1028,21 +996,18 @@ static void create_volumes_pane(GtkWidget *top)
 	static const combo_desc options[] = {
 		STR_BOOT_ANY_LAB,
 		STR_BOOT_CDROM_LAB,
-		0};
+		0
+	};
 	int bootdriver = PrefsFindInt32("bootdriver"), active = 0;
-	switch (bootdriver)
-	{
-	case 0:
-		active = 0;
-		break;
-	case CDROMRefNum:
-		active = 1;
-		break;
+	switch (bootdriver) {
+		case 0: active = 0; break;
+		case CDROMRefNum: active = 1; break;
 	}
 	make_option_menu(box, STR_BOOTDRIVER_CTRL, options, G_CALLBACK(mn_bootdriver), active);
 
 	make_checkbox(box, STR_NOCDROM_CTRL, "nocdrom", G_CALLBACK(tb_nocdrom));
 }
+
 
 /*
  *  "JIT Compiler" pane
@@ -1061,8 +1026,7 @@ static bool is_jit_capable(void)
 #elif defined __APPLE__ && defined __MACH__
 	// XXX run-time detect so that we can use a PPC GUI prefs editor
 	static char cpu[10];
-	if (cpu[0] == 0)
-	{
+	if (cpu[0] == 0) {
 		FILE *fp = popen("uname -p", "r");
 		if (fp == NULL)
 			return false;
@@ -1114,8 +1078,7 @@ static void tb_jit_follow_const_jumps(GtkWidget *widget)
 static void read_jit_settings(void)
 {
 	bool jit_enabled = is_jit_capable() && PrefsFindBool("jit");
-	if (jit_enabled)
-	{
+	if (jit_enabled) {
 		const char *str = gtk_combo_box_get_active_text(GTK_COMBO_BOX(w_jit_cache_size));
 		PrefsReplaceInt32("jitcachesize", atoi(str));
 	}
@@ -1140,7 +1103,8 @@ static void create_jit_pane(GtkWidget *top)
 		STR_JIT_CACHE_SIZE_4MB_LAB,
 		STR_JIT_CACHE_SIZE_8MB_LAB,
 		STR_JIT_CACHE_SIZE_16MB_LAB,
-		0};
+		0
+	};
 	w_jit_cache_size = make_combobox(box, STR_JIT_CACHE_SIZE_CTRL, "jitcachesize", options);
 
 	// Lazy translation cache invalidation
@@ -1161,8 +1125,7 @@ static GtkWidget *w_scsi[7];
 // Read settings from widgets and set preferences
 static void read_scsi_settings(void)
 {
-	for (int id = 0; id < 7; id++)
-	{
+	for (int id=0; id<7; id++) {
 		char prefs_name[32];
 		sprintf(prefs_name, "scsi%d", id);
 		const char *str = get_file_entry_path(w_scsi[id]);
@@ -1180,21 +1143,20 @@ static void create_scsi_pane(GtkWidget *top)
 
 	box = make_pane(top, STR_SCSI_PANE_TITLE);
 
-	for (int id = 0; id < 7; id++)
-	{
+	for (int id=0; id<7; id++) {
 		char prefs_name[32];
 		sprintf(prefs_name, "scsi%d", id);
 		w_scsi[id] = make_file_entry(box, STR_SCSI_ID_0 + id, prefs_name);
 	}
 }
 
+
 /*
  *  "Graphics/Sound" pane
  */
 
 // Display types
-enum
-{
+enum {
 	DISPLAY_WINDOW,
 	DISPLAY_SCREEN
 };
@@ -1217,32 +1179,23 @@ static GtkWidget *w_dspdevice_file, *w_mixerdevice_file;
 // Hide/show graphics widgets
 static void hide_show_graphics_widgets(void)
 {
-	switch (display_type)
-	{
-	case DISPLAY_WINDOW:
-		gtk_widget_show(w_frameskip);
-		gtk_widget_show(l_frameskip);
+	switch (display_type) {
+		case DISPLAY_WINDOW:
+			gtk_widget_show(w_frameskip); gtk_widget_show(l_frameskip);
 #ifdef ENABLE_FBDEV_DGA
-		gtk_widget_show(w_display_x);
-		gtk_widget_show(l_display_x);
-		gtk_widget_show(w_display_y);
-		gtk_widget_show(l_display_y);
-		gtk_widget_hide(w_fbdev_name);
-		gtk_widget_hide(l_fbdev_name);
+			gtk_widget_show(w_display_x); gtk_widget_show(l_display_x);
+			gtk_widget_show(w_display_y); gtk_widget_show(l_display_y);
+			gtk_widget_hide(w_fbdev_name); gtk_widget_hide(l_fbdev_name);
 #endif
-		break;
-	case DISPLAY_SCREEN:
-		gtk_widget_hide(w_frameskip);
-		gtk_widget_hide(l_frameskip);
+			break;
+		case DISPLAY_SCREEN:
+			gtk_widget_hide(w_frameskip); gtk_widget_hide(l_frameskip);
 #ifdef ENABLE_FBDEV_DGA
-		gtk_widget_hide(w_display_x);
-		gtk_widget_hide(l_display_x);
-		gtk_widget_hide(w_display_y);
-		gtk_widget_hide(l_display_y);
-		gtk_widget_show(w_fbdev_name);
-		gtk_widget_show(l_fbdev_name);
+			gtk_widget_hide(w_display_x); gtk_widget_hide(l_display_x);
+			gtk_widget_hide(w_display_y); gtk_widget_hide(l_display_y);
+			gtk_widget_show(w_fbdev_name); gtk_widget_show(l_fbdev_name);
 #endif
-		break;
+			break;
 	}
 }
 
@@ -1259,29 +1212,15 @@ static void mn_display(GtkWidget *widget)
 static void mn_frameskip(GtkWidget *widget)
 {
 	int frameskip = 1;
-	switch (gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
+	switch(gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
 	{
-	case 0:
-		frameskip = 12;
-		break;
-	case 1:
-		frameskip = 8;
-		break;
-	case 2:
-		frameskip = 6;
-		break;
-	case 3:
-		frameskip = 4;
-		break;
-	case 4:
-		frameskip = 2;
-		break;
-	case 5:
-		frameskip = 1;
-		break;
-	case 6:
-		frameskip = 0;
-		break;
+		case 0: frameskip = 12; break;
+		case 1: frameskip = 8; break;
+		case 2: frameskip = 6; break;
+		case 3: frameskip = 4; break;
+		case 4: frameskip = 2; break;
+		case 5: frameskip = 1; break;
+		case 6: frameskip = 0; break;
 	}
 	PrefsReplaceInt32("frameskip", frameskip);
 }
@@ -1324,8 +1263,7 @@ static void parse_graphics_prefs(void)
 #endif
 
 	const char *str = PrefsFindString("screen");
-	if (str)
-	{
+	if (str) {
 		if (sscanf(str, "win/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_WINDOW;
 #ifdef ENABLE_FBDEV_DGA
@@ -1349,22 +1287,21 @@ static void read_graphics_settings(void)
 	dis_height = atoi(str);
 
 	char pref[256];
-	switch (display_type)
-	{
-	case DISPLAY_WINDOW:
-		sprintf(pref, "win/%d/%d", dis_width, dis_height);
-		break;
-	case DISPLAY_SCREEN:
+	switch (display_type) {
+		case DISPLAY_WINDOW:
+			sprintf(pref, "win/%d/%d", dis_width, dis_height);
+			break;
+		case DISPLAY_SCREEN:
 #ifdef ENABLE_FBDEV_DGA
-		str = gtk_entry_get_text(GTK_ENTRY(w_fbdev_name));
-		sprintf(pref, "dga/%s", str);
+			str = gtk_entry_get_text(GTK_ENTRY(w_fbdev_name));
+			sprintf(pref, "dga/%s", str);
 #else
-		sprintf(pref, "dga/%d/%d", dis_width, dis_height);
+			sprintf(pref, "dga/%d/%d", dis_width, dis_height);
 #endif
-		break;
-	default:
-		PrefsRemoveItem("screen");
-		return;
+			break;
+		default:
+			PrefsRemoveItem("screen");
+			return;
 	}
 	PrefsReplaceString("screen", pref);
 
@@ -1401,14 +1338,13 @@ static void create_graphics_pane(GtkWidget *top)
 	gtk_widget_show(combo);
 	gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(STR_WINDOW_LAB));
 	gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(STR_FULLSCREEN_LAB));
-	switch (display_type)
-	{
-	case DISPLAY_WINDOW:
-		gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
-		break;
-	case DISPLAY_SCREEN:
-		gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 1);
-		break;
+	switch (display_type) {
+		case DISPLAY_WINDOW:
+			gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
+			break;
+		case DISPLAY_SCREEN:
+			gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 1);
+			break;
 	}
 	g_signal_connect(combo, "changed", G_CALLBACK(mn_display), NULL);
 	gtk_table_attach(GTK_TABLE(table), combo, 1, 2, 0, 1, (GtkAttachOptions)GTK_FILL, (GtkAttachOptions)0, 4, 4);
@@ -1428,29 +1364,14 @@ static void create_graphics_pane(GtkWidget *top)
 	gtk_combo_box_append_text(GTK_COMBO_BOX(w_frameskip), GetString(STR_REF_DYNAMIC_LAB));
 	int frameskip = PrefsFindInt32("frameskip");
 	int item = -1;
-	switch (frameskip)
-	{
-	case 12:
-		item = 0;
-		break;
-	case 8:
-		item = 1;
-		break;
-	case 6:
-		item = 2;
-		break;
-	case 4:
-		item = 3;
-		break;
-	case 2:
-		item = 4;
-		break;
-	case 1:
-		item = 5;
-		break;
-	case 0:
-		item = 6;
-		break;
+	switch (frameskip) {
+		case 12: item = 0; break;
+		case 8: item = 1; break;
+		case 6: item = 2; break;
+		case 4: item = 3; break;
+		case 2: item = 4; break;
+		case 1: item = 5; break;
+		case 0: item = 6; break;
 	}
 	if (item >= 0)
 		gtk_combo_box_set_active(GTK_COMBO_BOX(w_frameskip), item);
@@ -1513,7 +1434,7 @@ static void create_graphics_pane(GtkWidget *top)
 
 	// SDL scaling settings section
 	label = gtk_label_new(GetString(STR_SDL_SCALING));
-	markup = g_markup_printf_escaped("<b>%s</b>", GetString(STR_SDL_SCALING));
+	markup = g_markup_printf_escaped ("<b>%s</b>", GetString(STR_SDL_SCALING));
 	gtk_label_set_markup(GTK_LABEL(label), markup);
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
 	gtk_widget_show(label);
@@ -1542,6 +1463,7 @@ static void create_graphics_pane(GtkWidget *top)
 
 	hide_show_graphics_widgets();
 }
+
 
 /*
  *  "Input" pane
@@ -1621,16 +1543,12 @@ static void create_input_pane(GtkWidget *top)
 	static const combo_desc options[] = {
 		STR_MOUSEWHEELMODE_PAGE_LAB,
 		STR_MOUSEWHEELMODE_CURSOR_LAB,
-		0};
+		0
+	};
 	int wheelmode = PrefsFindInt32("mousewheelmode"), active = 0;
-	switch (wheelmode)
-	{
-	case 0:
-		active = 0;
-		break;
-	case 1:
-		active = 1;
-		break;
+	switch (wheelmode) {
+		case 0: active = 0; break;
+		case 1: active = 1; break;
 	}
 	make_option_menu(box, STR_MOUSEWHEELMODE_CTRL, options, G_CALLBACK(mn_wheelmode), active);
 
@@ -1649,6 +1567,7 @@ static void create_input_pane(GtkWidget *top)
 
 	set_input_sensitive();
 }
+
 
 /*
  *  "Serial/Network" pane
@@ -1706,26 +1625,19 @@ static GList *add_serial_names(void)
 
 	// Search /dev for ttyS* and lp*
 	DIR *d = opendir("/dev");
-	if (d)
-	{
+	if (d) {
 		struct dirent *de;
-		while ((de = readdir(d)) != NULL)
-		{
+		while ((de = readdir(d)) != NULL) {
 #if defined(__linux__)
-			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0)
-			{
+			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0) {
 #elif defined(__FreeBSD__)
-			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
-			{
+			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
 #elif defined(__NetBSD__)
-			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
-			{
+			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
 #elif defined(sgi)
-			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0)
-			{
+			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0) {
 #else
-			if (false)
-			{
+			if (false) {
 #endif
 				char *str = new char[64];
 				sprintf(str, "/dev/%s", de->d_name);
@@ -1748,27 +1660,21 @@ static GList *add_ether_names(void)
 
 	// Get list of all Ethernet interfaces
 	int s = socket(PF_INET, SOCK_DGRAM, 0);
-	if (s >= 0)
-	{
+	if (s >= 0) {
 		char inbuf[8192];
 		struct ifconf ifc;
 		ifc.ifc_len = sizeof(inbuf);
 		ifc.ifc_buf = inbuf;
-		if (ioctl(s, SIOCGIFCONF, &ifc) == 0)
-		{
+		if (ioctl(s, SIOCGIFCONF, &ifc) == 0) {
 			struct ifreq req, *ifr = ifc.ifc_req;
-			for (int i = 0; i < ifc.ifc_len; i += sizeof(ifreq), ifr++)
-			{
+			for (int i=0; i<ifc.ifc_len; i+=sizeof(ifreq), ifr++) {
 				req = *ifr;
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(sgi)
-				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER + 1))
-				{
+				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER+1)) {
 #elif defined(__linux__)
-				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER)
-				{
+				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
 #else
-				if (false)
-				{
+				if (false) {
 #endif
 					char *str = new char[64];
 					strncpy(str, ifr->ifr_name, 63);
@@ -1812,9 +1718,9 @@ static void create_serial_pane(GtkWidget *top)
 	gtk_widget_show(w_serialb);
 	while (glist)
 	{
-		gtk_combo_box_append_text(GTK_COMBO_BOX(w_seriala), (gchar *)glist->data);
-		gtk_combo_box_append_text(GTK_COMBO_BOX(w_serialb), (gchar *)glist->data);
-		glist = glist->next;
+	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_seriala), (gchar *)glist->data);
+	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_serialb), (gchar *)glist->data);
+	    glist = glist->next;
 	}
 
 	const char *str = PrefsFindString("seriala");
@@ -1838,8 +1744,8 @@ static void create_serial_pane(GtkWidget *top)
 	gtk_widget_show(w_ether);
 	while (glist)
 	{
-		gtk_combo_box_append_text(GTK_COMBO_BOX(w_ether), (gchar *)glist->data);
-		glist = glist->next;
+	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_ether), (gchar *)glist->data);
+	    glist = glist->next;
 	}
 	str = PrefsFindString("ether");
 	if (str == NULL)
@@ -1866,6 +1772,7 @@ static void create_serial_pane(GtkWidget *top)
 
 	set_serial_sensitive();
 }
+
 
 /*
  *  "Memory/Misc" pane
@@ -1896,22 +1803,15 @@ static void mn_modelid(GtkWidget *widget)
 }
 
 // CPU/FPU type
-static void mn_cpu(GtkWidget *widget)
-{
+static void mn_cpu(GtkWidget *widget){
 	int cpu = 4;
 	bool fpu = true;
 	switch (gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
 	{
-	case 0:
-		fpu = false;
-	case 1:
-		cpu = 2;
-		break;
-	case 2:
-		fpu = false;
-	case 3:
-		cpu = 3;
-		break;
+		case 0: fpu = false;
+		case 1: cpu = 2; break;
+		case 2: fpu = false;
+		case 3: cpu = 3; break;
 	}
 	PrefsReplaceInt32("cpu", cpu);
 	PrefsReplaceBool("fpu", fpu);
@@ -1928,6 +1828,7 @@ static void read_memory_settings(void)
 		PrefsReplaceString("rom", str);
 	else
 		PrefsRemoveItem("rom");
+
 }
 
 // Create "Memory/Misc" pane
@@ -1949,7 +1850,8 @@ static void create_memory_pane(GtkWidget *top)
 		STR_RAMSIZE_256MB_LAB,
 		STR_RAMSIZE_512MB_LAB,
 		STR_RAMSIZE_1024MB_LAB,
-		0};
+		0
+	};
 	char default_ramsize[10];
 	sprintf(default_ramsize, "%d", PrefsFindInt32("ramsize") >> 20);
 	w_ramsize = table_make_combobox(table, 0, STR_RAMSIZE_CTRL, default_ramsize, options);
@@ -1957,16 +1859,12 @@ static void create_memory_pane(GtkWidget *top)
 	static const combo_desc model_options[] = {
 		STR_MODELID_5_LAB,
 		STR_MODELID_14_LAB,
-		0};
+		0
+	};
 	int modelid = PrefsFindInt32("modelid"), active = 0;
-	switch (modelid)
-	{
-	case 5:
-		active = 0;
-		break;
-	case 14:
-		active = 1;
-		break;
+	switch (modelid) {
+		case 5: active = 0; break;
+		case 14: active = 1; break;
 	}
 	table_make_option_menu(table, 2, STR_MODELID_CTRL, model_options, G_CALLBACK(mn_modelid), active);
 
@@ -1977,20 +1875,15 @@ static void create_memory_pane(GtkWidget *top)
 		STR_CPU_68030_LAB,
 		STR_CPU_68030_FPU_LAB,
 		STR_CPU_68040_LAB,
-		0};
+		0
+	};
 	int cpu = PrefsFindInt32("cpu");
 	bool fpu = PrefsFindBool("fpu");
 	active = 0;
-	switch (cpu)
-	{
-	case 2:
-		active = fpu ? 1 : 0;
-		break;
-	case 3:
-		active = fpu ? 3 : 2;
-		break;
-	case 4:
-		active = 4;
+	switch (cpu) {
+		case 2: active = fpu ? 1 : 0; break;
+		case 3: active = fpu ? 3 : 2; break;
+		case 4: active = 4;
 	}
 	table_make_option_menu(table, 3, STR_CPU_CTRL, cpu_options, G_CALLBACK(mn_cpu), active);
 #endif
@@ -2004,6 +1897,7 @@ static void create_memory_pane(GtkWidget *top)
 	gtk_widget_set_sensitive(w_ignoresegv, false);
 #endif
 }
+
 
 /*
  *  Read settings from widgets and set preferences
@@ -2020,6 +1914,7 @@ static void read_settings(void)
 	read_jit_settings();
 }
 
+
 #ifdef STANDALONE_GUI
 #include <errno.h>
 #include <sys/wait.h>
@@ -2030,16 +1925,17 @@ static void read_settings(void)
  */
 
 uint8 XPRAM[XPRAM_SIZE];
-void MountVolume(void *fh) {}
-void FileDiskLayout(loff_t size, uint8 *data, loff_t &start_byte, loff_t &real_size) {}
+void MountVolume(void *fh) { }
+void FileDiskLayout(loff_t size, uint8 *data, loff_t &start_byte, loff_t &real_size) { }
 
 #if defined __APPLE__ && defined __MACH__
-void DarwinSysInit(void) {}
-void DarwinSysExit(void) {}
-void DarwinAddFloppyPrefs(void) {}
-void DarwinAddSerialPrefs(void) {}
-bool DarwinCDReadTOC(char *, uint8 *) {}
+void DarwinSysInit(void) { }
+void DarwinSysExit(void) { }
+void DarwinAddFloppyPrefs(void) { }
+void DarwinAddSerialPrefs(void) { }
+bool DarwinCDReadTOC(char *, uint8 *) { }
 #endif
+
 
 /*
  *  Display alert
@@ -2055,17 +1951,18 @@ static GCallback dl_destroyed(GtkWidget *dialog)
 void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 {
 	GtkWidget *dialog = gtk_message_dialog_new(NULL,
-											   GTK_DIALOG_MODAL,
-											   GTK_MESSAGE_WARNING,
-											   GTK_BUTTONS_NONE,
-											   GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
+	                                           GTK_DIALOG_MODAL,
+	                                           GTK_MESSAGE_WARNING,
+	                                           GTK_BUTTONS_NONE,
+	                                           GetString(title_id), NULL);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);
 
 	gtk_main();
 }
+
 
 /*
  *  Display error alert
@@ -2076,6 +1973,7 @@ void ErrorAlert(const char *text)
 	display_alert(STR_ERROR_ALERT_TITLE, STR_GUI_ERROR_PREFIX, STR_QUIT_BUTTON, text);
 }
 
+
 /*
  *  Display warning alert
  */
@@ -2084,6 +1982,7 @@ void WarningAlert(const char *text)
 {
 	display_alert(STR_WARNING_ALERT_TITLE, STR_GUI_WARNING_PREFIX, STR_OK_BUTTON, text);
 }
+
 
 /*
  *  RPC handlers
@@ -2127,6 +2026,7 @@ static int handle_Exit(rpc_connection_t *connection)
 	return RPC_ERROR_NO_ERROR;
 }
 
+
 /*
  *  SIGCHLD handler
  */
@@ -2147,23 +2047,22 @@ static void sigchld_handler(int sig, siginfo_t *sip, void *)
 	if (WIFEXITED(status))
 		status = WEXITSTATUS(status);
 	if (status & 0x80)
-		status |= -1 ^ 0xff;
+		status |= -1 ^0xff;
 
-	if (status < 0)
-	{ // negative -> execlp/-errno
+	if (status < 0) {	// negative -> execlp/-errno
 		char str[256];
 		sprintf(str, GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(-status));
 		ErrorAlert(str);
 		status = 1;
 	}
 
-	if (status != 0)
-	{
+	if (status != 0) {
 		if (g_gui_connection)
 			rpc_exit(g_gui_connection);
 		exit(status);
 	}
 }
+
 
 /*
  *  Start standalone GUI
@@ -2186,8 +2085,7 @@ int main(int argc, char *argv[])
 	PrefsExit();
 
 	// Transfer control to the executable
-	if (start)
-	{
+	if (start) {
 		char gui_connection_path[64];
 		sprintf(gui_connection_path, "/org/BasiliskII/GUI/%d", getpid());
 
@@ -2196,8 +2094,7 @@ int main(int argc, char *argv[])
 		sigemptyset(&sigchld_sa.sa_mask);
 		sigchld_sa.sa_sigaction = sigchld_handler;
 		sigchld_sa.sa_flags = SA_NOCLDSTOP | SA_SIGINFO;
-		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0)
-		{
+		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0) {
 			char str[256];
 			sprintf(str, GetString(STR_SIG_INSTALL_ERR), SIGCHLD, strerror(errno));
 			ErrorAlert(str);
@@ -2207,27 +2104,22 @@ int main(int argc, char *argv[])
 		// Search and run the BasiliskII executable
 		char *p;
 		strcpy(g_app_path, argv[0]);
-		if ((p = strstr(g_app_path, "BasiliskIIGUI.app/Contents/MacOS")) != NULL)
-		{
-			strcpy(p, "BasiliskII.app/Contents/MacOS/BasiliskII");
-			if (access(g_app_path, X_OK) < 0)
-			{
+		if ((p = strstr(g_app_path, "BasiliskIIGUI.app/Contents/MacOS")) != NULL) {
+		    strcpy(p, "BasiliskII.app/Contents/MacOS/BasiliskII");
+			if (access(g_app_path, X_OK) < 0) {
 				char str[256];
 				sprintf(str, GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(errno));
 				WarningAlert(str);
 				strcpy(g_app_path, "/Applications/BasiliskII.app/Contents/MacOS/BasiliskII");
 			}
-		}
-		else
-		{
+		} else {
 			p = strrchr(g_app_path, '/');
 			p = p ? p + 1 : g_app_path;
 			strcpy(p, "BasiliskII");
 		}
 
 		int pid = fork();
-		if (pid == 0)
-		{
+		if (pid == 0) {
 			D(bug("Trying to execute %s\n", g_app_path));
 			execlp(g_app_path, g_app_path, "--gui-connection", gui_connection_path, (char *)NULL);
 #ifdef _POSIX_PRIORITY_SCHEDULING
@@ -2238,35 +2130,31 @@ int main(int argc, char *argv[])
 		}
 
 		// Establish a connection to Basilisk II
-		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL)
-		{
+		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL) {
 			printf("ERROR: failed to initialize GUI-side RPC server connection\n");
 			return 1;
 		}
 		static const rpc_method_descriptor_t vtable[] = {
-			{RPC_METHOD_ERROR_ALERT, handle_ErrorAlert},
-			{RPC_METHOD_WARNING_ALERT, handle_WarningAlert},
-			{RPC_METHOD_EXIT, handle_Exit}};
-		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0)
-		{
+			{ RPC_METHOD_ERROR_ALERT,			handle_ErrorAlert },
+			{ RPC_METHOD_WARNING_ALERT,			handle_WarningAlert },
+			{ RPC_METHOD_EXIT,					handle_Exit }
+		};
+		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0) {
 			printf("ERROR: failed to setup GUI method callbacks\n");
 			return 1;
 		}
 		int socket;
-		if ((socket = rpc_listen_socket(g_gui_connection)) < 0)
-		{
+		if ((socket = rpc_listen_socket(g_gui_connection)) < 0) {
 			printf("ERROR: failed to initialize RPC server thread\n");
 			return 1;
 		}
 
 		g_gui_loop = g_main_new(TRUE);
-		while (g_main_is_running(g_gui_loop))
-		{
+		while (g_main_is_running(g_gui_loop)) {
 
 			// Process a few events pending
 			const int N_EVENTS_DISPATCH = 10;
-			for (int i = 0; i < N_EVENTS_DISPATCH; i++)
-			{
+			for (int i = 0; i < N_EVENTS_DISPATCH; i++) {
 				if (!g_main_iteration(FALSE))
 					break;
 			}

--- a/BasiliskII/src/Unix/prefs_editor_gtk.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk.cpp
@@ -42,11 +42,9 @@
 #define DEBUG 0
 #include "debug.h"
 
-
 // Global variables
-static GtkWidget *win;				// Preferences window
-static bool start_clicked = false;	// Return value of PrefsEditor() function
-
+static GtkWidget *win;			   // Preferences window
+static bool start_clicked = false; // Return value of PrefsEditor() function
 
 // Prototypes
 static void create_volumes_pane(GtkWidget *top);
@@ -57,29 +55,30 @@ static void create_serial_pane(GtkWidget *top);
 static void create_memory_pane(GtkWidget *top);
 static void create_jit_pane(GtkWidget *top);
 static void read_settings(void);
-static void add_volume_entry_with_type(const char * filename, bool cdrom);
-static void add_volume_entry_guessed(const char * filename);
-
+static void add_volume_entry_with_type(const char *filename, bool cdrom);
+static void add_volume_entry_guessed(const char *filename);
 
 /*
  *  Utility functions
  */
 
-#if ! GLIB_CHECK_VERSION(2,0,0)
-#define G_OBJECT(obj)							GTK_OBJECT(obj)
-#define g_object_get_data(obj, key)				gtk_object_get_data((obj), (key))
-#define g_object_set_data(obj, key, data)		gtk_object_set_data((obj), (key), (data))
+#if !GLIB_CHECK_VERSION(2, 0, 0)
+#define G_OBJECT(obj) GTK_OBJECT(obj)
+#define g_object_get_data(obj, key) gtk_object_get_data((obj), (key))
+#define g_object_set_data(obj, key, data) gtk_object_set_data((obj), (key), (data))
 #endif
 
-struct opt_desc {
-	opt_desc(int l, GCallback f, GtkWidget **s=NULL) : label_id(l), func(f), save_ref(s) {}
+struct opt_desc
+{
+	opt_desc(int l, GCallback f, GtkWidget **s = NULL) : label_id(l), func(f), save_ref(s) {}
 
 	int label_id;
 	GtkSignalFunc func;
-	GtkWidget ** save_ref;
+	GtkWidget **save_ref;
 };
 
-struct combo_desc {
+struct combo_desc
+{
 	int label_id;
 };
 
@@ -89,22 +88,22 @@ static void cb_browse_response(GtkWidget *chooser, int response, GtkEntry *entry
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
 		gchar *filename;
-		filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (chooser));
+		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
 		gtk_entry_set_text(GTK_ENTRY(entry), filename);
-		g_free (filename);
+		g_free(filename);
 	}
-	gtk_widget_destroy (chooser);
+	gtk_widget_destroy(chooser);
 }
 
 // Open the file chooser dialog to select a file
 static void cb_browse(GtkWidget *button, GtkWidget *entry)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_BROWSE_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_OPEN,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Open", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_OPEN,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Open", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_path_get_dirname(gtk_entry_get_text(GTK_ENTRY(entry))));
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
@@ -117,11 +116,11 @@ static void cb_browse(GtkWidget *button, GtkWidget *entry)
 static void cb_browse_dir(GtkWidget *button, GtkWidget *entry)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_BROWSE_FOLDER_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Select", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Select", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), gtk_entry_get_text(GTK_ENTRY(entry)));
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
@@ -177,12 +176,14 @@ static GtkWidget *make_button_box(GtkWidget *top, int border, const opt_desc *bu
 	gtk_button_box_set_spacing(GTK_BUTTON_BOX(bb), 4);
 	gtk_box_pack_start(GTK_BOX(top), bb, FALSE, FALSE, 0);
 
-	while (buttons->label_id) {
+	while (buttons->label_id)
+	{
 		button = gtk_button_new_with_label(GetString(buttons->label_id));
 		gtk_widget_show(button);
-		g_signal_connect_object(button, "clicked", buttons->func, NULL, (GConnectFlags) 0);
+		g_signal_connect_object(button, "clicked", buttons->func, NULL, (GConnectFlags)0);
 		gtk_box_pack_start(GTK_BOX(bb), button, TRUE, TRUE, 0);
-		if (buttons->save_ref) {
+		if (buttons->save_ref)
+		{
 			*(buttons->save_ref) = button;
 		}
 		buttons++;
@@ -207,8 +208,8 @@ static GtkWidget *make_table(GtkWidget *top, int x, int y)
 }
 
 static GtkWidget *table_make_option_menu(GtkWidget *table, int row, int label_id,
-                                         const combo_desc *options, GCallback func,
-                                         int active)
+										 const combo_desc *options, GCallback func,
+										 int active)
 {
 	GtkWidget *label, *combo;
 
@@ -219,7 +220,8 @@ static GtkWidget *table_make_option_menu(GtkWidget *table, int row, int label_id
 	combo = gtk_combo_box_new_text();
 	gtk_widget_show(combo);
 
-	while (options->label_id) {
+	while (options->label_id)
+	{
 		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(options->label_id));
 		options++;
 	}
@@ -239,13 +241,13 @@ static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, c
 
 	combo = gtk_combo_box_entry_new_text();
 	gtk_widget_show(combo);
-	while(list)
+	while (list)
 	{
-		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), ((gchar *) list->data));
+		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), ((gchar *)list->data));
 		list = list->next;
 	}
 
-	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN (combo))), pref);
+	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo))), pref);
 	gtk_table_attach(GTK_TABLE(table), combo, 1, 2, row, row + 1, (GtkAttachOptions)(GTK_FILL | GTK_EXPAND), (GtkAttachOptions)0, 4, 4);
 
 	return combo;
@@ -254,7 +256,8 @@ static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, c
 static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, const char *default_value, const combo_desc *options)
 {
 	GList *glist = NULL;
-	while (options->label_id) {
+	while (options->label_id)
+	{
 		glist = g_list_append(glist, (void *)GetString(options->label_id));
 		options++;
 	}
@@ -304,7 +307,8 @@ static GtkWidget *make_option_menu(GtkWidget *top, int label_id, const combo_des
 	combo = gtk_combo_box_new_text();
 	gtk_widget_show(combo);
 
-	while (options->label_id) {
+	while (options->label_id)
+	{
 		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(options->label_id));
 		options++;
 	}
@@ -335,7 +339,7 @@ static GtkWidget *make_file_entry(GtkWidget *top, int label_id, const char *pref
 	button = make_browse_button(entry, only_dirs);
 
 	gtk_widget_show(entry);
-#if GLIB_CHECK_VERSION(2,26,0)
+#if GLIB_CHECK_VERSION(2, 26, 0)
 	g_object_bind_property(entry, "sensitive", button, "sensitive", G_BINDING_SYNC_CREATE);
 #endif
 	gtk_box_pack_start(GTK_BOX(box), entry, TRUE, TRUE, 0);
@@ -355,7 +359,7 @@ static GtkWidget *make_checkbox(GtkWidget *top, int label_id, const char *prefs_
 	gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(button), PrefsFindBool(prefs_item));
 	g_signal_connect(button, "toggled", func, NULL);
 	if (top)
-	    gtk_box_pack_start(GTK_BOX(top), button, FALSE, FALSE, 0);
+		gtk_box_pack_start(GTK_BOX(top), button, FALSE, FALSE, 0);
 	return button;
 }
 
@@ -376,18 +380,18 @@ static GtkWidget *make_combobox(GtkWidget *top, int label_id, const char *prefs_
 	gtk_widget_show(combo);
 	gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
 
-	while (options->label_id) {
-		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), (gchar *) GetString(options->label_id));
+	while (options->label_id)
+	{
+		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), (gchar *)GetString(options->label_id));
 		options++;
 	}
 
 	sprintf(str, "%d", PrefsFindInt32(prefs_item));
-	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN (combo))), str);
+	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo))), str);
 	gtk_box_pack_start(GTK_BOX(box), combo, TRUE, TRUE, 0);
 
 	return combo;
 }
-
 
 /*
  *  Show preferences editor
@@ -453,20 +457,19 @@ static void mn_about(...)
 		"Lauri Pesonen",
 		"Bernd Schmidt",
 		"and others",
-		NULL
-	};
+		NULL};
 	char version[64];
 	sprintf(version, "%d.%d", VERSION_MAJOR, VERSION_MINOR);
 	gtk_show_about_dialog(GTK_WINDOW(win), "version", version,
-	                     "copyright", GetString(STR_ABOUT_COPYRIGHT),
-	                     "authors", authors,
-	                     "comments", GetString(STR_ABOUT_COMMENTS),
-	                     "website", GetString(STR_ABOUT_WEBSITE),
-	                     "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
-	                     "license", GetString(STR_ABOUT_LICENSE),
-	                     "wrap-license", true,
-	                     "logo-icon-name", "BasiliskII",
-	                     NULL);
+						  "copyright", GetString(STR_ABOUT_COPYRIGHT),
+						  "authors", authors,
+						  "comments", GetString(STR_ABOUT_COMMENTS),
+						  "website", GetString(STR_ABOUT_WEBSITE),
+						  "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
+						  "license", GetString(STR_ABOUT_LICENSE),
+						  "wrap-license", true,
+						  "logo-icon-name", "BasiliskII",
+						  NULL);
 }
 
 // "Zap PRAM" selected
@@ -477,15 +480,14 @@ static void mn_zap_pram(...)
 
 // Menu item descriptions
 static GtkItemFactoryEntry menu_items[] = {
-	{(gchar *)GetString(STR_PREFS_MENU_FILE_GTK),		NULL,			NULL,							0, "<Branch>"},
-	{(gchar *)GetString(STR_PREFS_ITEM_START_GTK),		"<control>S",	G_CALLBACK(cb_start),		0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_SAVE_GTK),		NULL,			G_CALLBACK(cb_save),		0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_ZAP_PRAM_GTK),	NULL,			G_CALLBACK(mn_zap_pram),	0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_SEPL_GTK),		NULL,			NULL,							0, "<Separator>"},
-	{(gchar *)GetString(STR_PREFS_ITEM_QUIT_GTK),		"<control>Q",	G_CALLBACK(cb_quit),		0, NULL},
-	{(gchar *)GetString(STR_HELP_MENU_GTK),				NULL,			NULL,							0, "<LastBranch>"},
-	{(gchar *)GetString(STR_HELP_ITEM_ABOUT_GTK),		NULL,			G_CALLBACK(mn_about),		0, NULL}
-};
+	{(gchar *)GetString(STR_PREFS_MENU_FILE_GTK), NULL, NULL, 0, "<Branch>"},
+	{(gchar *)GetString(STR_PREFS_ITEM_START_GTK), "<control>S", G_CALLBACK(cb_start), 0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_SAVE_GTK), NULL, G_CALLBACK(cb_save), 0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_ZAP_PRAM_GTK), NULL, G_CALLBACK(mn_zap_pram), 0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_SEPL_GTK), NULL, NULL, 0, "<Separator>"},
+	{(gchar *)GetString(STR_PREFS_ITEM_QUIT_GTK), "<control>Q", G_CALLBACK(cb_quit), 0, NULL},
+	{(gchar *)GetString(STR_HELP_MENU_GTK), NULL, NULL, 0, "<LastBranch>"},
+	{(gchar *)GetString(STR_HELP_ITEM_ABOUT_GTK), NULL, G_CALLBACK(mn_about), 0, NULL}};
 
 bool PrefsEditor(void)
 {
@@ -527,8 +529,7 @@ bool PrefsEditor(void)
 	static const opt_desc buttons[] = {
 		opt_desc(STR_START_BUTTON, G_CALLBACK(cb_start)),
 		opt_desc(STR_QUIT_BUTTON, G_CALLBACK(cb_quit)),
-		opt_desc(0, NULL)
-	};
+		opt_desc(0, NULL)};
 	make_button_box(box, 4, buttons);
 
 	// Show window and enter main loop
@@ -536,7 +537,6 @@ bool PrefsEditor(void)
 	gtk_main();
 	return start_clicked;
 }
-
 
 /*
  *  "Volumes" pane
@@ -547,34 +547,37 @@ static GtkListStore *volume_list_model;
 static GtkWidget *volume_remove_button;
 
 // Volume list selection changed
-static void cl_selected(GtkTreeSelection * selection, gpointer user_data) {
-	if (selection) {
+static void cl_selected(GtkTreeSelection *selection, gpointer user_data)
+{
+	if (selection)
+	{
 		bool have_selection = gtk_tree_selection_get_selected(selection, NULL, NULL);
 
 		gtk_widget_set_sensitive(GTK_WIDGET(volume_remove_button), have_selection);
 	}
 }
 
-
 // Process proposed drop
-gboolean volume_list_drag_motion (GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time,
-                                            gpointer user_data)
+gboolean volume_list_drag_motion(GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time,
+								 gpointer user_data)
 {
 	GtkTreePath *path;
 	GtkTreeViewDropPosition pos;
 	// Don't allow tree-style drops onto, only list-style drops between
-	if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x,y, &path, &pos)) {
-		switch (pos) {
-			case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
-				gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_AFTER);
-				break;
-			case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
-				gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_BEFORE);
-				break;
-			case GTK_TREE_VIEW_DROP_BEFORE:
-			case GTK_TREE_VIEW_DROP_AFTER:
-				// these are ok, no change
-				break;
+	if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x, y, &path, &pos))
+	{
+		switch (pos)
+		{
+		case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
+			gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_AFTER);
+			break;
+		case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
+			gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_BEFORE);
+			break;
+		case GTK_TREE_VIEW_DROP_BEFORE:
+		case GTK_TREE_VIEW_DROP_AFTER:
+			// these are ok, no change
+			break;
 		}
 		gdk_drag_status(drag_context, drag_context->suggested_action, time);
 		return TRUE;
@@ -582,50 +585,59 @@ gboolean volume_list_drag_motion (GtkWidget *widget, GdkDragContext *drag_contex
 	return FALSE;
 }
 
-
 // Something dropped on volume list
 static void drag_data_received(GtkWidget *list, GdkDragContext *drag_context, gint x, gint y, GtkSelectionData *data,
-	guint info, guint time, gpointer user_data)
+							   guint info, guint time, gpointer user_data)
 {
 	// reordering drags have already been handled by clist
-	if (data->type == gdk_atom_intern("gtk-clist-drag-reorder", true)) {
+	if (data->type == gdk_atom_intern("gtk-clist-drag-reorder", true))
+	{
 		return;
 	}
 
 	// get URIs from the drag selection data and add them
-	gchar ** uris = g_strsplit((gchar *)(data->data), "\r\n", -1);
-	for (gchar ** uri = uris; *uri != NULL; uri++) {
-		if (strlen(*uri) < 7) continue;
-		if (strncmp("file://", *uri, 7) != 0) continue;
+	gchar **uris = g_strsplit((gchar *)(data->data), "\r\n", -1);
+	for (gchar **uri = uris; *uri != NULL; uri++)
+	{
+		if (strlen(*uri) < 7)
+			continue;
+		if (strncmp("file://", *uri, 7) != 0)
+			continue;
 
-		gchar * filename = g_filename_from_uri(*uri, NULL, NULL);
-		if (filename) {
+		gchar *filename = g_filename_from_uri(*uri, NULL, NULL);
+		if (filename)
+		{
 			add_volume_entry_guessed(filename);
 
 			// figure out where in the list they dropped
 			GtkTreePath *path;
 			GtkTreeViewDropPosition pos;
-			if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x,y, &path, &pos)) {
+			if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x, y, &path, &pos))
+			{
 				GtkTreeIter dest_iter;
-				if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &dest_iter, path)) {
+				if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &dest_iter, path))
+				{
 
 					// Find the item we just added and put it in place
 					GtkTreeIter last;
 					GtkTreeIter cur;
-					if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(volume_list_model), &cur)) {
-						do {
+					if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(volume_list_model), &cur))
+					{
+						do
+						{
 							last = cur;
 						} while (gtk_tree_model_iter_next(GTK_TREE_MODEL(volume_list_model), &cur));
 					}
-					switch (pos) {
-						case GTK_TREE_VIEW_DROP_AFTER:
-						case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
-							gtk_list_store_move_after(volume_list_model, &last, &dest_iter);
-							break;
-						case GTK_TREE_VIEW_DROP_BEFORE:
-						case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
-							gtk_list_store_move_before(volume_list_model, &last, &dest_iter);
-							break;
+					switch (pos)
+					{
+					case GTK_TREE_VIEW_DROP_AFTER:
+					case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
+						gtk_list_store_move_after(volume_list_model, &last, &dest_iter);
+						break;
+					case GTK_TREE_VIEW_DROP_BEFORE:
+					case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
+						gtk_list_store_move_before(volume_list_model, &last, &dest_iter);
+						break;
 					}
 				}
 			}
@@ -637,7 +649,7 @@ static void drag_data_received(GtkWidget *list, GdkDragContext *drag_context, gi
 }
 
 // Volume selected for addition
-static void cb_add_volume_response (GtkWidget *chooser, int response)
+static void cb_add_volume_response(GtkWidget *chooser, int response)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
@@ -648,7 +660,7 @@ static void cb_add_volume_response (GtkWidget *chooser, int response)
 }
 
 // Volume selected for creation
-static void cb_create_volume_response (GtkWidget *chooser, int response, GtkEntry *size_entry)
+static void cb_create_volume_response(GtkWidget *chooser, int response, GtkEntry *size_entry)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
@@ -658,10 +670,10 @@ static void cb_create_volume_response (GtkWidget *chooser, int response, GtkEntr
 		if (disk_size < 1 || disk_size > 2000)
 		{
 			GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-							(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
-							GTK_MESSAGE_WARNING,
-							GTK_BUTTONS_CLOSE,
-							"Enter a valid size", NULL);
+													   (GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+													   GTK_MESSAGE_WARNING,
+													   GTK_BUTTONS_CLOSE,
+													   "Enter a valid size", NULL);
 			gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "The volume size should be between 1 and 2000.");
 			gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(chooser));
 			g_signal_connect(dialog, "response", G_CALLBACK(dl_quit), NULL);
@@ -669,26 +681,29 @@ static void cb_create_volume_response (GtkWidget *chooser, int response, GtkEntr
 			return; // Don't close the file chooser dialog
 		}
 		int fd = open(file, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
-		if (fd < 0) {
+		if (fd < 0)
+		{
 			fprintf(stderr, "Could not create %s (%s)\n", file, strerror(errno));
-		} else {
+		}
+		else
+		{
 			ftruncate(fd, disk_size * 1024 * 1024);
 			// A created empty volume is always a new disk
 			add_volume_entry_with_type(file, false);
 		}
 	}
-	gtk_widget_destroy (chooser);
+	gtk_widget_destroy(chooser);
 }
 
 // "Add Volume" button clicked
-static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_ADD_VOLUME_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_OPEN,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Add", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_OPEN,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Add", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_get_home_dir());
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_modal(GTK_WINDOW(chooser), true);
@@ -697,14 +712,14 @@ static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer 
 }
 
 // "Create Hardfile" button clicked
-static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_CREATE_VOLUME_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_SAVE,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Create", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_SAVE,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Create", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_get_home_dir());
 	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(chooser), TRUE);
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
@@ -732,9 +747,11 @@ static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpoint
 static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(volume_list));
-	if (sel) {
+	if (sel)
+	{
 		GtkTreeIter row;
-		if (gtk_tree_selection_get_selected(sel, NULL, &row)) {
+		if (gtk_tree_selection_get_selected(sel, NULL, &row))
+		{
 			gtk_list_store_remove(volume_list_model, &row);
 		}
 	}
@@ -756,32 +773,35 @@ static void tb_nocdrom(GtkWidget *widget)
 }
 
 // Data source for the volumes list
-enum {
+enum
+{
 	VOLUME_LIST_FILENAME = 0,
 	VOLUME_LIST_CDROM,
 	VOLUME_LIST_SIZE_DESC,
 	NUM_VOLUME_LIST_FIELDS
 };
 
-static void init_volume_model() {
+static void init_volume_model()
+{
 	volume_list_model = gtk_list_store_new(NUM_VOLUME_LIST_FIELDS,
-		G_TYPE_STRING,	// filename
-		G_TYPE_BOOLEAN,	// is CD-ROM
-		G_TYPE_STRING	// size desc
-		);
+										   G_TYPE_STRING,  // filename
+										   G_TYPE_BOOLEAN, // is CD-ROM
+										   G_TYPE_STRING   // size desc
+	);
 }
 
-static void toggle_cdrom_val(GtkTreeIter *row) {
+static void toggle_cdrom_val(GtkTreeIter *row)
+{
 	gboolean cdrom;
 	gtk_tree_model_get(GTK_TREE_MODEL(volume_list_model), row,
-		VOLUME_LIST_CDROM, &cdrom,
-		-1);
+					   VOLUME_LIST_CDROM, &cdrom,
+					   -1);
 
 	cdrom = !cdrom;
 
 	gtk_list_store_set(volume_list_model, row,
-		VOLUME_LIST_CDROM, cdrom,
-		-1);
+					   VOLUME_LIST_CDROM, cdrom,
+					   -1);
 }
 
 // Read settings from widgets and set preferences
@@ -792,11 +812,13 @@ static void read_volumes_settings(void)
 	while (PrefsFindString("cdrom"))
 		PrefsRemoveItem("cdrom");
 
-	GtkTreeModel * m = GTK_TREE_MODEL(volume_list_model);
+	GtkTreeModel *m = GTK_TREE_MODEL(volume_list_model);
 
 	GtkTreeIter row;
-	if (gtk_tree_model_get_iter_first(m, &row)) {
-		do {
+	if (gtk_tree_model_get_iter_first(m, &row))
+	{
+		do
+		{
 			GValue filename = G_VALUE_INIT, is_cdrom = G_VALUE_INIT;
 
 			gtk_tree_model_get_value(m, &row, VOLUME_LIST_FILENAME, &filename);
@@ -804,7 +826,7 @@ static void read_volumes_settings(void)
 
 			D(bug("handling %d: %s\n", g_value_get_boolean(&is_cdrom), g_value_get_string(&filename)));
 
-			const char * pref_name = g_value_get_boolean(&is_cdrom) ? "cdrom": "disk";
+			const char *pref_name = g_value_get_boolean(&is_cdrom) ? "cdrom" : "disk";
 			PrefsAddString(pref_name, g_value_get_string(&filename));
 
 			g_value_unset(&filename);
@@ -817,10 +839,11 @@ static void read_volumes_settings(void)
 }
 
 // Gets the size of the volume as a pretty string
-static const char* get_file_size (const char * filename)
+static const char *get_file_size(const char *filename)
 {
 	std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
-	if (in.is_open()) {
+	if (in.is_open())
+	{
 		uint64_t size = in.tellg();
 		in.close();
 		char *sizestr = g_format_size_full(size, G_FORMAT_SIZE_IEC_UNITS);
@@ -832,48 +855,53 @@ static const char* get_file_size (const char * filename)
 	}
 }
 
-
-static bool volume_in_list(const char * filename) {
+static bool volume_in_list(const char *filename)
+{
 	bool found = false;
 
-	GtkTreeModel * m = GTK_TREE_MODEL(volume_list_model);
+	GtkTreeModel *m = GTK_TREE_MODEL(volume_list_model);
 
 	GtkTreeIter row;
-	if (gtk_tree_model_get_iter_first(m, &row)) {
-		do {
+	if (gtk_tree_model_get_iter_first(m, &row))
+	{
+		do
+		{
 			GValue cur_filename = G_VALUE_INIT;
 
 			gtk_tree_model_get_value(m, &row, VOLUME_LIST_FILENAME, &cur_filename);
 
-			if (strcmp(g_value_get_string(&cur_filename), filename) == 0) {
+			if (strcmp(g_value_get_string(&cur_filename), filename) == 0)
+			{
 				found = true;
 			}
 
 			g_value_unset(&cur_filename);
 
-			if (found) break;
+			if (found)
+				break;
 		} while (gtk_tree_model_iter_next(GTK_TREE_MODEL(volume_list_model), &row));
 	}
 
 	return found;
 }
 
-
 // Add a volume file as the given type
-static void add_volume_entry_with_type(const char * filename, bool cdrom) {
-	if (volume_in_list(filename)) return;
+static void add_volume_entry_with_type(const char *filename, bool cdrom)
+{
+	if (volume_in_list(filename))
+		return;
 
 	GtkTreeIter row;
 	gtk_list_store_append(GTK_LIST_STORE(volume_list_model), &row);
 	// set the values for the new row
 	gtk_list_store_set(GTK_LIST_STORE(volume_list_model), &row,
-		VOLUME_LIST_FILENAME, filename,
-		VOLUME_LIST_CDROM, cdrom,
-		VOLUME_LIST_SIZE_DESC, get_file_size(filename),
-		-1);
+					   VOLUME_LIST_FILENAME, filename,
+					   VOLUME_LIST_CDROM, cdrom,
+					   VOLUME_LIST_SIZE_DESC, get_file_size(filename),
+					   -1);
 }
 
-static bool has_file_ext (const char * str, const char *ext)
+static bool has_file_ext(const char *str, const char *ext)
 {
 	char *file_ext = g_utf8_strrchr(str, 255, '.');
 	if (!file_ext)
@@ -881,30 +909,32 @@ static bool has_file_ext (const char * str, const char *ext)
 	return (g_strcmp0(file_ext, ext) == 0);
 }
 
-static bool guess_if_file_is_cdrom(const char * volume) {
+static bool guess_if_file_is_cdrom(const char *volume)
+{
 	return has_file_ext(volume, ".iso") ||
 #ifdef BINCUE
-		has_file_ext(volume, ".cue") ||
+		   has_file_ext(volume, ".cue") ||
 #endif
-		has_file_ext(volume, ".toast");
+		   has_file_ext(volume, ".toast");
 }
 
 // Add a volume file and guess the type
-static void add_volume_entry_guessed(const char * filename) {
+static void add_volume_entry_guessed(const char *filename)
+{
 	add_volume_entry_with_type(filename, guess_if_file_is_cdrom(filename));
 }
 
 // CD-ROM checkbox changed
-static void cb_cdrom (GtkCellRendererToggle *cell, char *path_str, gpointer data)
+static void cb_cdrom(GtkCellRendererToggle *cell, char *path_str, gpointer data)
 {
 	GtkTreeIter iter;
-	GtkTreePath *path = gtk_tree_path_new_from_string (path_str);
-	if (gtk_tree_model_get_iter (GTK_TREE_MODEL(volume_list_model), &iter, path)) {
+	GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+	if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &iter, path))
+	{
 		toggle_cdrom_val(&iter);
 	}
-	gtk_tree_path_free (path);
+	gtk_tree_path_free(path);
 }
-
 
 // Create "Volumes" pane
 static void create_volumes_pane(GtkWidget *top)
@@ -940,8 +970,8 @@ static void create_volumes_pane(GtkWidget *top)
 	gtk_tree_view_column_set_title(column, GetString(STR_VOL_HEADING_CDROM));
 	gtk_tree_view_append_column(GTK_TREE_VIEW(volume_list), column);
 	renderer = gtk_cell_renderer_toggle_new();
-	g_signal_connect (renderer, "toggled",
-	                  G_CALLBACK (cb_cdrom), NULL);
+	g_signal_connect(renderer, "toggled",
+					 G_CALLBACK(cb_cdrom), NULL);
 	gtk_tree_view_column_set_alignment(column, 0.5);
 
 	gtk_tree_view_column_pack_start(column, renderer, TRUE);
@@ -969,10 +999,12 @@ static void create_volumes_pane(GtkWidget *top)
 
 	char *str;
 	int32 index;
-	const char * types[] = {"disk", "cdrom", NULL};
-	for (const char ** type = types; *type != NULL; type++) {
+	const char *types[] = {"disk", "cdrom", NULL};
+	for (const char **type = types; *type != NULL; type++)
+	{
 		index = 0;
-		while ((str = const_cast<char *>(PrefsFindString(*type, index))) != NULL) {
+		while ((str = const_cast<char *>(PrefsFindString(*type, index))) != NULL)
+		{
 			bool is_cdrom = strcmp(*type, "cdrom") == 0;
 			add_volume_entry_with_type(str, is_cdrom);
 			index++;
@@ -996,18 +1028,21 @@ static void create_volumes_pane(GtkWidget *top)
 	static const combo_desc options[] = {
 		STR_BOOT_ANY_LAB,
 		STR_BOOT_CDROM_LAB,
-		0
-	};
+		0};
 	int bootdriver = PrefsFindInt32("bootdriver"), active = 0;
-	switch (bootdriver) {
-		case 0: active = 0; break;
-		case CDROMRefNum: active = 1; break;
+	switch (bootdriver)
+	{
+	case 0:
+		active = 0;
+		break;
+	case CDROMRefNum:
+		active = 1;
+		break;
 	}
 	make_option_menu(box, STR_BOOTDRIVER_CTRL, options, G_CALLBACK(mn_bootdriver), active);
 
 	make_checkbox(box, STR_NOCDROM_CTRL, "nocdrom", G_CALLBACK(tb_nocdrom));
 }
-
 
 /*
  *  "JIT Compiler" pane
@@ -1026,7 +1061,8 @@ static bool is_jit_capable(void)
 #elif defined __APPLE__ && defined __MACH__
 	// XXX run-time detect so that we can use a PPC GUI prefs editor
 	static char cpu[10];
-	if (cpu[0] == 0) {
+	if (cpu[0] == 0)
+	{
 		FILE *fp = popen("uname -p", "r");
 		if (fp == NULL)
 			return false;
@@ -1078,7 +1114,8 @@ static void tb_jit_follow_const_jumps(GtkWidget *widget)
 static void read_jit_settings(void)
 {
 	bool jit_enabled = is_jit_capable() && PrefsFindBool("jit");
-	if (jit_enabled) {
+	if (jit_enabled)
+	{
 		const char *str = gtk_combo_box_get_active_text(GTK_COMBO_BOX(w_jit_cache_size));
 		PrefsReplaceInt32("jitcachesize", atoi(str));
 	}
@@ -1103,8 +1140,7 @@ static void create_jit_pane(GtkWidget *top)
 		STR_JIT_CACHE_SIZE_4MB_LAB,
 		STR_JIT_CACHE_SIZE_8MB_LAB,
 		STR_JIT_CACHE_SIZE_16MB_LAB,
-		0
-	};
+		0};
 	w_jit_cache_size = make_combobox(box, STR_JIT_CACHE_SIZE_CTRL, "jitcachesize", options);
 
 	// Lazy translation cache invalidation
@@ -1125,7 +1161,8 @@ static GtkWidget *w_scsi[7];
 // Read settings from widgets and set preferences
 static void read_scsi_settings(void)
 {
-	for (int id=0; id<7; id++) {
+	for (int id = 0; id < 7; id++)
+	{
 		char prefs_name[32];
 		sprintf(prefs_name, "scsi%d", id);
 		const char *str = get_file_entry_path(w_scsi[id]);
@@ -1143,20 +1180,21 @@ static void create_scsi_pane(GtkWidget *top)
 
 	box = make_pane(top, STR_SCSI_PANE_TITLE);
 
-	for (int id=0; id<7; id++) {
+	for (int id = 0; id < 7; id++)
+	{
 		char prefs_name[32];
 		sprintf(prefs_name, "scsi%d", id);
 		w_scsi[id] = make_file_entry(box, STR_SCSI_ID_0 + id, prefs_name);
 	}
 }
 
-
 /*
  *  "Graphics/Sound" pane
  */
 
 // Display types
-enum {
+enum
+{
 	DISPLAY_WINDOW,
 	DISPLAY_SCREEN
 };
@@ -1179,23 +1217,32 @@ static GtkWidget *w_dspdevice_file, *w_mixerdevice_file;
 // Hide/show graphics widgets
 static void hide_show_graphics_widgets(void)
 {
-	switch (display_type) {
-		case DISPLAY_WINDOW:
-			gtk_widget_show(w_frameskip); gtk_widget_show(l_frameskip);
+	switch (display_type)
+	{
+	case DISPLAY_WINDOW:
+		gtk_widget_show(w_frameskip);
+		gtk_widget_show(l_frameskip);
 #ifdef ENABLE_FBDEV_DGA
-			gtk_widget_show(w_display_x); gtk_widget_show(l_display_x);
-			gtk_widget_show(w_display_y); gtk_widget_show(l_display_y);
-			gtk_widget_hide(w_fbdev_name); gtk_widget_hide(l_fbdev_name);
+		gtk_widget_show(w_display_x);
+		gtk_widget_show(l_display_x);
+		gtk_widget_show(w_display_y);
+		gtk_widget_show(l_display_y);
+		gtk_widget_hide(w_fbdev_name);
+		gtk_widget_hide(l_fbdev_name);
 #endif
-			break;
-		case DISPLAY_SCREEN:
-			gtk_widget_hide(w_frameskip); gtk_widget_hide(l_frameskip);
+		break;
+	case DISPLAY_SCREEN:
+		gtk_widget_hide(w_frameskip);
+		gtk_widget_hide(l_frameskip);
 #ifdef ENABLE_FBDEV_DGA
-			gtk_widget_hide(w_display_x); gtk_widget_hide(l_display_x);
-			gtk_widget_hide(w_display_y); gtk_widget_hide(l_display_y);
-			gtk_widget_show(w_fbdev_name); gtk_widget_show(l_fbdev_name);
+		gtk_widget_hide(w_display_x);
+		gtk_widget_hide(l_display_x);
+		gtk_widget_hide(w_display_y);
+		gtk_widget_hide(l_display_y);
+		gtk_widget_show(w_fbdev_name);
+		gtk_widget_show(l_fbdev_name);
 #endif
-			break;
+		break;
 	}
 }
 
@@ -1212,15 +1259,29 @@ static void mn_display(GtkWidget *widget)
 static void mn_frameskip(GtkWidget *widget)
 {
 	int frameskip = 1;
-	switch(gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
+	switch (gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
 	{
-		case 0: frameskip = 12; break;
-		case 1: frameskip = 8; break;
-		case 2: frameskip = 6; break;
-		case 3: frameskip = 4; break;
-		case 4: frameskip = 2; break;
-		case 5: frameskip = 1; break;
-		case 6: frameskip = 0; break;
+	case 0:
+		frameskip = 12;
+		break;
+	case 1:
+		frameskip = 8;
+		break;
+	case 2:
+		frameskip = 6;
+		break;
+	case 3:
+		frameskip = 4;
+		break;
+	case 4:
+		frameskip = 2;
+		break;
+	case 5:
+		frameskip = 1;
+		break;
+	case 6:
+		frameskip = 0;
+		break;
 	}
 	PrefsReplaceInt32("frameskip", frameskip);
 }
@@ -1263,7 +1324,8 @@ static void parse_graphics_prefs(void)
 #endif
 
 	const char *str = PrefsFindString("screen");
-	if (str) {
+	if (str)
+	{
 		if (sscanf(str, "win/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_WINDOW;
 #ifdef ENABLE_FBDEV_DGA
@@ -1287,21 +1349,22 @@ static void read_graphics_settings(void)
 	dis_height = atoi(str);
 
 	char pref[256];
-	switch (display_type) {
-		case DISPLAY_WINDOW:
-			sprintf(pref, "win/%d/%d", dis_width, dis_height);
-			break;
-		case DISPLAY_SCREEN:
+	switch (display_type)
+	{
+	case DISPLAY_WINDOW:
+		sprintf(pref, "win/%d/%d", dis_width, dis_height);
+		break;
+	case DISPLAY_SCREEN:
 #ifdef ENABLE_FBDEV_DGA
-			str = gtk_entry_get_text(GTK_ENTRY(w_fbdev_name));
-			sprintf(pref, "dga/%s", str);
+		str = gtk_entry_get_text(GTK_ENTRY(w_fbdev_name));
+		sprintf(pref, "dga/%s", str);
 #else
-			sprintf(pref, "dga/%d/%d", dis_width, dis_height);
+		sprintf(pref, "dga/%d/%d", dis_width, dis_height);
 #endif
-			break;
-		default:
-			PrefsRemoveItem("screen");
-			return;
+		break;
+	default:
+		PrefsRemoveItem("screen");
+		return;
 	}
 	PrefsReplaceString("screen", pref);
 
@@ -1338,13 +1401,14 @@ static void create_graphics_pane(GtkWidget *top)
 	gtk_widget_show(combo);
 	gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(STR_WINDOW_LAB));
 	gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(STR_FULLSCREEN_LAB));
-	switch (display_type) {
-		case DISPLAY_WINDOW:
-			gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
-			break;
-		case DISPLAY_SCREEN:
-			gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 1);
-			break;
+	switch (display_type)
+	{
+	case DISPLAY_WINDOW:
+		gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
+		break;
+	case DISPLAY_SCREEN:
+		gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 1);
+		break;
 	}
 	g_signal_connect(combo, "changed", G_CALLBACK(mn_display), NULL);
 	gtk_table_attach(GTK_TABLE(table), combo, 1, 2, 0, 1, (GtkAttachOptions)GTK_FILL, (GtkAttachOptions)0, 4, 4);
@@ -1364,14 +1428,29 @@ static void create_graphics_pane(GtkWidget *top)
 	gtk_combo_box_append_text(GTK_COMBO_BOX(w_frameskip), GetString(STR_REF_DYNAMIC_LAB));
 	int frameskip = PrefsFindInt32("frameskip");
 	int item = -1;
-	switch (frameskip) {
-		case 12: item = 0; break;
-		case 8: item = 1; break;
-		case 6: item = 2; break;
-		case 4: item = 3; break;
-		case 2: item = 4; break;
-		case 1: item = 5; break;
-		case 0: item = 6; break;
+	switch (frameskip)
+	{
+	case 12:
+		item = 0;
+		break;
+	case 8:
+		item = 1;
+		break;
+	case 6:
+		item = 2;
+		break;
+	case 4:
+		item = 3;
+		break;
+	case 2:
+		item = 4;
+		break;
+	case 1:
+		item = 5;
+		break;
+	case 0:
+		item = 6;
+		break;
 	}
 	if (item >= 0)
 		gtk_combo_box_set_active(GTK_COMBO_BOX(w_frameskip), item);
@@ -1434,7 +1513,7 @@ static void create_graphics_pane(GtkWidget *top)
 
 	// SDL scaling settings section
 	label = gtk_label_new(GetString(STR_SDL_SCALING));
-	markup = g_markup_printf_escaped ("<b>%s</b>", GetString(STR_SDL_SCALING));
+	markup = g_markup_printf_escaped("<b>%s</b>", GetString(STR_SDL_SCALING));
 	gtk_label_set_markup(GTK_LABEL(label), markup);
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
 	gtk_widget_show(label);
@@ -1463,7 +1542,6 @@ static void create_graphics_pane(GtkWidget *top)
 
 	hide_show_graphics_widgets();
 }
-
 
 /*
  *  "Input" pane
@@ -1543,12 +1621,16 @@ static void create_input_pane(GtkWidget *top)
 	static const combo_desc options[] = {
 		STR_MOUSEWHEELMODE_PAGE_LAB,
 		STR_MOUSEWHEELMODE_CURSOR_LAB,
-		0
-	};
+		0};
 	int wheelmode = PrefsFindInt32("mousewheelmode"), active = 0;
-	switch (wheelmode) {
-		case 0: active = 0; break;
-		case 1: active = 1; break;
+	switch (wheelmode)
+	{
+	case 0:
+		active = 0;
+		break;
+	case 1:
+		active = 1;
+		break;
 	}
 	make_option_menu(box, STR_MOUSEWHEELMODE_CTRL, options, G_CALLBACK(mn_wheelmode), active);
 
@@ -1567,7 +1649,6 @@ static void create_input_pane(GtkWidget *top)
 
 	set_input_sensitive();
 }
-
 
 /*
  *  "Serial/Network" pane
@@ -1625,19 +1706,26 @@ static GList *add_serial_names(void)
 
 	// Search /dev for ttyS* and lp*
 	DIR *d = opendir("/dev");
-	if (d) {
+	if (d)
+	{
 		struct dirent *de;
-		while ((de = readdir(d)) != NULL) {
+		while ((de = readdir(d)) != NULL)
+		{
 #if defined(__linux__)
-			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0) {
+			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0)
+			{
 #elif defined(__FreeBSD__)
-			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
+			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
+			{
 #elif defined(__NetBSD__)
-			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
+			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
+			{
 #elif defined(sgi)
-			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0) {
+			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0)
+			{
 #else
-			if (false) {
+			if (false)
+			{
 #endif
 				char *str = new char[64];
 				sprintf(str, "/dev/%s", de->d_name);
@@ -1660,21 +1748,27 @@ static GList *add_ether_names(void)
 
 	// Get list of all Ethernet interfaces
 	int s = socket(PF_INET, SOCK_DGRAM, 0);
-	if (s >= 0) {
+	if (s >= 0)
+	{
 		char inbuf[8192];
 		struct ifconf ifc;
 		ifc.ifc_len = sizeof(inbuf);
 		ifc.ifc_buf = inbuf;
-		if (ioctl(s, SIOCGIFCONF, &ifc) == 0) {
+		if (ioctl(s, SIOCGIFCONF, &ifc) == 0)
+		{
 			struct ifreq req, *ifr = ifc.ifc_req;
-			for (int i=0; i<ifc.ifc_len; i+=sizeof(ifreq), ifr++) {
+			for (int i = 0; i < ifc.ifc_len; i += sizeof(ifreq), ifr++)
+			{
 				req = *ifr;
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(sgi)
-				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER+1)) {
+				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER + 1))
+				{
 #elif defined(__linux__)
-				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
+				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER)
+				{
 #else
-				if (false) {
+				if (false)
+				{
 #endif
 					char *str = new char[64];
 					strncpy(str, ifr->ifr_name, 63);
@@ -1718,9 +1812,9 @@ static void create_serial_pane(GtkWidget *top)
 	gtk_widget_show(w_serialb);
 	while (glist)
 	{
-	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_seriala), (gchar *)glist->data);
-	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_serialb), (gchar *)glist->data);
-	    glist = glist->next;
+		gtk_combo_box_append_text(GTK_COMBO_BOX(w_seriala), (gchar *)glist->data);
+		gtk_combo_box_append_text(GTK_COMBO_BOX(w_serialb), (gchar *)glist->data);
+		glist = glist->next;
 	}
 
 	const char *str = PrefsFindString("seriala");
@@ -1744,8 +1838,8 @@ static void create_serial_pane(GtkWidget *top)
 	gtk_widget_show(w_ether);
 	while (glist)
 	{
-	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_ether), (gchar *)glist->data);
-	    glist = glist->next;
+		gtk_combo_box_append_text(GTK_COMBO_BOX(w_ether), (gchar *)glist->data);
+		glist = glist->next;
 	}
 	str = PrefsFindString("ether");
 	if (str == NULL)
@@ -1772,7 +1866,6 @@ static void create_serial_pane(GtkWidget *top)
 
 	set_serial_sensitive();
 }
-
 
 /*
  *  "Memory/Misc" pane
@@ -1803,15 +1896,22 @@ static void mn_modelid(GtkWidget *widget)
 }
 
 // CPU/FPU type
-static void mn_cpu(GtkWidget *widget){
+static void mn_cpu(GtkWidget *widget)
+{
 	int cpu = 4;
 	bool fpu = true;
 	switch (gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
 	{
-		case 0: fpu = false;
-		case 1: cpu = 2; break;
-		case 2: fpu = false;
-		case 3: cpu = 3; break;
+	case 0:
+		fpu = false;
+	case 1:
+		cpu = 2;
+		break;
+	case 2:
+		fpu = false;
+	case 3:
+		cpu = 3;
+		break;
 	}
 	PrefsReplaceInt32("cpu", cpu);
 	PrefsReplaceBool("fpu", fpu);
@@ -1828,7 +1928,6 @@ static void read_memory_settings(void)
 		PrefsReplaceString("rom", str);
 	else
 		PrefsRemoveItem("rom");
-
 }
 
 // Create "Memory/Misc" pane
@@ -1850,8 +1949,7 @@ static void create_memory_pane(GtkWidget *top)
 		STR_RAMSIZE_256MB_LAB,
 		STR_RAMSIZE_512MB_LAB,
 		STR_RAMSIZE_1024MB_LAB,
-		0
-	};
+		0};
 	char default_ramsize[10];
 	sprintf(default_ramsize, "%d", PrefsFindInt32("ramsize") >> 20);
 	w_ramsize = table_make_combobox(table, 0, STR_RAMSIZE_CTRL, default_ramsize, options);
@@ -1859,12 +1957,16 @@ static void create_memory_pane(GtkWidget *top)
 	static const combo_desc model_options[] = {
 		STR_MODELID_5_LAB,
 		STR_MODELID_14_LAB,
-		0
-	};
+		0};
 	int modelid = PrefsFindInt32("modelid"), active = 0;
-	switch (modelid) {
-		case 5: active = 0; break;
-		case 14: active = 1; break;
+	switch (modelid)
+	{
+	case 5:
+		active = 0;
+		break;
+	case 14:
+		active = 1;
+		break;
 	}
 	table_make_option_menu(table, 2, STR_MODELID_CTRL, model_options, G_CALLBACK(mn_modelid), active);
 
@@ -1875,15 +1977,20 @@ static void create_memory_pane(GtkWidget *top)
 		STR_CPU_68030_LAB,
 		STR_CPU_68030_FPU_LAB,
 		STR_CPU_68040_LAB,
-		0
-	};
+		0};
 	int cpu = PrefsFindInt32("cpu");
 	bool fpu = PrefsFindBool("fpu");
 	active = 0;
-	switch (cpu) {
-		case 2: active = fpu ? 1 : 0; break;
-		case 3: active = fpu ? 3 : 2; break;
-		case 4: active = 4;
+	switch (cpu)
+	{
+	case 2:
+		active = fpu ? 1 : 0;
+		break;
+	case 3:
+		active = fpu ? 3 : 2;
+		break;
+	case 4:
+		active = 4;
 	}
 	table_make_option_menu(table, 3, STR_CPU_CTRL, cpu_options, G_CALLBACK(mn_cpu), active);
 #endif
@@ -1897,7 +2004,6 @@ static void create_memory_pane(GtkWidget *top)
 	gtk_widget_set_sensitive(w_ignoresegv, false);
 #endif
 }
-
 
 /*
  *  Read settings from widgets and set preferences
@@ -1914,7 +2020,6 @@ static void read_settings(void)
 	read_jit_settings();
 }
 
-
 #ifdef STANDALONE_GUI
 #include <errno.h>
 #include <sys/wait.h>
@@ -1925,17 +2030,16 @@ static void read_settings(void)
  */
 
 uint8 XPRAM[XPRAM_SIZE];
-void MountVolume(void *fh) { }
-void FileDiskLayout(loff_t size, uint8 *data, loff_t &start_byte, loff_t &real_size) { }
+void MountVolume(void *fh) {}
+void FileDiskLayout(loff_t size, uint8 *data, loff_t &start_byte, loff_t &real_size) {}
 
 #if defined __APPLE__ && defined __MACH__
-void DarwinSysInit(void) { }
-void DarwinSysExit(void) { }
-void DarwinAddFloppyPrefs(void) { }
-void DarwinAddSerialPrefs(void) { }
-bool DarwinCDReadTOC(char *, uint8 *) { }
+void DarwinSysInit(void) {}
+void DarwinSysExit(void) {}
+void DarwinAddFloppyPrefs(void) {}
+void DarwinAddSerialPrefs(void) {}
+bool DarwinCDReadTOC(char *, uint8 *) {}
 #endif
-
 
 /*
  *  Display alert
@@ -1951,18 +2055,17 @@ static GCallback dl_destroyed(GtkWidget *dialog)
 void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 {
 	GtkWidget *dialog = gtk_message_dialog_new(NULL,
-	                                           GTK_DIALOG_MODAL,
-	                                           GTK_MESSAGE_WARNING,
-	                                           GTK_BUTTONS_NONE,
-	                                           GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+											   GTK_DIALOG_MODAL,
+											   GTK_MESSAGE_WARNING,
+											   GTK_BUTTONS_NONE,
+											   GetString(title_id), NULL);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);
 
 	gtk_main();
 }
-
 
 /*
  *  Display error alert
@@ -1973,7 +2076,6 @@ void ErrorAlert(const char *text)
 	display_alert(STR_ERROR_ALERT_TITLE, STR_GUI_ERROR_PREFIX, STR_QUIT_BUTTON, text);
 }
 
-
 /*
  *  Display warning alert
  */
@@ -1982,7 +2084,6 @@ void WarningAlert(const char *text)
 {
 	display_alert(STR_WARNING_ALERT_TITLE, STR_GUI_WARNING_PREFIX, STR_OK_BUTTON, text);
 }
-
 
 /*
  *  RPC handlers
@@ -2026,7 +2127,6 @@ static int handle_Exit(rpc_connection_t *connection)
 	return RPC_ERROR_NO_ERROR;
 }
 
-
 /*
  *  SIGCHLD handler
  */
@@ -2047,22 +2147,23 @@ static void sigchld_handler(int sig, siginfo_t *sip, void *)
 	if (WIFEXITED(status))
 		status = WEXITSTATUS(status);
 	if (status & 0x80)
-		status |= -1 ^0xff;
+		status |= -1 ^ 0xff;
 
-	if (status < 0) {	// negative -> execlp/-errno
+	if (status < 0)
+	{ // negative -> execlp/-errno
 		char str[256];
 		sprintf(str, GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(-status));
 		ErrorAlert(str);
 		status = 1;
 	}
 
-	if (status != 0) {
+	if (status != 0)
+	{
 		if (g_gui_connection)
 			rpc_exit(g_gui_connection);
 		exit(status);
 	}
 }
-
 
 /*
  *  Start standalone GUI
@@ -2085,7 +2186,8 @@ int main(int argc, char *argv[])
 	PrefsExit();
 
 	// Transfer control to the executable
-	if (start) {
+	if (start)
+	{
 		char gui_connection_path[64];
 		sprintf(gui_connection_path, "/org/BasiliskII/GUI/%d", getpid());
 
@@ -2094,7 +2196,8 @@ int main(int argc, char *argv[])
 		sigemptyset(&sigchld_sa.sa_mask);
 		sigchld_sa.sa_sigaction = sigchld_handler;
 		sigchld_sa.sa_flags = SA_NOCLDSTOP | SA_SIGINFO;
-		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0) {
+		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0)
+		{
 			char str[256];
 			sprintf(str, GetString(STR_SIG_INSTALL_ERR), SIGCHLD, strerror(errno));
 			ErrorAlert(str);
@@ -2104,22 +2207,27 @@ int main(int argc, char *argv[])
 		// Search and run the BasiliskII executable
 		char *p;
 		strcpy(g_app_path, argv[0]);
-		if ((p = strstr(g_app_path, "BasiliskIIGUI.app/Contents/MacOS")) != NULL) {
-		    strcpy(p, "BasiliskII.app/Contents/MacOS/BasiliskII");
-			if (access(g_app_path, X_OK) < 0) {
+		if ((p = strstr(g_app_path, "BasiliskIIGUI.app/Contents/MacOS")) != NULL)
+		{
+			strcpy(p, "BasiliskII.app/Contents/MacOS/BasiliskII");
+			if (access(g_app_path, X_OK) < 0)
+			{
 				char str[256];
 				sprintf(str, GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(errno));
 				WarningAlert(str);
 				strcpy(g_app_path, "/Applications/BasiliskII.app/Contents/MacOS/BasiliskII");
 			}
-		} else {
+		}
+		else
+		{
 			p = strrchr(g_app_path, '/');
 			p = p ? p + 1 : g_app_path;
 			strcpy(p, "BasiliskII");
 		}
 
 		int pid = fork();
-		if (pid == 0) {
+		if (pid == 0)
+		{
 			D(bug("Trying to execute %s\n", g_app_path));
 			execlp(g_app_path, g_app_path, "--gui-connection", gui_connection_path, (char *)NULL);
 #ifdef _POSIX_PRIORITY_SCHEDULING
@@ -2130,31 +2238,35 @@ int main(int argc, char *argv[])
 		}
 
 		// Establish a connection to Basilisk II
-		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL) {
+		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL)
+		{
 			printf("ERROR: failed to initialize GUI-side RPC server connection\n");
 			return 1;
 		}
 		static const rpc_method_descriptor_t vtable[] = {
-			{ RPC_METHOD_ERROR_ALERT,			handle_ErrorAlert },
-			{ RPC_METHOD_WARNING_ALERT,			handle_WarningAlert },
-			{ RPC_METHOD_EXIT,					handle_Exit }
-		};
-		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0) {
+			{RPC_METHOD_ERROR_ALERT, handle_ErrorAlert},
+			{RPC_METHOD_WARNING_ALERT, handle_WarningAlert},
+			{RPC_METHOD_EXIT, handle_Exit}};
+		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0)
+		{
 			printf("ERROR: failed to setup GUI method callbacks\n");
 			return 1;
 		}
 		int socket;
-		if ((socket = rpc_listen_socket(g_gui_connection)) < 0) {
+		if ((socket = rpc_listen_socket(g_gui_connection)) < 0)
+		{
 			printf("ERROR: failed to initialize RPC server thread\n");
 			return 1;
 		}
 
 		g_gui_loop = g_main_new(TRUE);
-		while (g_main_is_running(g_gui_loop)) {
+		while (g_main_is_running(g_gui_loop))
+		{
 
 			// Process a few events pending
 			const int N_EVENTS_DISPATCH = 10;
-			for (int i = 0; i < N_EVENTS_DISPATCH; i++) {
+			for (int i = 0; i < N_EVENTS_DISPATCH; i++)
+			{
 				if (!g_main_iteration(FALSE))
 					break;
 			}

--- a/BasiliskII/src/Unix/prefs_editor_gtk3.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk3.cpp
@@ -1440,7 +1440,7 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 						GTK_MESSAGE_WARNING,
 						GTK_BUTTONS_NONE,
 						GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);

--- a/BasiliskII/src/Unix/prefs_editor_gtk3.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk3.cpp
@@ -50,8 +50,8 @@
 
 // Global variables
 static GtkBuilder *builder;
-static GtkWidget *win;				// Preferences window
-static bool start_clicked = false;	// Return value of PrefsEditor() function
+static GtkWidget *win;					// Preferences window
+static bool start_clicked = false;		// Return value of PrefsEditor() function
 static int screen_width, screen_height; // Screen dimensions
 
 static GtkAdjustment *size_adj;
@@ -73,19 +73,21 @@ static int dis_width, dis_height;
 static bool is_fbdev_dga_mode = false;
 #endif
 
-struct opt_desc {
+struct opt_desc
+{
 	int label_id;
 	GCallback func;
 };
 
-struct combo_desc {
+struct combo_desc
+{
 	int label_id;
 };
 
-static GtkWidget *create_tree_view (void);
-static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data);
-static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data);
-static void cb_remove_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data);
+static GtkWidget *create_tree_view(void);
+static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data);
+static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data);
+static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data);
 static GList *add_serial_names(void);
 static GList *add_ether_names(void);
 static void save_volumes(void);
@@ -105,7 +107,7 @@ const char *authors[] = {"Christian Bauer", "Marc Hellwig", "Gwenolé Beauchesne
 const char *authors[] = {
 	"Christian Bauer", "Orlando Bassotto", "Gwenolé Beauchesne", "Marc Chabanas", "Marc Hellwig",
 	"Bill Huey", "Brian J. Johnson", "Jürgen Lachmann", "Samuel Lander", "David Lawrence",
-	"Lauri Pesonen", "Bernd Schmidt", "and others", NULL };
+	"Lauri Pesonen", "Bernd Schmidt", "and others", NULL};
 #endif
 
 #if REAL_ADDRESSING
@@ -115,7 +117,7 @@ const char *authors[] = {
 #endif
 
 #if defined(USE_SDL_AUDIO) && defined(USE_SDL_VIDEO)
-#if SDL_VERSION_ATLEAST(2,0,0)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 #define ABOUT_VIDEO "SDL 2 audio"
 #else
 #define ABOUT_VIDEO "SDL 1.2 audio"
@@ -123,7 +125,7 @@ const char *authors[] = {
 #define ABOUT_AUDIO "video"
 #else
 #ifdef USE_SDL_AUDIO
-#if SDL_VERSION_ATLEAST(2,0,0)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 #define ABOUT_AUDIO "SDL 2 audio"
 #else
 #define ABOUT_AUDIO "SDL 1.2 audio"
@@ -134,7 +136,7 @@ const char *authors[] = {
 #define ABOUT_AUDIO "no audio"
 #endif
 #ifdef USE_SDL_VIDEO
-#if SDL_VERSION_ATLEAST(2,0,0)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 #define ABOUT_VIDEO "SDL 2 video"
 #else
 #define ABOUT_VIDEO "SDL 1.2 video"
@@ -153,14 +155,14 @@ const char *sysinfo = ABOUT_MODE "\nBuilt with " ABOUT_VIDEO " and " ABOUT_AUDIO
 // The widgets from prefs-editor.ui that need their values set on launch
 const char *check_boxes[] = {
 	"udptunnel", "keycodes", "ignoresegv", "idlewait", "jit", "jitfpu", "jitinline",
-	"jitlazyflush", "jit68k", "gfxaccel", "swap_opt_cmd", "scale_nearest", "scale_integer", NULL };
-const char *inv_check_boxes[] = { "nocdrom", "nosound", "nogui", NULL };
+	"jitlazyflush", "jit68k", "gfxaccel", "swap_opt_cmd", "scale_nearest", "scale_integer", NULL};
+const char *inv_check_boxes[] = {"nocdrom", "nosound", "nogui", NULL};
 const char *entries[] = {
 	"extfs", "dsp", "mixer", "keycodefile", "scsi0", "scsi1", "scsi2", "scsi3", "scsi4",
-	"scsi5", "scsi6", "rom", NULL };
-const char *spin_buttons[] = { "mousewheellines", "udpport", NULL };
-const char *id_combos[] = { "bootdriver", "frameskip", "modelid", NULL };
-const char *text_combos[] = { "ramsize", NULL };
+	"scsi5", "scsi6", "rom", NULL};
+const char *spin_buttons[] = {"mousewheellines", "udpport", NULL};
+const char *id_combos[] = {"bootdriver", "frameskip", "modelid", NULL};
+const char *text_combos[] = {"ramsize", NULL};
 
 // Set initial widget states
 static void set_initial_prefs(void)
@@ -169,15 +171,15 @@ static void set_initial_prefs(void)
 	while (*id)
 	{
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, *id)),
-		                             PrefsFindBool(*id));
+									 PrefsFindBool(*id));
 		id++;
 	}
 
 	id = inv_check_boxes;
-	while(*id)
+	while (*id)
 	{
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, *id)),
-		                             !PrefsFindBool(*id));
+									 !PrefsFindBool(*id));
 		id++;
 	}
 	cb_swap_opt_cmd(NULL);
@@ -187,7 +189,7 @@ static void set_initial_prefs(void)
 	{
 		if (PrefsFindString(*id) != NULL)
 			gtk_entry_set_text(GTK_ENTRY(gtk_builder_get_object(builder, *id)),
-			                   PrefsFindString(*id));
+							   PrefsFindString(*id));
 		id++;
 	}
 
@@ -195,7 +197,7 @@ static void set_initial_prefs(void)
 	while (*id)
 	{
 		gtk_spin_button_set_value(GTK_SPIN_BUTTON(gtk_builder_get_object(builder, *id)),
-		                          PrefsFindInt32(*id));
+								  PrefsFindInt32(*id));
 		id++;
 	}
 
@@ -222,31 +224,29 @@ static void set_initial_prefs(void)
 	}
 }
 
-
-
 // Helper functions to create a file chooser
-static GtkFileChooser *file_chooser_new (GtkWidget *parent,
-                                         GtkFileChooserAction action,
-                                         uint32_t title_id,
-                                         uint32_t accept_id,
-                                         uint32_t cancel_id,
-                                         const char *directory)
+static GtkFileChooser *file_chooser_new(GtkWidget *parent,
+										GtkFileChooserAction action,
+										uint32_t title_id,
+										uint32_t accept_id,
+										uint32_t cancel_id,
+										const char *directory)
 {
 #ifdef USE_NATIVE_FILE_CHOOSER
 	GtkFileChooserNative *chooser = gtk_file_chooser_native_new(GetString(title_id),
-	                                                            GTK_WINDOW(parent),
-	                                                            action,
-	                                                            GetString(accept_id),
-	                                                            GetString(cancel_id));
+																GTK_WINDOW(parent),
+																action,
+																GetString(accept_id),
+																GetString(cancel_id));
 	gtk_native_dialog_set_transient_for(GTK_NATIVE_DIALOG(chooser), GTK_WINDOW(parent));
 	gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), true);
 #else
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(title_id),
-	                                                 GTK_WINDOW(parent),
-	                                                 action,
-	                                                 GetString(cancel_id), GTK_RESPONSE_CANCEL,
-	                                                 GetString(accept_id), GTK_RESPONSE_ACCEPT,
-	                                                 NULL);
+													 GTK_WINDOW(parent),
+													 action,
+													 GetString(cancel_id), GTK_RESPONSE_CANCEL,
+													 GetString(accept_id), GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
 	gtk_window_set_modal(GTK_WINDOW(chooser), true);
@@ -275,86 +275,89 @@ static void file_chooser_destroy(GtkFileChooser *chooser)
 	g_object_unref(G_OBJECT(chooser));
 }
 
-
 // User closed the file chooser dialog, possibly selecting a file
 static void cb_browse_response(GtkFileChooser *chooser, int response, GtkEntry *entry)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
 		char *filename;
-		filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (chooser));
+		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
 		gtk_entry_set_text(GTK_ENTRY(entry), filename);
-		g_free (filename);
+		g_free(filename);
 	}
-	file_chooser_destroy (chooser);
+	file_chooser_destroy(chooser);
 }
 
-extern "C" {
-
-// Open the file chooser dialog to select a file
-void cb_browse(GtkWidget *button, GtkWidget *entry)
+extern "C"
 {
-	GtkFileChooser *chooser = file_chooser_new(win,
-	                                           GTK_FILE_CHOOSER_ACTION_OPEN,
-	                                           STR_BROWSE_TITLE,
-	                                           STR_SELECT_BUTTON,
-	                                           STR_CANCEL_BUTTON,
-	                                           gtk_entry_get_text(GTK_ENTRY(entry)));
-	g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_ENTRY(entry));
-	file_chooser_show(chooser);
-}
 
-// Open the file chooser dialog to select a folder
-void cb_browse_dir(GtkWidget *button, GtkWidget *entry)
-{
-	GtkFileChooser *chooser = file_chooser_new(win,
-	                                           GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
-	                                           STR_BROWSE_FOLDER_TITLE,
-	                                           STR_SELECT_BUTTON,
-	                                           STR_CANCEL_BUTTON,
-	                                           gtk_entry_get_text(GTK_ENTRY(entry)));
-	g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_WIDGET(entry));
-	file_chooser_show(chooser);
-}
-
-// User changed scaling settings
-void cb_scaling(GtkWidget * widget)
-{
-	const char *mag_rate_str = gtk_entry_get_text(GTK_ENTRY(mag_rate));
-	if (mag_rate_str) {
-		PrefsReplaceString("mag_rate", mag_rate_str);
-	} else {
-		PrefsRemoveItem("mag_rate");
-	}
-}
-
-// User changed one of the screen mode settings
-void cb_screen_mode(GtkWidget *widget)
-{
-	const char *res = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(screen_res));
-	if (res)
+	// Open the file chooser dialog to select a file
+	void cb_browse(GtkWidget *button, GtkWidget *entry)
 	{
-		if (g_strcmp0(res, GetString(STR_SIZE_MAX_LAB)) == 0)
+		GtkFileChooser *chooser = file_chooser_new(win,
+												   GTK_FILE_CHOOSER_ACTION_OPEN,
+												   STR_BROWSE_TITLE,
+												   STR_SELECT_BUTTON,
+												   STR_CANCEL_BUTTON,
+												   gtk_entry_get_text(GTK_ENTRY(entry)));
+		g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_ENTRY(entry));
+		file_chooser_show(chooser);
+	}
+
+	// Open the file chooser dialog to select a folder
+	void cb_browse_dir(GtkWidget *button, GtkWidget *entry)
+	{
+		GtkFileChooser *chooser = file_chooser_new(win,
+												   GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+												   STR_BROWSE_FOLDER_TITLE,
+												   STR_SELECT_BUTTON,
+												   STR_CANCEL_BUTTON,
+												   gtk_entry_get_text(GTK_ENTRY(entry)));
+		g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_WIDGET(entry));
+		file_chooser_show(chooser);
+	}
+
+	// User changed scaling settings
+	void cb_scaling(GtkWidget *widget)
+	{
+		const char *mag_rate_str = gtk_entry_get_text(GTK_ENTRY(mag_rate));
+		if (mag_rate_str)
 		{
-			dis_width = 0;
-			dis_height = 0;
+			PrefsReplaceString("mag_rate", mag_rate_str);
 		}
 		else
-			sscanf(res, "%d x %d", &dis_width, &dis_height);
+		{
+			PrefsRemoveItem("mag_rate");
+		}
 	}
 
+	// User changed one of the screen mode settings
+	void cb_screen_mode(GtkWidget *widget)
+	{
+		const char *res = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(screen_res));
+		if (res)
+		{
+			if (g_strcmp0(res, GetString(STR_SIZE_MAX_LAB)) == 0)
+			{
+				dis_width = 0;
+				dis_height = 0;
+			}
+			else
+				sscanf(res, "%d x %d", &dis_width, &dis_height);
+		}
+
 #ifdef ENABLE_FBDEV_DGA
-	const char *str = gtk_toggle_button_get_active(screen_full) ? "fbdev/%d/%d" : "win/%d/%d";
+		const char *str = gtk_toggle_button_get_active(screen_full) ? "fbdev/%d/%d" : "win/%d/%d";
 #else
-	const char *str = gtk_toggle_button_get_active(screen_full) ? "dga/%d/%d" : "win/%d/%d";
+		const char *str = gtk_toggle_button_get_active(screen_full) ? "dga/%d/%d" : "win/%d/%d";
 #endif
-	char *screen = g_strdup_printf(str, dis_width, dis_height);
-	PrefsReplaceString("screen", screen);
-	// Old prefs are now migrated
-	PrefsRemoveItem("windowmodes");
-	PrefsRemoveItem("screenmodes");
-	g_free(screen);
-}
+		char *screen = g_strdup_printf(str, dis_width, dis_height);
+		PrefsReplaceString("screen", screen);
+		// Old prefs are now migrated
+		PrefsRemoveItem("windowmodes");
+		PrefsRemoveItem("screenmodes");
+		g_free(screen);
+	}
 
 } // extern "C"
 
@@ -398,7 +401,7 @@ static void set_hotkey_buttons(void)
 	gtk_toggle_button_set_active(super, hotkey & 4);
 }
 
-static void set_cpu_combo_box (void)
+static void set_cpu_combo_box(void)
 {
 	GtkComboBox *combo = GTK_COMBO_BOX(gtk_builder_get_object(builder, "cpu"));
 	int32_t cpu = PrefsFindInt32("cpu");
@@ -416,7 +419,7 @@ static GtkWidget *add_combo_box_values(GList *entries, const char *pref)
 	list = entries;
 	while (list)
 	{
-		gtk_combo_box_text_prepend(GTK_COMBO_BOX_TEXT(combo), ((char *) list->data), ((char *) list->data));
+		gtk_combo_box_text_prepend(GTK_COMBO_BOX_TEXT(combo), ((char *)list->data), ((char *)list->data));
 		list = list->next;
 	}
 
@@ -448,7 +451,7 @@ static void run_emulator()
 	gtk_widget_destroy(win);
 }
 // "Start" button clicked
-static void cb_start (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_start(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	if (access(PrefsFindString("rom"), F_OK) != 0)
 	{
@@ -461,14 +464,14 @@ static void cb_start (GSimpleAction *action, GVariant *parameter, gpointer user_
 
 // "Save Settings" menu item clicked
 static void
-cb_save_settings (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+cb_save_settings(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	save_volumes();
 	SavePrefs();
 }
 
 // "Quit" button clicked
-static void cb_quit (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_quit(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	start_clicked = false;
 	gtk_widget_destroy(win);
@@ -481,25 +484,25 @@ extern "C" void dl_quit(GtkWidget *dialog)
 }
 
 // "About" selected
-static void mn_about (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void mn_about(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
-    char *version = g_strdup_printf("%d.%d", VERSION_MAJOR, VERSION_MINOR);
+	char *version = g_strdup_printf("%d.%d", VERSION_MAJOR, VERSION_MINOR);
 	gtk_show_about_dialog(GTK_WINDOW(win),
-	                      "version", version,
-	                      "copyright", sysinfo,
-	                      "authors", authors,
-	                      "comments", GetString(STR_ABOUT_COMMENTS),
-	                      "website", GetString(STR_ABOUT_WEBSITE),
-	                      "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
-	                      "license", GetString(STR_ABOUT_LICENSE),
-	                      "wrap-license", true,
-	                      "logo-icon-name", GetString(STR_APP_NAME),
-	                      NULL);
-    g_free(version);
+						  "version", version,
+						  "copyright", sysinfo,
+						  "authors", authors,
+						  "comments", GetString(STR_ABOUT_COMMENTS),
+						  "website", GetString(STR_ABOUT_WEBSITE),
+						  "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
+						  "license", GetString(STR_ABOUT_LICENSE),
+						  "wrap-license", true,
+						  "logo-icon-name", GetString(STR_APP_NAME),
+						  NULL);
+	g_free(version);
 }
 
 // "Help" selected
-static void mn_help (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void mn_help(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 #if GTK_CHECK_VERSION(3, 22, 0)
 	gtk_show_uri_on_window(GTK_WINDOW(win), "https://github.com/kanjitalk755/macemu", GDK_CURRENT_TIME, NULL);
@@ -509,22 +512,22 @@ static void mn_help (GSimpleAction *action, GVariant *parameter, gpointer user_d
 }
 
 // "Zap NVRAM" selected
-static void mn_zap_pram (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void mn_zap_pram(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	ZapPRAM();
 }
 
 // Action entries (used in menus and buttons)
 static GActionEntry win_entries[] = {
-	{ "add-volume", cb_add_volume },
-	{ "create-volume", cb_create_volume },
-	{ "remove-volume", cb_remove_volume },
-	{ "start", cb_start },
-	{ "save-settings", cb_save_settings },
-	{ "zap-pram", mn_zap_pram },
-	{ "quit", cb_quit },
-	{ "help", mn_help },
-	{ "about", mn_about },
+	{"add-volume", cb_add_volume},
+	{"create-volume", cb_create_volume},
+	{"remove-volume", cb_remove_volume},
+	{"start", cb_start},
+	{"save-settings", cb_save_settings},
+	{"zap-pram", mn_zap_pram},
+	{"quit", cb_quit},
+	{"help", mn_help},
+	{"about", mn_about},
 };
 
 // Hide widgets which aren't applicable to this emulator
@@ -557,12 +560,12 @@ static void set_file_menu(GtkApplication *app)
 	g_object_unref(menubuilder);
 }
 
-static void set_help_overlay (GtkApplicationWindow *win)
+static void set_help_overlay(GtkApplicationWindow *win)
 {
 #if GTK_CHECK_VERSION(3, 20, 0)
 	GtkBuilder *helpbuilder = gtk_builder_new_from_resource(G_RES_PATH "help-overlay.ui");
 	gtk_application_window_set_help_overlay(win,
-			GTK_SHORTCUTS_WINDOW(gtk_builder_get_object(helpbuilder, "emulator-shortcuts")));
+											GTK_SHORTCUTS_WINDOW(gtk_builder_get_object(helpbuilder, "emulator-shortcuts")));
 	g_object_unref(helpbuilder);
 #endif
 }
@@ -585,13 +588,13 @@ bool PrefsEditor(void)
 	GtkSettings *settings = gtk_settings_get_default();
 	if (g_strcmp0(getenv("GTK_CSD"), "0") != 0)
 	{
-	    g_object_get(settings, "gtk-dialogs-use-header", &use_headerbar, NULL);
+		g_object_get(settings, "gtk-dialogs-use-header", &use_headerbar, NULL);
 	}
 	set_file_menu(GTK_APPLICATION(app));
 
 	// Create window
 	win = GTK_WIDGET(gtk_builder_get_object(builder, "prefs-editor"));
-	g_assert(GTK_IS_APPLICATION_WINDOW (win));
+	g_assert(GTK_IS_APPLICATION_WINDOW(win));
 	gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(win));
 	set_initial_prefs();
 	set_ramsize_combo_box();
@@ -611,11 +614,11 @@ bool PrefsEditor(void)
 	set_help_overlay(GTK_APPLICATION_WINDOW(win));
 
 	gtk_window_set_title(GTK_WINDOW(win), GetString(STR_PREFS_TITLE));
-	g_action_map_add_action_entries (G_ACTION_MAP (win),
-	                                 win_entries,
-	                                 G_N_ELEMENTS (win_entries),
-	                                 win);
-	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP (win), "remove-volume")), false);
+	g_action_map_add_action_entries(G_ACTION_MAP(win),
+									win_entries,
+									G_N_ELEMENTS(win_entries),
+									win);
+	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP(win), "remove-volume")), false);
 	g_signal_connect(GTK_WIDGET(win), "delete_event", G_CALLBACK(window_closed), NULL);
 	g_signal_connect(GTK_WIDGET(win), "destroy", G_CALLBACK(window_destroyed), NULL);
 
@@ -687,16 +690,16 @@ bool PrefsEditor(void)
  */
 
 // Values for the columns of the list store
-enum {
+enum
+{
 	COLUMN_PATH,
 	COLUMN_SIZE,
 	COLUMN_CDROM,
 	N_COLUMNS
 };
 
-
 // Gets the size of the volume as a pretty string
-static const char* get_file_size (GFile *file)
+static const char *get_file_size(GFile *file)
 {
 	GFileInfo *info;
 	if (g_file_query_exists(file, NULL))
@@ -713,7 +716,7 @@ static const char* get_file_size (GFile *file)
 	g_object_unref(info);
 }
 
-static bool has_file_ext (GFile *file, const char *ext)
+static bool has_file_ext(GFile *file, const char *ext)
 {
 	char *str = g_file_get_path(file);
 	char *file_ext = g_utf8_strrchr(str, 255, '.');
@@ -722,26 +725,27 @@ static bool has_file_ext (GFile *file, const char *ext)
 	return (g_strcmp0(file_ext, ext) == 0);
 }
 
-static bool guess_if_file_is_cdrom(GFile * volume) {
+static bool guess_if_file_is_cdrom(GFile *volume)
+{
 	return has_file_ext(volume, ".iso") ||
 #ifdef BINCUE
-		has_file_ext(volume, ".cue") ||
+		   has_file_ext(volume, ".cue") ||
 #endif
-		has_file_ext(volume, ".toast");
+		   has_file_ext(volume, ".toast");
 }
 
 // User selected a volume to add
-static void cb_add_volume_response (GtkFileChooser *chooser, int response)
+static void cb_add_volume_response(GtkFileChooser *chooser, int response)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
 		GFile *volume = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(chooser));
-		gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
-		gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
-				COLUMN_PATH, g_file_get_path(volume),
-				COLUMN_SIZE, get_file_size(volume),
-				COLUMN_CDROM, guess_if_file_is_cdrom(volume),
-				-1);
+		gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
+		gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
+						   COLUMN_PATH, g_file_get_path(volume),
+						   COLUMN_SIZE, get_file_size(volume),
+						   COLUMN_CDROM, guess_if_file_is_cdrom(volume),
+						   -1);
 		g_object_unref(volume);
 	}
 	file_chooser_destroy(chooser);
@@ -749,41 +753,42 @@ static void cb_add_volume_response (GtkFileChooser *chooser, int response)
 
 // Something dropped on volume list
 static void cb_volume_drag_data_received(GtkWidget *view, GdkDragContext *drag_context, gint x, gint y, GtkSelectionData *data,
-	guint info, guint time, gpointer user_data)
+										 guint info, guint time, gpointer user_data)
 {
-	if (gtk_selection_data_get_data_type(data) == gdk_atom_intern_static_string("text/uri-list")) {
+	if (gtk_selection_data_get_data_type(data) == gdk_atom_intern_static_string("text/uri-list"))
+	{
 		// get URIs from the drag selection data and add them
-		gchar ** uris = gtk_selection_data_get_uris(data);
-		for (gchar ** uri = uris; *uri != NULL; uri++) {
+		gchar **uris = gtk_selection_data_get_uris(data);
+		for (gchar **uri = uris; *uri != NULL; uri++)
+		{
 
 			GFile *volume = g_file_new_for_uri(*uri);
-			gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
-			gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
-			        COLUMN_PATH, g_file_get_path(volume),
-			        COLUMN_SIZE, get_file_size(volume),
-			        COLUMN_CDROM, has_file_ext(volume, ".iso"),
-			        -1);
+			gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
+			gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
+							   COLUMN_PATH, g_file_get_path(volume),
+							   COLUMN_SIZE, get_file_size(volume),
+							   COLUMN_CDROM, has_file_ext(volume, ".iso"),
+							   -1);
 			g_object_unref(volume);
-
 		}
 		g_strfreev(uris);
 	}
 }
 
 // "Add Volume" button clicked
-static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkFileChooser *chooser = file_chooser_new(win,
-	                                           GTK_FILE_CHOOSER_ACTION_OPEN,
-	                                           STR_ADD_VOLUME_TITLE,
-	                                           STR_SELECT_BUTTON,
-	                                           STR_CANCEL_BUTTON,
-	                                           NULL);
+											   GTK_FILE_CHOOSER_ACTION_OPEN,
+											   STR_ADD_VOLUME_TITLE,
+											   STR_SELECT_BUTTON,
+											   STR_CANCEL_BUTTON,
+											   NULL);
 	g_signal_connect(chooser, "response", G_CALLBACK(cb_add_volume_response), NULL);
 	file_chooser_show(chooser);
 }
 
-static gboolean volume_file_create (GFile *file, uint32_t size_mb)
+static gboolean volume_file_create(GFile *file, uint32_t size_mb)
 {
 	// The dialog asks to confirm overwrite, so no need to prevent overwriting if file already exists
 	GFileOutputStream *fd = g_file_replace(file, NULL, false, G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL);
@@ -791,19 +796,20 @@ static gboolean volume_file_create (GFile *file, uint32_t size_mb)
 	{
 		g_seekable_truncate(G_SEEKABLE(fd), size_mb * 1024 * 1024, NULL, NULL);
 	}
-	else return false;
+	else
+		return false;
 	g_object_unref(fd);
 
-	gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
-	gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
-			COLUMN_PATH, g_file_get_path(file),
-			COLUMN_SIZE, get_file_size(file),
-			-1);
+	gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
+	gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
+					   COLUMN_PATH, g_file_get_path(file),
+					   COLUMN_SIZE, get_file_size(file),
+					   -1);
 	g_object_unref(file);
 	return true;
 }
 
-static void cb_volume_create_size (GtkWidget *dialog, int response, GFile *file)
+static void cb_volume_create_size(GtkWidget *dialog, int response, GFile *file)
 {
 	if (response == GTK_RESPONSE_OK)
 	{
@@ -813,7 +819,7 @@ static void cb_volume_create_size (GtkWidget *dialog, int response, GFile *file)
 }
 
 // User selected to create a new volume
-static void cb_create_volume_response (GtkFileChooser *chooser, int response, GtkEntry *size_entry)
+static void cb_create_volume_response(GtkFileChooser *chooser, int response, GtkEntry *size_entry)
 {
 	GtkWidget *dialog, *spinbutton, *box;
 	if (response == GTK_RESPONSE_ACCEPT)
@@ -826,10 +832,10 @@ static void cb_create_volume_response (GtkFileChooser *chooser, int response, Gt
 		if (!chooser_is_widget)
 		{
 			dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-					(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
-					GTK_MESSAGE_WARNING,
-					GTK_BUTTONS_OK_CANCEL,
-					"Volume Size (MB):");
+											(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+											GTK_MESSAGE_WARNING,
+											GTK_BUTTONS_OK_CANCEL,
+											"Volume Size (MB):");
 			box = gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog));
 			size_adj = gtk_adjustment_new(atoi(VOLUME_SIZE_DEFAULT), 1, 2000, 1, 100, 100);
 			spinbutton = gtk_spin_button_new(size_adj, 10, 0);
@@ -845,10 +851,10 @@ static void cb_create_volume_response (GtkFileChooser *chooser, int response, Gt
 		if (disk_size < 1 || disk_size > 2000)
 		{
 			GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-					(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
-					GTK_MESSAGE_WARNING,
-					GTK_BUTTONS_CLOSE,
-					"Enter a valid size");
+													   (GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+													   GTK_MESSAGE_WARNING,
+													   GTK_BUTTONS_CLOSE,
+													   "Enter a valid size");
 			gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "The volume size should be between 1 and 2000.");
 			gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(chooser));
 			g_signal_connect(dialog, "response", G_CALLBACK(dl_quit), NULL);
@@ -857,7 +863,7 @@ static void cb_create_volume_response (GtkFileChooser *chooser, int response, Gt
 		}
 		volume_file_create(volume, disk_size);
 	}
-	file_chooser_destroy (chooser);
+	file_chooser_destroy(chooser);
 }
 
 // Doesn't run if the file chooser is displayed by the portal. We use this
@@ -868,14 +874,14 @@ static void size_entry_displayed(GtkWidget *size_entry, gpointer user_data)
 }
 
 // "Create" button clicked
-static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkFileChooser *chooser = file_chooser_new(win,
-	                                           GTK_FILE_CHOOSER_ACTION_SAVE,
-	                                           STR_CREATE_VOLUME_TITLE,
-	                                           STR_CREATE_BUTTON,
-	                                           STR_CANCEL_BUTTON,
-	                                           NULL);
+											   GTK_FILE_CHOOSER_ACTION_SAVE,
+											   STR_CREATE_VOLUME_TITLE,
+											   STR_CREATE_BUTTON,
+											   STR_CANCEL_BUTTON,
+											   NULL);
 	gtk_file_chooser_set_do_overwrite_confirmation(chooser, TRUE);
 
 	GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
@@ -902,11 +908,11 @@ static void cb_remove_enable(GtkWidget *widget)
 	bool enable = false;
 	if (selection != NULL && gtk_tree_selection_count_selected_rows(selection))
 		enable = true;
-	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP (win), "remove-volume")), enable);
+	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP(win), "remove-volume")), enable);
 }
 
 // "Remove" button clicked
-static void cb_remove_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	if (gtk_tree_selection_count_selected_rows(selection))
 	{
@@ -915,23 +921,23 @@ static void cb_remove_volume (GSimpleAction *action, GVariant *parameter, gpoint
 	}
 }
 
-static void cb_cdrom (GtkCellRendererToggle *cell, char *path_str, gpointer data)
+static void cb_cdrom(GtkCellRendererToggle *cell, char *path_str, gpointer data)
 {
 	GtkTreeIter iter;
-	GtkTreePath *path = gtk_tree_path_new_from_string (path_str);
+	GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
 	gboolean cd_rom;
 
-	gtk_tree_model_get_iter (volume_store, &iter, path);
-	gtk_tree_model_get (volume_store, &iter, COLUMN_CDROM, &cd_rom, -1);
+	gtk_tree_model_get_iter(volume_store, &iter, path);
+	gtk_tree_model_get(volume_store, &iter, COLUMN_CDROM, &cd_rom, -1);
 
 	cd_rom ^= 1;
 
-	gtk_list_store_set (GTK_LIST_STORE (volume_store), &iter, COLUMN_CDROM, cd_rom, -1);
-	gtk_tree_path_free (path);
+	gtk_list_store_set(GTK_LIST_STORE(volume_store), &iter, COLUMN_CDROM, cd_rom, -1);
+	gtk_tree_path_free(path);
 }
 
 // Save volumes from list store to prefs
-static void save_volumes (void)
+static void save_volumes(void)
 {
 	while (PrefsFindString("disk"))
 		PrefsRemoveItem("disk");
@@ -949,13 +955,12 @@ static void save_volumes (void)
 				PrefsAddString("cdrom", path);
 			else
 				PrefsAddString("disk", path);
-		}
-		while (gtk_tree_model_iter_next(volume_store, &toplevel));
+		} while (gtk_tree_model_iter_next(volume_store, &toplevel));
 	}
 }
 
 // Gets the list of disks and cdroms from the prefs file and adds them to the list store
-static GtkTreeModel *get_volumes (void)
+static GtkTreeModel *get_volumes(void)
 {
 	const char *str;
 	int32_t index = 0;
@@ -967,28 +972,28 @@ static GtkTreeModel *get_volumes (void)
 		{
 			read_only = 1;
 		}
-		gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
-			gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
-				COLUMN_PATH, str + read_only,
-				COLUMN_SIZE, get_file_size(g_file_new_for_path(str + read_only)),
-				COLUMN_CDROM, read_only,
-				-1);
+		gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
+		gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
+						   COLUMN_PATH, str + read_only,
+						   COLUMN_SIZE, get_file_size(g_file_new_for_path(str + read_only)),
+						   COLUMN_CDROM, read_only,
+						   -1);
 	}
 	index = 0;
 	while ((str = (const char *)PrefsFindString("cdrom", index++)) != NULL)
 	{
-		gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
-			gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
-				COLUMN_PATH, str,
-				COLUMN_SIZE, get_file_size(g_file_new_for_path(str)),
-				COLUMN_CDROM, true,
-				-1);
+		gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
+		gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
+						   COLUMN_PATH, str,
+						   COLUMN_SIZE, get_file_size(g_file_new_for_path(str)),
+						   COLUMN_CDROM, true,
+						   -1);
 	}
 	return volume_store;
 }
 
 // Creates the tree view widget to display the volume list
-static GtkWidget *create_tree_view (void)
+static GtkWidget *create_tree_view(void)
 {
 	GtkTreeViewColumn *col;
 	GtkCellRenderer *renderer;
@@ -1009,8 +1014,8 @@ static GtkWidget *create_tree_view (void)
 	gtk_tree_view_column_set_title(col, "CD-ROM");
 	gtk_tree_view_append_column(GTK_TREE_VIEW(view), col);
 	renderer = gtk_cell_renderer_toggle_new();
-	g_signal_connect (renderer, "toggled",
-	                  G_CALLBACK (cb_cdrom), NULL);
+	g_signal_connect(renderer, "toggled",
+					 G_CALLBACK(cb_cdrom), NULL);
 	gtk_tree_view_column_pack_start(col, renderer, TRUE);
 	gtk_tree_view_column_add_attribute(col, renderer, "active", COLUMN_CDROM);
 
@@ -1048,7 +1053,8 @@ static bool is_jit_capable(void)
 #elif defined __APPLE__ && defined __MACH__
 	// XXX run-time detect so that we can use a PPC GUI prefs editor
 	static char cpu[10];
-	if (cpu[0] == 0) {
+	if (cpu[0] == 0)
+	{
 		FILE *fp = popen("uname -p", "r");
 		if (fp == NULL)
 			return false;
@@ -1066,184 +1072,186 @@ static bool is_jit_capable(void)
  */
 
 // Display types
-enum {
+enum
+{
 	DISPLAY_WINDOW,
 	DISPLAY_SCREEN
 };
 
-extern "C" {
-
-// User changed the hotkey combination
-void cb_hotkey (GtkWidget *widget)
+extern "C"
 {
-	GtkToggleButton *ctrl = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "ctrl-hotkey"));
-	GtkToggleButton *alt = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "alt-hotkey"));
-	GtkToggleButton *super = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "super-hotkey"));
-	int hotkey = gtk_toggle_button_get_active(ctrl) |
-	             gtk_toggle_button_get_active(alt) << 1 |
-	             gtk_toggle_button_get_active(super) << 2;
-	if (hotkey == 0)
-		return;
-	PrefsReplaceInt32("hotkey", hotkey);
-}
 
-// Adds the MB suffix to the value entered by the user
-void cb_format_ramsize (GtkWidget *widget)
-{
-	int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
-	if (size_mb < 4)
-		size_mb = 4;
-	if (size_mb > 1024)
-		size_mb = 1024;
-	char *text = g_strdup_printf("%d MB", size_mb);
-	gtk_entry_set_text(GTK_ENTRY(widget), text);
-	g_free(text);
-}
-
-// Saves the new ram size preference
-void cb_ramsize (GtkWidget *widget)
-{
-	int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
-	if (size_mb >= 4 && size_mb <= 1024)
+	// User changed the hotkey combination
+	void cb_hotkey(GtkWidget *widget)
 	{
-		int size_bytes = size_mb << 20;
-		PrefsReplaceInt32("ramsize", size_bytes);
+		GtkToggleButton *ctrl = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "ctrl-hotkey"));
+		GtkToggleButton *alt = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "alt-hotkey"));
+		GtkToggleButton *super = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "super-hotkey"));
+		int hotkey = gtk_toggle_button_get_active(ctrl) |
+					 gtk_toggle_button_get_active(alt) << 1 |
+					 gtk_toggle_button_get_active(super) << 2;
+		if (hotkey == 0)
+			return;
+		PrefsReplaceInt32("hotkey", hotkey);
 	}
-}
 
-// Adds the MB suffix to the value entered by the user
-void cb_format_jitcachesize (GtkWidget *widget)
-{
-	int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
-	if (size_mb < 1)
-		size_mb = 1;
-	if (size_mb > 128)
-		size_mb = 16;
-	char *text = g_strdup_printf("%d MB", size_mb);
-	gtk_entry_set_text(GTK_ENTRY(widget), text);
-	g_free(text);
-}
-
-// Saves the new JIT cache size preference
-void cb_jitcachesize (GtkWidget *widget)
-{
-	int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
-	if (size_mb >= 1 && size_mb <= 128)
+	// Adds the MB suffix to the value entered by the user
+	void cb_format_ramsize(GtkWidget *widget)
 	{
-		int size_kb = size_mb << 10;
-		PrefsReplaceInt32("jitcachesize", size_kb);
+		int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
+		if (size_mb < 4)
+			size_mb = 4;
+		if (size_mb > 1024)
+			size_mb = 1024;
+		char *text = g_strdup_printf("%d MB", size_mb);
+		gtk_entry_set_text(GTK_ENTRY(widget), text);
+		g_free(text);
 	}
-}
 
-// Saves the new cpu and fpu preferences
-void cb_cpu (GtkWidget *widget)
-{
-	int value = atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
-	int cpu = value >> 1;
-	bool fpu = false;
-	if (value & 1)
-		fpu = true;
-	PrefsReplaceInt32("cpu", cpu);
-	PrefsReplaceBool("fpu", fpu);
-}
+	// Saves the new ram size preference
+	void cb_ramsize(GtkWidget *widget)
+	{
+		int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
+		if (size_mb >= 4 && size_mb <= 1024)
+		{
+			int size_bytes = size_mb << 20;
+			PrefsReplaceInt32("ramsize", size_bytes);
+		}
+	}
 
-// Save the id of the selected combo box item to its associated preference
-void cb_combo_int (GtkWidget *widget)
-{
-	PrefsReplaceInt32(gtk_widget_get_name(widget), atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget))));
-}
+	// Adds the MB suffix to the value entered by the user
+	void cb_format_jitcachesize(GtkWidget *widget)
+	{
+		int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
+		if (size_mb < 1)
+			size_mb = 1;
+		if (size_mb > 128)
+			size_mb = 16;
+		char *text = g_strdup_printf("%d MB", size_mb);
+		gtk_entry_set_text(GTK_ENTRY(widget), text);
+		g_free(text);
+	}
 
-void cb_combo_str (GtkWidget *widget)
-{
-	PrefsReplaceString(gtk_widget_get_name(widget), gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
-}
+	// Saves the new JIT cache size preference
+	void cb_jitcachesize(GtkWidget *widget)
+	{
+		int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
+		if (size_mb >= 1 && size_mb <= 128)
+		{
+			int size_kb = size_mb << 10;
+			PrefsReplaceInt32("jitcachesize", size_kb);
+		}
+	}
 
-// Save the value of the combo box entry to its associated preference
-void cb_combo_entry_int (GtkWidget *widget)
-{
-	PrefsReplaceInt32(gtk_widget_get_name(widget),
-	                  atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget))));
-}
+	// Saves the new cpu and fpu preferences
+	void cb_cpu(GtkWidget *widget)
+	{
+		int value = atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
+		int cpu = value >> 1;
+		bool fpu = false;
+		if (value & 1)
+			fpu = true;
+		PrefsReplaceInt32("cpu", cpu);
+		PrefsReplaceBool("fpu", fpu);
+	}
 
-void cb_combo_entry_str (GtkWidget *widget)
-{
-	PrefsReplaceString(gtk_widget_get_name(widget),
-	                   gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
-}
+	// Save the id of the selected combo box item to its associated preference
+	void cb_combo_int(GtkWidget *widget)
+	{
+		PrefsReplaceInt32(gtk_widget_get_name(widget), atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget))));
+	}
 
-// Save the value of the spin button to its associated preference
-void cb_spin_button (GtkWidget *widget)
-{
-	PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget)));
-}
+	void cb_combo_str(GtkWidget *widget)
+	{
+		PrefsReplaceString(gtk_widget_get_name(widget), gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
+	}
 
-// Save the value of the check box to its associated preference
-void cb_check_box (GtkWidget *widget)
-{
-	PrefsReplaceBool(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-}
+	// Save the value of the combo box entry to its associated preference
+	void cb_combo_entry_int(GtkWidget *widget)
+	{
+		PrefsReplaceInt32(gtk_widget_get_name(widget),
+						  atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget))));
+	}
 
-// Save the value of the check box as an int to its associated preference
-void cb_check_box_int (GtkWidget *widget)
-{
-	PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-}
+	void cb_combo_entry_str(GtkWidget *widget)
+	{
+		PrefsReplaceString(gtk_widget_get_name(widget),
+						   gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
+	}
 
-// Save the value of the check box (inverted) to its associated preference
-void cb_check_box_inv (GtkWidget *widget)
-{
-	PrefsReplaceBool(gtk_widget_get_name(widget), !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-}
+	// Save the value of the spin button to its associated preference
+	void cb_spin_button(GtkWidget *widget)
+	{
+		PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget)));
+	}
 
-// Save the contents of the entry to its associated preference
-void cb_entry (GtkWidget *widget)
-{
-	if (gtk_entry_get_text_length(GTK_ENTRY(widget)))
-		PrefsReplaceString(gtk_widget_get_name(widget), gtk_entry_get_text(GTK_ENTRY(widget)));
-	else
-		PrefsRemoveItem(gtk_widget_get_name(widget));
-}
+	// Save the value of the check box to its associated preference
+	void cb_check_box(GtkWidget *widget)
+	{
+		PrefsReplaceBool(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+	}
 
-// Display the info bar
-void cb_infobar_show (GtkWidget *widget)
-{
+	// Save the value of the check box as an int to its associated preference
+	void cb_check_box_int(GtkWidget *widget)
+	{
+		PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+	}
+
+	// Save the value of the check box (inverted) to its associated preference
+	void cb_check_box_inv(GtkWidget *widget)
+	{
+		PrefsReplaceBool(gtk_widget_get_name(widget), !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+	}
+
+	// Save the contents of the entry to its associated preference
+	void cb_entry(GtkWidget *widget)
+	{
+		if (gtk_entry_get_text_length(GTK_ENTRY(widget)))
+			PrefsReplaceString(gtk_widget_get_name(widget), gtk_entry_get_text(GTK_ENTRY(widget)));
+		else
+			PrefsRemoveItem(gtk_widget_get_name(widget));
+	}
+
+	// Display the info bar
+	void cb_infobar_show(GtkWidget *widget)
+	{
 #if GTK_CHECK_VERSION(3, 22, 29)
-	/* Workaround for the fact that having the revealed property in the XML is not valid
-	in older GTK versions. Instead we hide it until it is about to be revealed. */
-	if (!gtk_widget_get_visible(widget))
-	{
-		gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), false);
+		/* Workaround for the fact that having the revealed property in the XML is not valid
+		in older GTK versions. Instead we hide it until it is about to be revealed. */
+		if (!gtk_widget_get_visible(widget))
+		{
+			gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), false);
+			gtk_widget_show(widget);
+		}
+		gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), true);
+#else
 		gtk_widget_show(widget);
+#endif
 	}
-	gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), true);
-#else
-	gtk_widget_show(widget);
-#endif
-}
 
-// Close the info bar
-void cb_infobar_hide (GtkWidget *widget)
-{
+	// Close the info bar
+	void cb_infobar_hide(GtkWidget *widget)
+	{
 #if GTK_CHECK_VERSION(3, 22, 29)
-	gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), false);
+		gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), false);
 #else
-	gtk_widget_hide(GTK_WIDGET(widget));
+		gtk_widget_hide(GTK_WIDGET(widget));
 #endif
-}
+	}
 
-void cb_swap_opt_cmd (GtkWidget *widget)
-{
-	bool swapped = PrefsFindBool("swap_opt_cmd");
-	GtkLabel *opt_label = GTK_LABEL(gtk_builder_get_object(builder, "opt-label"));
-	GtkLabel *cmd_label = GTK_LABEL(gtk_builder_get_object(builder, "cmd-label"));
-	gtk_label_set_text(opt_label, swapped ? "Super" : "Alt");
-	gtk_label_set_text(cmd_label, swapped ? "Alt" : "Super");
-}
+	void cb_swap_opt_cmd(GtkWidget *widget)
+	{
+		bool swapped = PrefsFindBool("swap_opt_cmd");
+		GtkLabel *opt_label = GTK_LABEL(gtk_builder_get_object(builder, "opt-label"));
+		GtkLabel *cmd_label = GTK_LABEL(gtk_builder_get_object(builder, "cmd-label"));
+		gtk_label_set_text(opt_label, swapped ? "Super" : "Alt");
+		gtk_label_set_text(cmd_label, swapped ? "Alt" : "Super");
+	}
 
 } // extern "C"
 
 // Read and set mouse wheel mode preference
-static void get_mouse_wheel_mode (void)
+static void get_mouse_wheel_mode(void)
 {
 	GtkToggleButton *page = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "mousewheelmode-inv"));
 	GtkToggleButton *cursor = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "mousewheelmode"));
@@ -1251,7 +1259,7 @@ static void get_mouse_wheel_mode (void)
 }
 
 // Read and convert graphics preferences
-static void get_graphics_settings (void)
+static void get_graphics_settings(void)
 {
 	display_type = DISPLAY_WINDOW;
 	dis_width = 640;
@@ -1263,48 +1271,57 @@ static void get_graphics_settings (void)
 	mag_rate = GTK_ENTRY(gtk_builder_get_object(builder, "mag_rate"));
 
 	const char *str = PrefsFindString("screen");
-	if (str) {
+	if (str)
+	{
 		if (sscanf(str, "win/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_WINDOW;
 		else if (sscanf(str, "dga/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_SCREEN;
-		else if (sscanf(str, "fbdev/%d/%d", &dis_width, &dis_height) == 2) {
+		else if (sscanf(str, "fbdev/%d/%d", &dis_width, &dis_height) == 2)
+		{
 #ifdef ENABLE_FBDEV_DGA
 			is_fbdev_dga_mode = true;
 #endif
 			display_type = DISPLAY_SCREEN;
 		}
 	}
-	else {
+	else
+	{
 		uint32_t window_modes = PrefsFindInt32("windowmodes");
 		uint32_t screen_modes = PrefsFindInt32("screenmodes");
-		if (screen_modes) {
+		if (screen_modes)
+		{
 			display_type = DISPLAY_SCREEN;
-			static const struct {
+			static const struct
+			{
 				int id;
 				int width;
 				int height;
-			}
-			modes[] = {
-				{  1,	 640,	 480 },
-				{  2,	 800,	 600 },
-				{  4,	1024,	 768 },
-				{ 64,	1152,	 768 },
-				{  8,	1152,	 900 },
-				{ 16,	1280,	1024 },
-				{ 32,	1600,	1200 },
-				{ 0, }
-			};
-			for (int i = 0; modes[i].id != 0; i++) {
-				if (screen_modes & modes[i].id) {
-					if (modes[i].width <= screen_width && modes[i].height <= screen_height) {
+			} modes[] = {
+				{1, 640, 480},
+				{2, 800, 600},
+				{4, 1024, 768},
+				{64, 1152, 768},
+				{8, 1152, 900},
+				{16, 1280, 1024},
+				{32, 1600, 1200},
+				{
+					0,
+				}};
+			for (int i = 0; modes[i].id != 0; i++)
+			{
+				if (screen_modes & modes[i].id)
+				{
+					if (modes[i].width <= screen_width && modes[i].height <= screen_height)
+					{
 						dis_width = modes[i].width;
 						dis_height = modes[i].height;
 					}
 				}
 			}
 		}
-		else if (window_modes) {
+		else if (window_modes)
+		{
 			display_type = DISPLAY_WINDOW;
 			if (window_modes & 1)
 				dis_width = 640, dis_height = 480;
@@ -1316,7 +1333,7 @@ static void get_graphics_settings (void)
 		dis_width = 0;
 	if (dis_height == screen_height)
 		dis_height = 0;
-	gtk_toggle_button_set_active ((display_type ? screen_full : screen_win), true);
+	gtk_toggle_button_set_active((display_type ? screen_full : screen_win), true);
 	char *res_str = g_strdup_printf("%d x %d", dis_width, dis_height);
 	if (!gtk_combo_box_set_active_id(screen_res, res_str))
 	{
@@ -1326,7 +1343,8 @@ static void get_graphics_settings (void)
 
 	// scaling
 	const char *mag_rate_str = PrefsFindString("mag_rate");
-	if (!mag_rate_str) {
+	if (!mag_rate_str)
+	{
 		mag_rate_str = "1.0";
 	}
 	gtk_entry_set_text(GTK_ENTRY(mag_rate), mag_rate_str);
@@ -1334,25 +1352,32 @@ static void get_graphics_settings (void)
 }
 
 // Add names of serial devices
-static GList *add_serial_names (void)
+static GList *add_serial_names(void)
 {
 	GList *glist = NULL;
 
 	// Search /dev for ttyS* and lp*
 	DIR *d = opendir("/dev");
-	if (d) {
+	if (d)
+	{
 		struct dirent *de;
-		while ((de = readdir(d)) != NULL) {
+		while ((de = readdir(d)) != NULL)
+		{
 #if defined(__linux__)
-			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0) {
+			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0)
+			{
 #elif defined(__FreeBSD__)
-			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
+			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
+			{
 #elif defined(__NetBSD__)
-			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
+			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
+			{
 #elif defined(sgi)
-			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0) {
+			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0)
+			{
 #else
-			if (false) {
+			if (false)
+			{
 #endif
 				char *str = g_strdup_printf("/dev/%s", de->d_name);
 				glist = g_list_append(glist, str);
@@ -1366,27 +1391,33 @@ static GList *add_serial_names (void)
 }
 
 // Add names of ethernet interfaces
-static GList *add_ether_names (void)
+static GList *add_ether_names(void)
 {
 	GList *glist = NULL;
 
 	// Get list of all Ethernet interfaces
 	int s = socket(PF_INET, SOCK_DGRAM, 0);
-	if (s >= 0) {
+	if (s >= 0)
+	{
 		char inbuf[8192];
 		struct ifconf ifc;
 		ifc.ifc_len = sizeof(inbuf);
 		ifc.ifc_buf = inbuf;
-		if (ioctl(s, SIOCGIFCONF, &ifc) == 0) {
+		if (ioctl(s, SIOCGIFCONF, &ifc) == 0)
+		{
 			struct ifreq req, *ifr = ifc.ifc_req;
-			for (int i=0; i<ifc.ifc_len; i+=sizeof(ifreq), ifr++) {
+			for (int i = 0; i < ifc.ifc_len; i += sizeof(ifreq), ifr++)
+			{
 				req = *ifr;
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(sgi)
-				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER+1)) {
+				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER + 1))
+				{
 #elif defined(__linux__)
-				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
+				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER)
+				{
 #else
-				if (false) {
+				if (false)
+				{
 #endif
 					char *str = new char[64];
 					strncpy(str, ifr->ifr_name, 63);
@@ -1415,15 +1446,15 @@ static GList *add_ether_names (void)
  */
 
 uint8_t XPRAM[XPRAM_SIZE];
-void MountVolume(void *fh) { }
-void FileDiskLayout(loff_t size, uint8_t *data, loff_t &start_byte, loff_t &real_size) { }
+void MountVolume(void *fh) {}
+void FileDiskLayout(loff_t size, uint8_t *data, loff_t &start_byte, loff_t &real_size) {}
 
 #if defined __APPLE__ && defined __MACH__
-void DarwinSysInit(void) { }
-void DarwinSysExit(void) { }
-void DarwinAddFloppyPrefs(void) { }
-void DarwinAddSerialPrefs(void) { }
-bool DarwinCDReadTOC(char *, uint8_t *) { }
+void DarwinSysInit(void) {}
+void DarwinSysExit(void) {}
+void DarwinAddFloppyPrefs(void) {}
+void DarwinAddSerialPrefs(void) {}
+bool DarwinCDReadTOC(char *, uint8_t *) {}
 #endif
 
 static GCallback dl_destroyed(GtkWidget *dialog)
@@ -1436,11 +1467,11 @@ static GCallback dl_destroyed(GtkWidget *dialog)
 void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 {
 	GtkWidget *dialog = gtk_message_dialog_new(NULL,
-						GTK_DIALOG_MODAL,
-						GTK_MESSAGE_WARNING,
-						GTK_BUTTONS_NONE,
-						GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+											   GTK_DIALOG_MODAL,
+											   GTK_MESSAGE_WARNING,
+											   GTK_BUTTONS_NONE,
+											   GetString(title_id), NULL);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);
@@ -1452,21 +1483,19 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
  *  Display error alert
  */
 
-void ErrorAlert (const char *text)
+void ErrorAlert(const char *text)
 {
 	display_alert(STR_ERROR_ALERT_TITLE, STR_GUI_ERROR_PREFIX, STR_QUIT_BUTTON, text);
 }
-
 
 /*
  *  Display warning alert
  */
 
-void WarningAlert (const char *text)
+void WarningAlert(const char *text)
 {
 	display_alert(STR_WARNING_ALERT_TITLE, STR_GUI_WARNING_PREFIX, STR_OK_BUTTON, text);
 }
-
 
 /*
  *  RPC handlers
@@ -1510,7 +1539,6 @@ static int handle_Exit(rpc_connection_t *connection)
 	return RPC_ERROR_NO_ERROR;
 }
 
-
 /*
  *  SIGCHLD handler
  */
@@ -1518,7 +1546,7 @@ static int handle_Exit(rpc_connection_t *connection)
 static char g_app_path[PATH_MAX];
 static rpc_connection_t *g_gui_connection = NULL;
 
-static void sigchld_handler (int sig, siginfo_t *sip, void *)
+static void sigchld_handler(int sig, siginfo_t *sip, void *)
 {
 	D(bug("Child %d exitted with status = %x\n", sip->si_pid, sip->si_status));
 
@@ -1531,28 +1559,29 @@ static void sigchld_handler (int sig, siginfo_t *sip, void *)
 	if (WIFEXITED(status))
 		status = WEXITSTATUS(status);
 	if (status & 0x80)
-		status |= -1 ^0xff;
+		status |= -1 ^ 0xff;
 
-	if (status < 0) {	// negative -> execlp/-errno
+	if (status < 0)
+	{ // negative -> execlp/-errno
 		char *str = g_strdup_printf(GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(-status));
 		ErrorAlert(str);
 		status = 1;
 		g_free(str);
 	}
 
-	if (status != 0) {
+	if (status != 0)
+	{
 		if (g_gui_connection)
 			rpc_exit(g_gui_connection);
 		exit(status);
 	}
 }
 
-
 /*
  *  Start standalone GUI
  */
 
-int main (int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 	// Read preferences
 	PrefsInit(0, argc, argv);
@@ -1563,13 +1592,15 @@ int main (int argc, char *argv[])
 	PrefsExit();
 
 	// Transfer control to the executable
-	if (start) {
+	if (start)
+	{
 		// Catch exits from the child process
 		struct sigaction sigchld_sa, old_sigchld_sa;
 		sigemptyset(&sigchld_sa.sa_mask);
 		sigchld_sa.sa_sigaction = sigchld_handler;
 		sigchld_sa.sa_flags = SA_NOCLDSTOP | SA_SIGINFO;
-		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0) {
+		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0)
+		{
 			char *str = g_strdup_printf(GetString(STR_SIG_INSTALL_ERR), SIGCHLD, strerror(errno));
 			ErrorAlert(str);
 			return 1;
@@ -1579,15 +1610,19 @@ int main (int argc, char *argv[])
 		// Search and run the SheepShaver executable
 		char *p;
 		strcpy(g_app_path, argv[0]);
-		if ((p = strstr(g_app_path, "SheepShaverGUI.app/Contents/MacOS")) != NULL) {
+		if ((p = strstr(g_app_path, "SheepShaverGUI.app/Contents/MacOS")) != NULL)
+		{
 			strcpy(p, "SheepShaver.app/Contents/MacOS/SheepShaver");
-			if (access(g_app_path, X_OK) < 0) {
+			if (access(g_app_path, X_OK) < 0)
+			{
 				char *str = g_strdup_printf(GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(errno));
 				WarningAlert(str);
 				strcpy(g_app_path, "/Applications/SheepShaver.app/Contents/MacOS/SheepShaver");
 				g_free(str);
 			}
-		} else {
+		}
+		else
+		{
 			p = strrchr(g_app_path, '/');
 			p = p ? p + 1 : g_app_path;
 			strcpy(p, "SheepShaver");
@@ -1595,7 +1630,8 @@ int main (int argc, char *argv[])
 
 		char *gui_connection_path = g_strdup_printf("/org/SheepShaver/GUI/%d", getpid());
 		int pid = fork();
-		if (pid == 0) {
+		if (pid == 0)
+		{
 			D(bug("Trying to execute %s\n", g_app_path));
 			execlp(g_app_path, g_app_path, "--gui-connection", gui_connection_path, (char *)NULL);
 			g_free(gui_connection_path);
@@ -1607,7 +1643,8 @@ int main (int argc, char *argv[])
 		}
 
 		// Establish a connection to Basilisk II
-		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL) {
+		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL)
+		{
 			printf("ERROR: failed to initialize GUI-side RPC server connection\n");
 			g_free(gui_connection_path);
 			return 1;
@@ -1615,26 +1652,29 @@ int main (int argc, char *argv[])
 		g_free(gui_connection_path);
 
 		static const rpc_method_descriptor_t vtable[] = {
-			{ RPC_METHOD_ERROR_ALERT,			handle_ErrorAlert },
-			{ RPC_METHOD_WARNING_ALERT,			handle_WarningAlert },
-			{ RPC_METHOD_EXIT,					handle_Exit }
-		};
-		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0) {
+			{RPC_METHOD_ERROR_ALERT, handle_ErrorAlert},
+			{RPC_METHOD_WARNING_ALERT, handle_WarningAlert},
+			{RPC_METHOD_EXIT, handle_Exit}};
+		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0)
+		{
 			printf("ERROR: failed to setup GUI method callbacks\n");
 			return 1;
 		}
 		int socket;
-		if ((socket = rpc_listen_socket(g_gui_connection)) < 0) {
+		if ((socket = rpc_listen_socket(g_gui_connection)) < 0)
+		{
 			printf("ERROR: failed to initialize RPC server thread\n");
 			return 1;
 		}
 
 		g_gui_loop = g_main_new(TRUE);
-		while (g_main_is_running(g_gui_loop)) {
+		while (g_main_is_running(g_gui_loop))
+		{
 
 			// Process a few events pending
 			const int N_EVENTS_DISPATCH = 10;
-			for (int i = 0; i < N_EVENTS_DISPATCH; i++) {
+			for (int i = 0; i < N_EVENTS_DISPATCH; i++)
+			{
 				if (!g_main_iteration(FALSE))
 					break;
 			}

--- a/BasiliskII/src/Unix/prefs_editor_gtk3.cpp
+++ b/BasiliskII/src/Unix/prefs_editor_gtk3.cpp
@@ -50,8 +50,8 @@
 
 // Global variables
 static GtkBuilder *builder;
-static GtkWidget *win;					// Preferences window
-static bool start_clicked = false;		// Return value of PrefsEditor() function
+static GtkWidget *win;				// Preferences window
+static bool start_clicked = false;	// Return value of PrefsEditor() function
 static int screen_width, screen_height; // Screen dimensions
 
 static GtkAdjustment *size_adj;
@@ -73,21 +73,19 @@ static int dis_width, dis_height;
 static bool is_fbdev_dga_mode = false;
 #endif
 
-struct opt_desc
-{
+struct opt_desc {
 	int label_id;
 	GCallback func;
 };
 
-struct combo_desc
-{
+struct combo_desc {
 	int label_id;
 };
 
-static GtkWidget *create_tree_view(void);
-static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data);
-static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data);
-static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data);
+static GtkWidget *create_tree_view (void);
+static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data);
+static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data);
+static void cb_remove_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data);
 static GList *add_serial_names(void);
 static GList *add_ether_names(void);
 static void save_volumes(void);
@@ -107,7 +105,7 @@ const char *authors[] = {"Christian Bauer", "Marc Hellwig", "Gwenolé Beauchesne
 const char *authors[] = {
 	"Christian Bauer", "Orlando Bassotto", "Gwenolé Beauchesne", "Marc Chabanas", "Marc Hellwig",
 	"Bill Huey", "Brian J. Johnson", "Jürgen Lachmann", "Samuel Lander", "David Lawrence",
-	"Lauri Pesonen", "Bernd Schmidt", "and others", NULL};
+	"Lauri Pesonen", "Bernd Schmidt", "and others", NULL };
 #endif
 
 #if REAL_ADDRESSING
@@ -117,7 +115,7 @@ const char *authors[] = {
 #endif
 
 #if defined(USE_SDL_AUDIO) && defined(USE_SDL_VIDEO)
-#if SDL_VERSION_ATLEAST(2, 0, 0)
+#if SDL_VERSION_ATLEAST(2,0,0)
 #define ABOUT_VIDEO "SDL 2 audio"
 #else
 #define ABOUT_VIDEO "SDL 1.2 audio"
@@ -125,7 +123,7 @@ const char *authors[] = {
 #define ABOUT_AUDIO "video"
 #else
 #ifdef USE_SDL_AUDIO
-#if SDL_VERSION_ATLEAST(2, 0, 0)
+#if SDL_VERSION_ATLEAST(2,0,0)
 #define ABOUT_AUDIO "SDL 2 audio"
 #else
 #define ABOUT_AUDIO "SDL 1.2 audio"
@@ -136,7 +134,7 @@ const char *authors[] = {
 #define ABOUT_AUDIO "no audio"
 #endif
 #ifdef USE_SDL_VIDEO
-#if SDL_VERSION_ATLEAST(2, 0, 0)
+#if SDL_VERSION_ATLEAST(2,0,0)
 #define ABOUT_VIDEO "SDL 2 video"
 #else
 #define ABOUT_VIDEO "SDL 1.2 video"
@@ -155,14 +153,14 @@ const char *sysinfo = ABOUT_MODE "\nBuilt with " ABOUT_VIDEO " and " ABOUT_AUDIO
 // The widgets from prefs-editor.ui that need their values set on launch
 const char *check_boxes[] = {
 	"udptunnel", "keycodes", "ignoresegv", "idlewait", "jit", "jitfpu", "jitinline",
-	"jitlazyflush", "jit68k", "gfxaccel", "swap_opt_cmd", "scale_nearest", "scale_integer", NULL};
-const char *inv_check_boxes[] = {"nocdrom", "nosound", "nogui", NULL};
+	"jitlazyflush", "jit68k", "gfxaccel", "swap_opt_cmd", "scale_nearest", "scale_integer", NULL };
+const char *inv_check_boxes[] = { "nocdrom", "nosound", "nogui", NULL };
 const char *entries[] = {
 	"extfs", "dsp", "mixer", "keycodefile", "scsi0", "scsi1", "scsi2", "scsi3", "scsi4",
-	"scsi5", "scsi6", "rom", NULL};
-const char *spin_buttons[] = {"mousewheellines", "udpport", NULL};
-const char *id_combos[] = {"bootdriver", "frameskip", "modelid", NULL};
-const char *text_combos[] = {"ramsize", NULL};
+	"scsi5", "scsi6", "rom", NULL };
+const char *spin_buttons[] = { "mousewheellines", "udpport", NULL };
+const char *id_combos[] = { "bootdriver", "frameskip", "modelid", NULL };
+const char *text_combos[] = { "ramsize", NULL };
 
 // Set initial widget states
 static void set_initial_prefs(void)
@@ -171,15 +169,15 @@ static void set_initial_prefs(void)
 	while (*id)
 	{
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, *id)),
-									 PrefsFindBool(*id));
+		                             PrefsFindBool(*id));
 		id++;
 	}
 
 	id = inv_check_boxes;
-	while (*id)
+	while(*id)
 	{
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, *id)),
-									 !PrefsFindBool(*id));
+		                             !PrefsFindBool(*id));
 		id++;
 	}
 	cb_swap_opt_cmd(NULL);
@@ -189,7 +187,7 @@ static void set_initial_prefs(void)
 	{
 		if (PrefsFindString(*id) != NULL)
 			gtk_entry_set_text(GTK_ENTRY(gtk_builder_get_object(builder, *id)),
-							   PrefsFindString(*id));
+			                   PrefsFindString(*id));
 		id++;
 	}
 
@@ -197,7 +195,7 @@ static void set_initial_prefs(void)
 	while (*id)
 	{
 		gtk_spin_button_set_value(GTK_SPIN_BUTTON(gtk_builder_get_object(builder, *id)),
-								  PrefsFindInt32(*id));
+		                          PrefsFindInt32(*id));
 		id++;
 	}
 
@@ -224,29 +222,31 @@ static void set_initial_prefs(void)
 	}
 }
 
+
+
 // Helper functions to create a file chooser
-static GtkFileChooser *file_chooser_new(GtkWidget *parent,
-										GtkFileChooserAction action,
-										uint32_t title_id,
-										uint32_t accept_id,
-										uint32_t cancel_id,
-										const char *directory)
+static GtkFileChooser *file_chooser_new (GtkWidget *parent,
+                                         GtkFileChooserAction action,
+                                         uint32_t title_id,
+                                         uint32_t accept_id,
+                                         uint32_t cancel_id,
+                                         const char *directory)
 {
 #ifdef USE_NATIVE_FILE_CHOOSER
 	GtkFileChooserNative *chooser = gtk_file_chooser_native_new(GetString(title_id),
-																GTK_WINDOW(parent),
-																action,
-																GetString(accept_id),
-																GetString(cancel_id));
+	                                                            GTK_WINDOW(parent),
+	                                                            action,
+	                                                            GetString(accept_id),
+	                                                            GetString(cancel_id));
 	gtk_native_dialog_set_transient_for(GTK_NATIVE_DIALOG(chooser), GTK_WINDOW(parent));
 	gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), true);
 #else
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(title_id),
-													 GTK_WINDOW(parent),
-													 action,
-													 GetString(cancel_id), GTK_RESPONSE_CANCEL,
-													 GetString(accept_id), GTK_RESPONSE_ACCEPT,
-													 NULL);
+	                                                 GTK_WINDOW(parent),
+	                                                 action,
+	                                                 GetString(cancel_id), GTK_RESPONSE_CANCEL,
+	                                                 GetString(accept_id), GTK_RESPONSE_ACCEPT,
+	                                                 NULL);
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
 	gtk_window_set_modal(GTK_WINDOW(chooser), true);
@@ -275,89 +275,86 @@ static void file_chooser_destroy(GtkFileChooser *chooser)
 	g_object_unref(G_OBJECT(chooser));
 }
 
+
 // User closed the file chooser dialog, possibly selecting a file
 static void cb_browse_response(GtkFileChooser *chooser, int response, GtkEntry *entry)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
 		char *filename;
-		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
+		filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (chooser));
 		gtk_entry_set_text(GTK_ENTRY(entry), filename);
-		g_free(filename);
+		g_free (filename);
 	}
-	file_chooser_destroy(chooser);
+	file_chooser_destroy (chooser);
 }
 
-extern "C"
+extern "C" {
+
+// Open the file chooser dialog to select a file
+void cb_browse(GtkWidget *button, GtkWidget *entry)
 {
+	GtkFileChooser *chooser = file_chooser_new(win,
+	                                           GTK_FILE_CHOOSER_ACTION_OPEN,
+	                                           STR_BROWSE_TITLE,
+	                                           STR_SELECT_BUTTON,
+	                                           STR_CANCEL_BUTTON,
+	                                           gtk_entry_get_text(GTK_ENTRY(entry)));
+	g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_ENTRY(entry));
+	file_chooser_show(chooser);
+}
 
-	// Open the file chooser dialog to select a file
-	void cb_browse(GtkWidget *button, GtkWidget *entry)
-	{
-		GtkFileChooser *chooser = file_chooser_new(win,
-												   GTK_FILE_CHOOSER_ACTION_OPEN,
-												   STR_BROWSE_TITLE,
-												   STR_SELECT_BUTTON,
-												   STR_CANCEL_BUTTON,
-												   gtk_entry_get_text(GTK_ENTRY(entry)));
-		g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_ENTRY(entry));
-		file_chooser_show(chooser);
+// Open the file chooser dialog to select a folder
+void cb_browse_dir(GtkWidget *button, GtkWidget *entry)
+{
+	GtkFileChooser *chooser = file_chooser_new(win,
+	                                           GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+	                                           STR_BROWSE_FOLDER_TITLE,
+	                                           STR_SELECT_BUTTON,
+	                                           STR_CANCEL_BUTTON,
+	                                           gtk_entry_get_text(GTK_ENTRY(entry)));
+	g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_WIDGET(entry));
+	file_chooser_show(chooser);
+}
+
+// User changed scaling settings
+void cb_scaling(GtkWidget * widget)
+{
+	const char *mag_rate_str = gtk_entry_get_text(GTK_ENTRY(mag_rate));
+	if (mag_rate_str) {
+		PrefsReplaceString("mag_rate", mag_rate_str);
+	} else {
+		PrefsRemoveItem("mag_rate");
 	}
+}
 
-	// Open the file chooser dialog to select a folder
-	void cb_browse_dir(GtkWidget *button, GtkWidget *entry)
+// User changed one of the screen mode settings
+void cb_screen_mode(GtkWidget *widget)
+{
+	const char *res = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(screen_res));
+	if (res)
 	{
-		GtkFileChooser *chooser = file_chooser_new(win,
-												   GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
-												   STR_BROWSE_FOLDER_TITLE,
-												   STR_SELECT_BUTTON,
-												   STR_CANCEL_BUTTON,
-												   gtk_entry_get_text(GTK_ENTRY(entry)));
-		g_signal_connect(chooser, "response", G_CALLBACK(cb_browse_response), GTK_WIDGET(entry));
-		file_chooser_show(chooser);
-	}
-
-	// User changed scaling settings
-	void cb_scaling(GtkWidget *widget)
-	{
-		const char *mag_rate_str = gtk_entry_get_text(GTK_ENTRY(mag_rate));
-		if (mag_rate_str)
+		if (g_strcmp0(res, GetString(STR_SIZE_MAX_LAB)) == 0)
 		{
-			PrefsReplaceString("mag_rate", mag_rate_str);
+			dis_width = 0;
+			dis_height = 0;
 		}
 		else
-		{
-			PrefsRemoveItem("mag_rate");
-		}
+			sscanf(res, "%d x %d", &dis_width, &dis_height);
 	}
-
-	// User changed one of the screen mode settings
-	void cb_screen_mode(GtkWidget *widget)
-	{
-		const char *res = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(screen_res));
-		if (res)
-		{
-			if (g_strcmp0(res, GetString(STR_SIZE_MAX_LAB)) == 0)
-			{
-				dis_width = 0;
-				dis_height = 0;
-			}
-			else
-				sscanf(res, "%d x %d", &dis_width, &dis_height);
-		}
 
 #ifdef ENABLE_FBDEV_DGA
-		const char *str = gtk_toggle_button_get_active(screen_full) ? "fbdev/%d/%d" : "win/%d/%d";
+	const char *str = gtk_toggle_button_get_active(screen_full) ? "fbdev/%d/%d" : "win/%d/%d";
 #else
-		const char *str = gtk_toggle_button_get_active(screen_full) ? "dga/%d/%d" : "win/%d/%d";
+	const char *str = gtk_toggle_button_get_active(screen_full) ? "dga/%d/%d" : "win/%d/%d";
 #endif
-		char *screen = g_strdup_printf(str, dis_width, dis_height);
-		PrefsReplaceString("screen", screen);
-		// Old prefs are now migrated
-		PrefsRemoveItem("windowmodes");
-		PrefsRemoveItem("screenmodes");
-		g_free(screen);
-	}
+	char *screen = g_strdup_printf(str, dis_width, dis_height);
+	PrefsReplaceString("screen", screen);
+	// Old prefs are now migrated
+	PrefsRemoveItem("windowmodes");
+	PrefsRemoveItem("screenmodes");
+	g_free(screen);
+}
 
 } // extern "C"
 
@@ -401,7 +398,7 @@ static void set_hotkey_buttons(void)
 	gtk_toggle_button_set_active(super, hotkey & 4);
 }
 
-static void set_cpu_combo_box(void)
+static void set_cpu_combo_box (void)
 {
 	GtkComboBox *combo = GTK_COMBO_BOX(gtk_builder_get_object(builder, "cpu"));
 	int32_t cpu = PrefsFindInt32("cpu");
@@ -419,7 +416,7 @@ static GtkWidget *add_combo_box_values(GList *entries, const char *pref)
 	list = entries;
 	while (list)
 	{
-		gtk_combo_box_text_prepend(GTK_COMBO_BOX_TEXT(combo), ((char *)list->data), ((char *)list->data));
+		gtk_combo_box_text_prepend(GTK_COMBO_BOX_TEXT(combo), ((char *) list->data), ((char *) list->data));
 		list = list->next;
 	}
 
@@ -451,7 +448,7 @@ static void run_emulator()
 	gtk_widget_destroy(win);
 }
 // "Start" button clicked
-static void cb_start(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_start (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	if (access(PrefsFindString("rom"), F_OK) != 0)
 	{
@@ -464,14 +461,14 @@ static void cb_start(GSimpleAction *action, GVariant *parameter, gpointer user_d
 
 // "Save Settings" menu item clicked
 static void
-cb_save_settings(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+cb_save_settings (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	save_volumes();
 	SavePrefs();
 }
 
 // "Quit" button clicked
-static void cb_quit(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_quit (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	start_clicked = false;
 	gtk_widget_destroy(win);
@@ -484,25 +481,25 @@ extern "C" void dl_quit(GtkWidget *dialog)
 }
 
 // "About" selected
-static void mn_about(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void mn_about (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
-	char *version = g_strdup_printf("%d.%d", VERSION_MAJOR, VERSION_MINOR);
+    char *version = g_strdup_printf("%d.%d", VERSION_MAJOR, VERSION_MINOR);
 	gtk_show_about_dialog(GTK_WINDOW(win),
-						  "version", version,
-						  "copyright", sysinfo,
-						  "authors", authors,
-						  "comments", GetString(STR_ABOUT_COMMENTS),
-						  "website", GetString(STR_ABOUT_WEBSITE),
-						  "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
-						  "license", GetString(STR_ABOUT_LICENSE),
-						  "wrap-license", true,
-						  "logo-icon-name", GetString(STR_APP_NAME),
-						  NULL);
-	g_free(version);
+	                      "version", version,
+	                      "copyright", sysinfo,
+	                      "authors", authors,
+	                      "comments", GetString(STR_ABOUT_COMMENTS),
+	                      "website", GetString(STR_ABOUT_WEBSITE),
+	                      "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
+	                      "license", GetString(STR_ABOUT_LICENSE),
+	                      "wrap-license", true,
+	                      "logo-icon-name", GetString(STR_APP_NAME),
+	                      NULL);
+    g_free(version);
 }
 
 // "Help" selected
-static void mn_help(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void mn_help (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 #if GTK_CHECK_VERSION(3, 22, 0)
 	gtk_show_uri_on_window(GTK_WINDOW(win), "https://github.com/kanjitalk755/macemu", GDK_CURRENT_TIME, NULL);
@@ -512,22 +509,22 @@ static void mn_help(GSimpleAction *action, GVariant *parameter, gpointer user_da
 }
 
 // "Zap NVRAM" selected
-static void mn_zap_pram(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void mn_zap_pram (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	ZapPRAM();
 }
 
 // Action entries (used in menus and buttons)
 static GActionEntry win_entries[] = {
-	{"add-volume", cb_add_volume},
-	{"create-volume", cb_create_volume},
-	{"remove-volume", cb_remove_volume},
-	{"start", cb_start},
-	{"save-settings", cb_save_settings},
-	{"zap-pram", mn_zap_pram},
-	{"quit", cb_quit},
-	{"help", mn_help},
-	{"about", mn_about},
+	{ "add-volume", cb_add_volume },
+	{ "create-volume", cb_create_volume },
+	{ "remove-volume", cb_remove_volume },
+	{ "start", cb_start },
+	{ "save-settings", cb_save_settings },
+	{ "zap-pram", mn_zap_pram },
+	{ "quit", cb_quit },
+	{ "help", mn_help },
+	{ "about", mn_about },
 };
 
 // Hide widgets which aren't applicable to this emulator
@@ -560,12 +557,12 @@ static void set_file_menu(GtkApplication *app)
 	g_object_unref(menubuilder);
 }
 
-static void set_help_overlay(GtkApplicationWindow *win)
+static void set_help_overlay (GtkApplicationWindow *win)
 {
 #if GTK_CHECK_VERSION(3, 20, 0)
 	GtkBuilder *helpbuilder = gtk_builder_new_from_resource(G_RES_PATH "help-overlay.ui");
 	gtk_application_window_set_help_overlay(win,
-											GTK_SHORTCUTS_WINDOW(gtk_builder_get_object(helpbuilder, "emulator-shortcuts")));
+			GTK_SHORTCUTS_WINDOW(gtk_builder_get_object(helpbuilder, "emulator-shortcuts")));
 	g_object_unref(helpbuilder);
 #endif
 }
@@ -588,13 +585,13 @@ bool PrefsEditor(void)
 	GtkSettings *settings = gtk_settings_get_default();
 	if (g_strcmp0(getenv("GTK_CSD"), "0") != 0)
 	{
-		g_object_get(settings, "gtk-dialogs-use-header", &use_headerbar, NULL);
+	    g_object_get(settings, "gtk-dialogs-use-header", &use_headerbar, NULL);
 	}
 	set_file_menu(GTK_APPLICATION(app));
 
 	// Create window
 	win = GTK_WIDGET(gtk_builder_get_object(builder, "prefs-editor"));
-	g_assert(GTK_IS_APPLICATION_WINDOW(win));
+	g_assert(GTK_IS_APPLICATION_WINDOW (win));
 	gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(win));
 	set_initial_prefs();
 	set_ramsize_combo_box();
@@ -614,11 +611,11 @@ bool PrefsEditor(void)
 	set_help_overlay(GTK_APPLICATION_WINDOW(win));
 
 	gtk_window_set_title(GTK_WINDOW(win), GetString(STR_PREFS_TITLE));
-	g_action_map_add_action_entries(G_ACTION_MAP(win),
-									win_entries,
-									G_N_ELEMENTS(win_entries),
-									win);
-	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP(win), "remove-volume")), false);
+	g_action_map_add_action_entries (G_ACTION_MAP (win),
+	                                 win_entries,
+	                                 G_N_ELEMENTS (win_entries),
+	                                 win);
+	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP (win), "remove-volume")), false);
 	g_signal_connect(GTK_WIDGET(win), "delete_event", G_CALLBACK(window_closed), NULL);
 	g_signal_connect(GTK_WIDGET(win), "destroy", G_CALLBACK(window_destroyed), NULL);
 
@@ -690,16 +687,16 @@ bool PrefsEditor(void)
  */
 
 // Values for the columns of the list store
-enum
-{
+enum {
 	COLUMN_PATH,
 	COLUMN_SIZE,
 	COLUMN_CDROM,
 	N_COLUMNS
 };
 
+
 // Gets the size of the volume as a pretty string
-static const char *get_file_size(GFile *file)
+static const char* get_file_size (GFile *file)
 {
 	GFileInfo *info;
 	if (g_file_query_exists(file, NULL))
@@ -716,7 +713,7 @@ static const char *get_file_size(GFile *file)
 	g_object_unref(info);
 }
 
-static bool has_file_ext(GFile *file, const char *ext)
+static bool has_file_ext (GFile *file, const char *ext)
 {
 	char *str = g_file_get_path(file);
 	char *file_ext = g_utf8_strrchr(str, 255, '.');
@@ -725,27 +722,26 @@ static bool has_file_ext(GFile *file, const char *ext)
 	return (g_strcmp0(file_ext, ext) == 0);
 }
 
-static bool guess_if_file_is_cdrom(GFile *volume)
-{
+static bool guess_if_file_is_cdrom(GFile * volume) {
 	return has_file_ext(volume, ".iso") ||
 #ifdef BINCUE
-		   has_file_ext(volume, ".cue") ||
+		has_file_ext(volume, ".cue") ||
 #endif
-		   has_file_ext(volume, ".toast");
+		has_file_ext(volume, ".toast");
 }
 
 // User selected a volume to add
-static void cb_add_volume_response(GtkFileChooser *chooser, int response)
+static void cb_add_volume_response (GtkFileChooser *chooser, int response)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
 		GFile *volume = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(chooser));
-		gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
-		gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
-						   COLUMN_PATH, g_file_get_path(volume),
-						   COLUMN_SIZE, get_file_size(volume),
-						   COLUMN_CDROM, guess_if_file_is_cdrom(volume),
-						   -1);
+		gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
+		gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
+				COLUMN_PATH, g_file_get_path(volume),
+				COLUMN_SIZE, get_file_size(volume),
+				COLUMN_CDROM, guess_if_file_is_cdrom(volume),
+				-1);
 		g_object_unref(volume);
 	}
 	file_chooser_destroy(chooser);
@@ -753,42 +749,41 @@ static void cb_add_volume_response(GtkFileChooser *chooser, int response)
 
 // Something dropped on volume list
 static void cb_volume_drag_data_received(GtkWidget *view, GdkDragContext *drag_context, gint x, gint y, GtkSelectionData *data,
-										 guint info, guint time, gpointer user_data)
+	guint info, guint time, gpointer user_data)
 {
-	if (gtk_selection_data_get_data_type(data) == gdk_atom_intern_static_string("text/uri-list"))
-	{
+	if (gtk_selection_data_get_data_type(data) == gdk_atom_intern_static_string("text/uri-list")) {
 		// get URIs from the drag selection data and add them
-		gchar **uris = gtk_selection_data_get_uris(data);
-		for (gchar **uri = uris; *uri != NULL; uri++)
-		{
+		gchar ** uris = gtk_selection_data_get_uris(data);
+		for (gchar ** uri = uris; *uri != NULL; uri++) {
 
 			GFile *volume = g_file_new_for_uri(*uri);
-			gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
-			gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
-							   COLUMN_PATH, g_file_get_path(volume),
-							   COLUMN_SIZE, get_file_size(volume),
-							   COLUMN_CDROM, has_file_ext(volume, ".iso"),
-							   -1);
+			gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
+			gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
+			        COLUMN_PATH, g_file_get_path(volume),
+			        COLUMN_SIZE, get_file_size(volume),
+			        COLUMN_CDROM, has_file_ext(volume, ".iso"),
+			        -1);
 			g_object_unref(volume);
+
 		}
 		g_strfreev(uris);
 	}
 }
 
 // "Add Volume" button clicked
-static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkFileChooser *chooser = file_chooser_new(win,
-											   GTK_FILE_CHOOSER_ACTION_OPEN,
-											   STR_ADD_VOLUME_TITLE,
-											   STR_SELECT_BUTTON,
-											   STR_CANCEL_BUTTON,
-											   NULL);
+	                                           GTK_FILE_CHOOSER_ACTION_OPEN,
+	                                           STR_ADD_VOLUME_TITLE,
+	                                           STR_SELECT_BUTTON,
+	                                           STR_CANCEL_BUTTON,
+	                                           NULL);
 	g_signal_connect(chooser, "response", G_CALLBACK(cb_add_volume_response), NULL);
 	file_chooser_show(chooser);
 }
 
-static gboolean volume_file_create(GFile *file, uint32_t size_mb)
+static gboolean volume_file_create (GFile *file, uint32_t size_mb)
 {
 	// The dialog asks to confirm overwrite, so no need to prevent overwriting if file already exists
 	GFileOutputStream *fd = g_file_replace(file, NULL, false, G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL);
@@ -796,20 +791,19 @@ static gboolean volume_file_create(GFile *file, uint32_t size_mb)
 	{
 		g_seekable_truncate(G_SEEKABLE(fd), size_mb * 1024 * 1024, NULL, NULL);
 	}
-	else
-		return false;
+	else return false;
 	g_object_unref(fd);
 
-	gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
-	gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
-					   COLUMN_PATH, g_file_get_path(file),
-					   COLUMN_SIZE, get_file_size(file),
-					   -1);
+	gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
+	gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
+			COLUMN_PATH, g_file_get_path(file),
+			COLUMN_SIZE, get_file_size(file),
+			-1);
 	g_object_unref(file);
 	return true;
 }
 
-static void cb_volume_create_size(GtkWidget *dialog, int response, GFile *file)
+static void cb_volume_create_size (GtkWidget *dialog, int response, GFile *file)
 {
 	if (response == GTK_RESPONSE_OK)
 	{
@@ -819,7 +813,7 @@ static void cb_volume_create_size(GtkWidget *dialog, int response, GFile *file)
 }
 
 // User selected to create a new volume
-static void cb_create_volume_response(GtkFileChooser *chooser, int response, GtkEntry *size_entry)
+static void cb_create_volume_response (GtkFileChooser *chooser, int response, GtkEntry *size_entry)
 {
 	GtkWidget *dialog, *spinbutton, *box;
 	if (response == GTK_RESPONSE_ACCEPT)
@@ -832,10 +826,10 @@ static void cb_create_volume_response(GtkFileChooser *chooser, int response, Gtk
 		if (!chooser_is_widget)
 		{
 			dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-											(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
-											GTK_MESSAGE_WARNING,
-											GTK_BUTTONS_OK_CANCEL,
-											"Volume Size (MB):");
+					(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+					GTK_MESSAGE_WARNING,
+					GTK_BUTTONS_OK_CANCEL,
+					"Volume Size (MB):");
 			box = gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog));
 			size_adj = gtk_adjustment_new(atoi(VOLUME_SIZE_DEFAULT), 1, 2000, 1, 100, 100);
 			spinbutton = gtk_spin_button_new(size_adj, 10, 0);
@@ -851,10 +845,10 @@ static void cb_create_volume_response(GtkFileChooser *chooser, int response, Gtk
 		if (disk_size < 1 || disk_size > 2000)
 		{
 			GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-													   (GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
-													   GTK_MESSAGE_WARNING,
-													   GTK_BUTTONS_CLOSE,
-													   "Enter a valid size");
+					(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+					GTK_MESSAGE_WARNING,
+					GTK_BUTTONS_CLOSE,
+					"Enter a valid size");
 			gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "The volume size should be between 1 and 2000.");
 			gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(chooser));
 			g_signal_connect(dialog, "response", G_CALLBACK(dl_quit), NULL);
@@ -863,7 +857,7 @@ static void cb_create_volume_response(GtkFileChooser *chooser, int response, Gtk
 		}
 		volume_file_create(volume, disk_size);
 	}
-	file_chooser_destroy(chooser);
+	file_chooser_destroy (chooser);
 }
 
 // Doesn't run if the file chooser is displayed by the portal. We use this
@@ -874,14 +868,14 @@ static void size_entry_displayed(GtkWidget *size_entry, gpointer user_data)
 }
 
 // "Create" button clicked
-static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkFileChooser *chooser = file_chooser_new(win,
-											   GTK_FILE_CHOOSER_ACTION_SAVE,
-											   STR_CREATE_VOLUME_TITLE,
-											   STR_CREATE_BUTTON,
-											   STR_CANCEL_BUTTON,
-											   NULL);
+	                                           GTK_FILE_CHOOSER_ACTION_SAVE,
+	                                           STR_CREATE_VOLUME_TITLE,
+	                                           STR_CREATE_BUTTON,
+	                                           STR_CANCEL_BUTTON,
+	                                           NULL);
 	gtk_file_chooser_set_do_overwrite_confirmation(chooser, TRUE);
 
 	GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
@@ -908,11 +902,11 @@ static void cb_remove_enable(GtkWidget *widget)
 	bool enable = false;
 	if (selection != NULL && gtk_tree_selection_count_selected_rows(selection))
 		enable = true;
-	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP(win), "remove-volume")), enable);
+	g_simple_action_set_enabled(G_SIMPLE_ACTION(g_action_map_lookup_action(G_ACTION_MAP (win), "remove-volume")), enable);
 }
 
 // "Remove" button clicked
-static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_remove_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	if (gtk_tree_selection_count_selected_rows(selection))
 	{
@@ -921,23 +915,23 @@ static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointe
 	}
 }
 
-static void cb_cdrom(GtkCellRendererToggle *cell, char *path_str, gpointer data)
+static void cb_cdrom (GtkCellRendererToggle *cell, char *path_str, gpointer data)
 {
 	GtkTreeIter iter;
-	GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+	GtkTreePath *path = gtk_tree_path_new_from_string (path_str);
 	gboolean cd_rom;
 
-	gtk_tree_model_get_iter(volume_store, &iter, path);
-	gtk_tree_model_get(volume_store, &iter, COLUMN_CDROM, &cd_rom, -1);
+	gtk_tree_model_get_iter (volume_store, &iter, path);
+	gtk_tree_model_get (volume_store, &iter, COLUMN_CDROM, &cd_rom, -1);
 
 	cd_rom ^= 1;
 
-	gtk_list_store_set(GTK_LIST_STORE(volume_store), &iter, COLUMN_CDROM, cd_rom, -1);
-	gtk_tree_path_free(path);
+	gtk_list_store_set (GTK_LIST_STORE (volume_store), &iter, COLUMN_CDROM, cd_rom, -1);
+	gtk_tree_path_free (path);
 }
 
 // Save volumes from list store to prefs
-static void save_volumes(void)
+static void save_volumes (void)
 {
 	while (PrefsFindString("disk"))
 		PrefsRemoveItem("disk");
@@ -955,12 +949,13 @@ static void save_volumes(void)
 				PrefsAddString("cdrom", path);
 			else
 				PrefsAddString("disk", path);
-		} while (gtk_tree_model_iter_next(volume_store, &toplevel));
+		}
+		while (gtk_tree_model_iter_next(volume_store, &toplevel));
 	}
 }
 
 // Gets the list of disks and cdroms from the prefs file and adds them to the list store
-static GtkTreeModel *get_volumes(void)
+static GtkTreeModel *get_volumes (void)
 {
 	const char *str;
 	int32_t index = 0;
@@ -972,28 +967,28 @@ static GtkTreeModel *get_volumes(void)
 		{
 			read_only = 1;
 		}
-		gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
-		gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
-						   COLUMN_PATH, str + read_only,
-						   COLUMN_SIZE, get_file_size(g_file_new_for_path(str + read_only)),
-						   COLUMN_CDROM, read_only,
-						   -1);
+		gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
+			gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
+				COLUMN_PATH, str + read_only,
+				COLUMN_SIZE, get_file_size(g_file_new_for_path(str + read_only)),
+				COLUMN_CDROM, read_only,
+				-1);
 	}
 	index = 0;
 	while ((str = (const char *)PrefsFindString("cdrom", index++)) != NULL)
 	{
-		gtk_list_store_append(GTK_LIST_STORE(volume_store), &toplevel);
-		gtk_list_store_set(GTK_LIST_STORE(volume_store), &toplevel,
-						   COLUMN_PATH, str,
-						   COLUMN_SIZE, get_file_size(g_file_new_for_path(str)),
-						   COLUMN_CDROM, true,
-						   -1);
+		gtk_list_store_append (GTK_LIST_STORE(volume_store), &toplevel);
+			gtk_list_store_set (GTK_LIST_STORE(volume_store), &toplevel,
+				COLUMN_PATH, str,
+				COLUMN_SIZE, get_file_size(g_file_new_for_path(str)),
+				COLUMN_CDROM, true,
+				-1);
 	}
 	return volume_store;
 }
 
 // Creates the tree view widget to display the volume list
-static GtkWidget *create_tree_view(void)
+static GtkWidget *create_tree_view (void)
 {
 	GtkTreeViewColumn *col;
 	GtkCellRenderer *renderer;
@@ -1014,8 +1009,8 @@ static GtkWidget *create_tree_view(void)
 	gtk_tree_view_column_set_title(col, "CD-ROM");
 	gtk_tree_view_append_column(GTK_TREE_VIEW(view), col);
 	renderer = gtk_cell_renderer_toggle_new();
-	g_signal_connect(renderer, "toggled",
-					 G_CALLBACK(cb_cdrom), NULL);
+	g_signal_connect (renderer, "toggled",
+	                  G_CALLBACK (cb_cdrom), NULL);
 	gtk_tree_view_column_pack_start(col, renderer, TRUE);
 	gtk_tree_view_column_add_attribute(col, renderer, "active", COLUMN_CDROM);
 
@@ -1053,8 +1048,7 @@ static bool is_jit_capable(void)
 #elif defined __APPLE__ && defined __MACH__
 	// XXX run-time detect so that we can use a PPC GUI prefs editor
 	static char cpu[10];
-	if (cpu[0] == 0)
-	{
+	if (cpu[0] == 0) {
 		FILE *fp = popen("uname -p", "r");
 		if (fp == NULL)
 			return false;
@@ -1072,186 +1066,184 @@ static bool is_jit_capable(void)
  */
 
 // Display types
-enum
-{
+enum {
 	DISPLAY_WINDOW,
 	DISPLAY_SCREEN
 };
 
-extern "C"
+extern "C" {
+
+// User changed the hotkey combination
+void cb_hotkey (GtkWidget *widget)
 {
+	GtkToggleButton *ctrl = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "ctrl-hotkey"));
+	GtkToggleButton *alt = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "alt-hotkey"));
+	GtkToggleButton *super = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "super-hotkey"));
+	int hotkey = gtk_toggle_button_get_active(ctrl) |
+	             gtk_toggle_button_get_active(alt) << 1 |
+	             gtk_toggle_button_get_active(super) << 2;
+	if (hotkey == 0)
+		return;
+	PrefsReplaceInt32("hotkey", hotkey);
+}
 
-	// User changed the hotkey combination
-	void cb_hotkey(GtkWidget *widget)
+// Adds the MB suffix to the value entered by the user
+void cb_format_ramsize (GtkWidget *widget)
+{
+	int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
+	if (size_mb < 4)
+		size_mb = 4;
+	if (size_mb > 1024)
+		size_mb = 1024;
+	char *text = g_strdup_printf("%d MB", size_mb);
+	gtk_entry_set_text(GTK_ENTRY(widget), text);
+	g_free(text);
+}
+
+// Saves the new ram size preference
+void cb_ramsize (GtkWidget *widget)
+{
+	int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
+	if (size_mb >= 4 && size_mb <= 1024)
 	{
-		GtkToggleButton *ctrl = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "ctrl-hotkey"));
-		GtkToggleButton *alt = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "alt-hotkey"));
-		GtkToggleButton *super = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "super-hotkey"));
-		int hotkey = gtk_toggle_button_get_active(ctrl) |
-					 gtk_toggle_button_get_active(alt) << 1 |
-					 gtk_toggle_button_get_active(super) << 2;
-		if (hotkey == 0)
-			return;
-		PrefsReplaceInt32("hotkey", hotkey);
+		int size_bytes = size_mb << 20;
+		PrefsReplaceInt32("ramsize", size_bytes);
 	}
+}
 
-	// Adds the MB suffix to the value entered by the user
-	void cb_format_ramsize(GtkWidget *widget)
+// Adds the MB suffix to the value entered by the user
+void cb_format_jitcachesize (GtkWidget *widget)
+{
+	int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
+	if (size_mb < 1)
+		size_mb = 1;
+	if (size_mb > 128)
+		size_mb = 16;
+	char *text = g_strdup_printf("%d MB", size_mb);
+	gtk_entry_set_text(GTK_ENTRY(widget), text);
+	g_free(text);
+}
+
+// Saves the new JIT cache size preference
+void cb_jitcachesize (GtkWidget *widget)
+{
+	int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
+	if (size_mb >= 1 && size_mb <= 128)
 	{
-		int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
-		if (size_mb < 4)
-			size_mb = 4;
-		if (size_mb > 1024)
-			size_mb = 1024;
-		char *text = g_strdup_printf("%d MB", size_mb);
-		gtk_entry_set_text(GTK_ENTRY(widget), text);
-		g_free(text);
+		int size_kb = size_mb << 10;
+		PrefsReplaceInt32("jitcachesize", size_kb);
 	}
+}
 
-	// Saves the new ram size preference
-	void cb_ramsize(GtkWidget *widget)
-	{
-		int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
-		if (size_mb >= 4 && size_mb <= 1024)
-		{
-			int size_bytes = size_mb << 20;
-			PrefsReplaceInt32("ramsize", size_bytes);
-		}
-	}
+// Saves the new cpu and fpu preferences
+void cb_cpu (GtkWidget *widget)
+{
+	int value = atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
+	int cpu = value >> 1;
+	bool fpu = false;
+	if (value & 1)
+		fpu = true;
+	PrefsReplaceInt32("cpu", cpu);
+	PrefsReplaceBool("fpu", fpu);
+}
 
-	// Adds the MB suffix to the value entered by the user
-	void cb_format_jitcachesize(GtkWidget *widget)
-	{
-		int size_mb = atoi(gtk_entry_get_text(GTK_ENTRY(widget)));
-		if (size_mb < 1)
-			size_mb = 1;
-		if (size_mb > 128)
-			size_mb = 16;
-		char *text = g_strdup_printf("%d MB", size_mb);
-		gtk_entry_set_text(GTK_ENTRY(widget), text);
-		g_free(text);
-	}
+// Save the id of the selected combo box item to its associated preference
+void cb_combo_int (GtkWidget *widget)
+{
+	PrefsReplaceInt32(gtk_widget_get_name(widget), atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget))));
+}
 
-	// Saves the new JIT cache size preference
-	void cb_jitcachesize(GtkWidget *widget)
-	{
-		int size_mb = atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
-		if (size_mb >= 1 && size_mb <= 128)
-		{
-			int size_kb = size_mb << 10;
-			PrefsReplaceInt32("jitcachesize", size_kb);
-		}
-	}
+void cb_combo_str (GtkWidget *widget)
+{
+	PrefsReplaceString(gtk_widget_get_name(widget), gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
+}
 
-	// Saves the new cpu and fpu preferences
-	void cb_cpu(GtkWidget *widget)
-	{
-		int value = atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
-		int cpu = value >> 1;
-		bool fpu = false;
-		if (value & 1)
-			fpu = true;
-		PrefsReplaceInt32("cpu", cpu);
-		PrefsReplaceBool("fpu", fpu);
-	}
+// Save the value of the combo box entry to its associated preference
+void cb_combo_entry_int (GtkWidget *widget)
+{
+	PrefsReplaceInt32(gtk_widget_get_name(widget),
+	                  atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget))));
+}
 
-	// Save the id of the selected combo box item to its associated preference
-	void cb_combo_int(GtkWidget *widget)
-	{
-		PrefsReplaceInt32(gtk_widget_get_name(widget), atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget))));
-	}
+void cb_combo_entry_str (GtkWidget *widget)
+{
+	PrefsReplaceString(gtk_widget_get_name(widget),
+	                   gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
+}
 
-	void cb_combo_str(GtkWidget *widget)
-	{
-		PrefsReplaceString(gtk_widget_get_name(widget), gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
-	}
+// Save the value of the spin button to its associated preference
+void cb_spin_button (GtkWidget *widget)
+{
+	PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget)));
+}
 
-	// Save the value of the combo box entry to its associated preference
-	void cb_combo_entry_int(GtkWidget *widget)
-	{
-		PrefsReplaceInt32(gtk_widget_get_name(widget),
-						  atoi(gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget))));
-	}
+// Save the value of the check box to its associated preference
+void cb_check_box (GtkWidget *widget)
+{
+	PrefsReplaceBool(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+}
 
-	void cb_combo_entry_str(GtkWidget *widget)
-	{
-		PrefsReplaceString(gtk_widget_get_name(widget),
-						   gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(widget)));
-	}
+// Save the value of the check box as an int to its associated preference
+void cb_check_box_int (GtkWidget *widget)
+{
+	PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+}
 
-	// Save the value of the spin button to its associated preference
-	void cb_spin_button(GtkWidget *widget)
-	{
-		PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget)));
-	}
+// Save the value of the check box (inverted) to its associated preference
+void cb_check_box_inv (GtkWidget *widget)
+{
+	PrefsReplaceBool(gtk_widget_get_name(widget), !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+}
 
-	// Save the value of the check box to its associated preference
-	void cb_check_box(GtkWidget *widget)
-	{
-		PrefsReplaceBool(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-	}
+// Save the contents of the entry to its associated preference
+void cb_entry (GtkWidget *widget)
+{
+	if (gtk_entry_get_text_length(GTK_ENTRY(widget)))
+		PrefsReplaceString(gtk_widget_get_name(widget), gtk_entry_get_text(GTK_ENTRY(widget)));
+	else
+		PrefsRemoveItem(gtk_widget_get_name(widget));
+}
 
-	// Save the value of the check box as an int to its associated preference
-	void cb_check_box_int(GtkWidget *widget)
-	{
-		PrefsReplaceInt32(gtk_widget_get_name(widget), gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-	}
-
-	// Save the value of the check box (inverted) to its associated preference
-	void cb_check_box_inv(GtkWidget *widget)
-	{
-		PrefsReplaceBool(gtk_widget_get_name(widget), !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
-	}
-
-	// Save the contents of the entry to its associated preference
-	void cb_entry(GtkWidget *widget)
-	{
-		if (gtk_entry_get_text_length(GTK_ENTRY(widget)))
-			PrefsReplaceString(gtk_widget_get_name(widget), gtk_entry_get_text(GTK_ENTRY(widget)));
-		else
-			PrefsRemoveItem(gtk_widget_get_name(widget));
-	}
-
-	// Display the info bar
-	void cb_infobar_show(GtkWidget *widget)
-	{
+// Display the info bar
+void cb_infobar_show (GtkWidget *widget)
+{
 #if GTK_CHECK_VERSION(3, 22, 29)
-		/* Workaround for the fact that having the revealed property in the XML is not valid
-		in older GTK versions. Instead we hide it until it is about to be revealed. */
-		if (!gtk_widget_get_visible(widget))
-		{
-			gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), false);
-			gtk_widget_show(widget);
-		}
-		gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), true);
-#else
-		gtk_widget_show(widget);
-#endif
-	}
-
-	// Close the info bar
-	void cb_infobar_hide(GtkWidget *widget)
+	/* Workaround for the fact that having the revealed property in the XML is not valid
+	in older GTK versions. Instead we hide it until it is about to be revealed. */
+	if (!gtk_widget_get_visible(widget))
 	{
-#if GTK_CHECK_VERSION(3, 22, 29)
 		gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), false);
+		gtk_widget_show(widget);
+	}
+	gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), true);
 #else
-		gtk_widget_hide(GTK_WIDGET(widget));
+	gtk_widget_show(widget);
 #endif
-	}
+}
 
-	void cb_swap_opt_cmd(GtkWidget *widget)
-	{
-		bool swapped = PrefsFindBool("swap_opt_cmd");
-		GtkLabel *opt_label = GTK_LABEL(gtk_builder_get_object(builder, "opt-label"));
-		GtkLabel *cmd_label = GTK_LABEL(gtk_builder_get_object(builder, "cmd-label"));
-		gtk_label_set_text(opt_label, swapped ? "Super" : "Alt");
-		gtk_label_set_text(cmd_label, swapped ? "Alt" : "Super");
-	}
+// Close the info bar
+void cb_infobar_hide (GtkWidget *widget)
+{
+#if GTK_CHECK_VERSION(3, 22, 29)
+	gtk_info_bar_set_revealed(GTK_INFO_BAR(widget), false);
+#else
+	gtk_widget_hide(GTK_WIDGET(widget));
+#endif
+}
+
+void cb_swap_opt_cmd (GtkWidget *widget)
+{
+	bool swapped = PrefsFindBool("swap_opt_cmd");
+	GtkLabel *opt_label = GTK_LABEL(gtk_builder_get_object(builder, "opt-label"));
+	GtkLabel *cmd_label = GTK_LABEL(gtk_builder_get_object(builder, "cmd-label"));
+	gtk_label_set_text(opt_label, swapped ? "Super" : "Alt");
+	gtk_label_set_text(cmd_label, swapped ? "Alt" : "Super");
+}
 
 } // extern "C"
 
 // Read and set mouse wheel mode preference
-static void get_mouse_wheel_mode(void)
+static void get_mouse_wheel_mode (void)
 {
 	GtkToggleButton *page = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "mousewheelmode-inv"));
 	GtkToggleButton *cursor = GTK_TOGGLE_BUTTON(gtk_builder_get_object(builder, "mousewheelmode"));
@@ -1259,7 +1251,7 @@ static void get_mouse_wheel_mode(void)
 }
 
 // Read and convert graphics preferences
-static void get_graphics_settings(void)
+static void get_graphics_settings (void)
 {
 	display_type = DISPLAY_WINDOW;
 	dis_width = 640;
@@ -1271,57 +1263,48 @@ static void get_graphics_settings(void)
 	mag_rate = GTK_ENTRY(gtk_builder_get_object(builder, "mag_rate"));
 
 	const char *str = PrefsFindString("screen");
-	if (str)
-	{
+	if (str) {
 		if (sscanf(str, "win/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_WINDOW;
 		else if (sscanf(str, "dga/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_SCREEN;
-		else if (sscanf(str, "fbdev/%d/%d", &dis_width, &dis_height) == 2)
-		{
+		else if (sscanf(str, "fbdev/%d/%d", &dis_width, &dis_height) == 2) {
 #ifdef ENABLE_FBDEV_DGA
 			is_fbdev_dga_mode = true;
 #endif
 			display_type = DISPLAY_SCREEN;
 		}
 	}
-	else
-	{
+	else {
 		uint32_t window_modes = PrefsFindInt32("windowmodes");
 		uint32_t screen_modes = PrefsFindInt32("screenmodes");
-		if (screen_modes)
-		{
+		if (screen_modes) {
 			display_type = DISPLAY_SCREEN;
-			static const struct
-			{
+			static const struct {
 				int id;
 				int width;
 				int height;
-			} modes[] = {
-				{1, 640, 480},
-				{2, 800, 600},
-				{4, 1024, 768},
-				{64, 1152, 768},
-				{8, 1152, 900},
-				{16, 1280, 1024},
-				{32, 1600, 1200},
-				{
-					0,
-				}};
-			for (int i = 0; modes[i].id != 0; i++)
-			{
-				if (screen_modes & modes[i].id)
-				{
-					if (modes[i].width <= screen_width && modes[i].height <= screen_height)
-					{
+			}
+			modes[] = {
+				{  1,	 640,	 480 },
+				{  2,	 800,	 600 },
+				{  4,	1024,	 768 },
+				{ 64,	1152,	 768 },
+				{  8,	1152,	 900 },
+				{ 16,	1280,	1024 },
+				{ 32,	1600,	1200 },
+				{ 0, }
+			};
+			for (int i = 0; modes[i].id != 0; i++) {
+				if (screen_modes & modes[i].id) {
+					if (modes[i].width <= screen_width && modes[i].height <= screen_height) {
 						dis_width = modes[i].width;
 						dis_height = modes[i].height;
 					}
 				}
 			}
 		}
-		else if (window_modes)
-		{
+		else if (window_modes) {
 			display_type = DISPLAY_WINDOW;
 			if (window_modes & 1)
 				dis_width = 640, dis_height = 480;
@@ -1333,7 +1316,7 @@ static void get_graphics_settings(void)
 		dis_width = 0;
 	if (dis_height == screen_height)
 		dis_height = 0;
-	gtk_toggle_button_set_active((display_type ? screen_full : screen_win), true);
+	gtk_toggle_button_set_active ((display_type ? screen_full : screen_win), true);
 	char *res_str = g_strdup_printf("%d x %d", dis_width, dis_height);
 	if (!gtk_combo_box_set_active_id(screen_res, res_str))
 	{
@@ -1343,8 +1326,7 @@ static void get_graphics_settings(void)
 
 	// scaling
 	const char *mag_rate_str = PrefsFindString("mag_rate");
-	if (!mag_rate_str)
-	{
+	if (!mag_rate_str) {
 		mag_rate_str = "1.0";
 	}
 	gtk_entry_set_text(GTK_ENTRY(mag_rate), mag_rate_str);
@@ -1352,32 +1334,25 @@ static void get_graphics_settings(void)
 }
 
 // Add names of serial devices
-static GList *add_serial_names(void)
+static GList *add_serial_names (void)
 {
 	GList *glist = NULL;
 
 	// Search /dev for ttyS* and lp*
 	DIR *d = opendir("/dev");
-	if (d)
-	{
+	if (d) {
 		struct dirent *de;
-		while ((de = readdir(d)) != NULL)
-		{
+		while ((de = readdir(d)) != NULL) {
 #if defined(__linux__)
-			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0)
-			{
+			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0) {
 #elif defined(__FreeBSD__)
-			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
-			{
+			if (strncmp(de->d_name, "cua", 3) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
 #elif defined(__NetBSD__)
-			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
-			{
+			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
 #elif defined(sgi)
-			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0)
-			{
+			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0) {
 #else
-			if (false)
-			{
+			if (false) {
 #endif
 				char *str = g_strdup_printf("/dev/%s", de->d_name);
 				glist = g_list_append(glist, str);
@@ -1391,33 +1366,27 @@ static GList *add_serial_names(void)
 }
 
 // Add names of ethernet interfaces
-static GList *add_ether_names(void)
+static GList *add_ether_names (void)
 {
 	GList *glist = NULL;
 
 	// Get list of all Ethernet interfaces
 	int s = socket(PF_INET, SOCK_DGRAM, 0);
-	if (s >= 0)
-	{
+	if (s >= 0) {
 		char inbuf[8192];
 		struct ifconf ifc;
 		ifc.ifc_len = sizeof(inbuf);
 		ifc.ifc_buf = inbuf;
-		if (ioctl(s, SIOCGIFCONF, &ifc) == 0)
-		{
+		if (ioctl(s, SIOCGIFCONF, &ifc) == 0) {
 			struct ifreq req, *ifr = ifc.ifc_req;
-			for (int i = 0; i < ifc.ifc_len; i += sizeof(ifreq), ifr++)
-			{
+			for (int i=0; i<ifc.ifc_len; i+=sizeof(ifreq), ifr++) {
 				req = *ifr;
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(sgi)
-				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER + 1))
-				{
+				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER+1)) {
 #elif defined(__linux__)
-				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER)
-				{
+				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
 #else
-				if (false)
-				{
+				if (false) {
 #endif
 					char *str = new char[64];
 					strncpy(str, ifr->ifr_name, 63);
@@ -1446,15 +1415,15 @@ static GList *add_ether_names(void)
  */
 
 uint8_t XPRAM[XPRAM_SIZE];
-void MountVolume(void *fh) {}
-void FileDiskLayout(loff_t size, uint8_t *data, loff_t &start_byte, loff_t &real_size) {}
+void MountVolume(void *fh) { }
+void FileDiskLayout(loff_t size, uint8_t *data, loff_t &start_byte, loff_t &real_size) { }
 
 #if defined __APPLE__ && defined __MACH__
-void DarwinSysInit(void) {}
-void DarwinSysExit(void) {}
-void DarwinAddFloppyPrefs(void) {}
-void DarwinAddSerialPrefs(void) {}
-bool DarwinCDReadTOC(char *, uint8_t *) {}
+void DarwinSysInit(void) { }
+void DarwinSysExit(void) { }
+void DarwinAddFloppyPrefs(void) { }
+void DarwinAddSerialPrefs(void) { }
+bool DarwinCDReadTOC(char *, uint8_t *) { }
 #endif
 
 static GCallback dl_destroyed(GtkWidget *dialog)
@@ -1467,11 +1436,11 @@ static GCallback dl_destroyed(GtkWidget *dialog)
 void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 {
 	GtkWidget *dialog = gtk_message_dialog_new(NULL,
-											   GTK_DIALOG_MODAL,
-											   GTK_MESSAGE_WARNING,
-											   GTK_BUTTONS_NONE,
-											   GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
+						GTK_DIALOG_MODAL,
+						GTK_MESSAGE_WARNING,
+						GTK_BUTTONS_NONE,
+						GetString(title_id), NULL);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);
@@ -1483,19 +1452,21 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
  *  Display error alert
  */
 
-void ErrorAlert(const char *text)
+void ErrorAlert (const char *text)
 {
 	display_alert(STR_ERROR_ALERT_TITLE, STR_GUI_ERROR_PREFIX, STR_QUIT_BUTTON, text);
 }
+
 
 /*
  *  Display warning alert
  */
 
-void WarningAlert(const char *text)
+void WarningAlert (const char *text)
 {
 	display_alert(STR_WARNING_ALERT_TITLE, STR_GUI_WARNING_PREFIX, STR_OK_BUTTON, text);
 }
+
 
 /*
  *  RPC handlers
@@ -1539,6 +1510,7 @@ static int handle_Exit(rpc_connection_t *connection)
 	return RPC_ERROR_NO_ERROR;
 }
 
+
 /*
  *  SIGCHLD handler
  */
@@ -1546,7 +1518,7 @@ static int handle_Exit(rpc_connection_t *connection)
 static char g_app_path[PATH_MAX];
 static rpc_connection_t *g_gui_connection = NULL;
 
-static void sigchld_handler(int sig, siginfo_t *sip, void *)
+static void sigchld_handler (int sig, siginfo_t *sip, void *)
 {
 	D(bug("Child %d exitted with status = %x\n", sip->si_pid, sip->si_status));
 
@@ -1559,29 +1531,28 @@ static void sigchld_handler(int sig, siginfo_t *sip, void *)
 	if (WIFEXITED(status))
 		status = WEXITSTATUS(status);
 	if (status & 0x80)
-		status |= -1 ^ 0xff;
+		status |= -1 ^0xff;
 
-	if (status < 0)
-	{ // negative -> execlp/-errno
+	if (status < 0) {	// negative -> execlp/-errno
 		char *str = g_strdup_printf(GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(-status));
 		ErrorAlert(str);
 		status = 1;
 		g_free(str);
 	}
 
-	if (status != 0)
-	{
+	if (status != 0) {
 		if (g_gui_connection)
 			rpc_exit(g_gui_connection);
 		exit(status);
 	}
 }
 
+
 /*
  *  Start standalone GUI
  */
 
-int main(int argc, char *argv[])
+int main (int argc, char *argv[])
 {
 	// Read preferences
 	PrefsInit(0, argc, argv);
@@ -1592,15 +1563,13 @@ int main(int argc, char *argv[])
 	PrefsExit();
 
 	// Transfer control to the executable
-	if (start)
-	{
+	if (start) {
 		// Catch exits from the child process
 		struct sigaction sigchld_sa, old_sigchld_sa;
 		sigemptyset(&sigchld_sa.sa_mask);
 		sigchld_sa.sa_sigaction = sigchld_handler;
 		sigchld_sa.sa_flags = SA_NOCLDSTOP | SA_SIGINFO;
-		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0)
-		{
+		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0) {
 			char *str = g_strdup_printf(GetString(STR_SIG_INSTALL_ERR), SIGCHLD, strerror(errno));
 			ErrorAlert(str);
 			return 1;
@@ -1610,19 +1579,15 @@ int main(int argc, char *argv[])
 		// Search and run the SheepShaver executable
 		char *p;
 		strcpy(g_app_path, argv[0]);
-		if ((p = strstr(g_app_path, "SheepShaverGUI.app/Contents/MacOS")) != NULL)
-		{
+		if ((p = strstr(g_app_path, "SheepShaverGUI.app/Contents/MacOS")) != NULL) {
 			strcpy(p, "SheepShaver.app/Contents/MacOS/SheepShaver");
-			if (access(g_app_path, X_OK) < 0)
-			{
+			if (access(g_app_path, X_OK) < 0) {
 				char *str = g_strdup_printf(GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(errno));
 				WarningAlert(str);
 				strcpy(g_app_path, "/Applications/SheepShaver.app/Contents/MacOS/SheepShaver");
 				g_free(str);
 			}
-		}
-		else
-		{
+		} else {
 			p = strrchr(g_app_path, '/');
 			p = p ? p + 1 : g_app_path;
 			strcpy(p, "SheepShaver");
@@ -1630,8 +1595,7 @@ int main(int argc, char *argv[])
 
 		char *gui_connection_path = g_strdup_printf("/org/SheepShaver/GUI/%d", getpid());
 		int pid = fork();
-		if (pid == 0)
-		{
+		if (pid == 0) {
 			D(bug("Trying to execute %s\n", g_app_path));
 			execlp(g_app_path, g_app_path, "--gui-connection", gui_connection_path, (char *)NULL);
 			g_free(gui_connection_path);
@@ -1643,8 +1607,7 @@ int main(int argc, char *argv[])
 		}
 
 		// Establish a connection to Basilisk II
-		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL)
-		{
+		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL) {
 			printf("ERROR: failed to initialize GUI-side RPC server connection\n");
 			g_free(gui_connection_path);
 			return 1;
@@ -1652,29 +1615,26 @@ int main(int argc, char *argv[])
 		g_free(gui_connection_path);
 
 		static const rpc_method_descriptor_t vtable[] = {
-			{RPC_METHOD_ERROR_ALERT, handle_ErrorAlert},
-			{RPC_METHOD_WARNING_ALERT, handle_WarningAlert},
-			{RPC_METHOD_EXIT, handle_Exit}};
-		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0)
-		{
+			{ RPC_METHOD_ERROR_ALERT,			handle_ErrorAlert },
+			{ RPC_METHOD_WARNING_ALERT,			handle_WarningAlert },
+			{ RPC_METHOD_EXIT,					handle_Exit }
+		};
+		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0) {
 			printf("ERROR: failed to setup GUI method callbacks\n");
 			return 1;
 		}
 		int socket;
-		if ((socket = rpc_listen_socket(g_gui_connection)) < 0)
-		{
+		if ((socket = rpc_listen_socket(g_gui_connection)) < 0) {
 			printf("ERROR: failed to initialize RPC server thread\n");
 			return 1;
 		}
 
 		g_gui_loop = g_main_new(TRUE);
-		while (g_main_is_running(g_gui_loop))
-		{
+		while (g_main_is_running(g_gui_loop)) {
 
 			// Process a few events pending
 			const int N_EVENTS_DISPATCH = 10;
-			for (int i = 0; i < N_EVENTS_DISPATCH; i++)
-			{
+			for (int i = 0; i < N_EVENTS_DISPATCH; i++) {
 				if (!g_main_iteration(FALSE))
 					break;
 			}

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -2374,7 +2374,7 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 	                                           GTK_MESSAGE_WARNING,
 	                                           GTK_BUTTONS_NONE,
 	                                           GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -118,7 +118,6 @@
 #define DEBUG 0
 #include "debug.h"
 
-
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif
@@ -126,7 +125,7 @@
 #ifdef USE_SDL
 #include <SDL.h>
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
-#define SDL_PLATFORM_MACOS      __MACOSX__
+#define SDL_PLATFORM_MACOS __MACOSX__
 #endif
 #endif
 
@@ -160,7 +159,6 @@
 #include "mon.h"
 #endif
 
-
 // Enable emulation of unaligned lmw/stmw?
 #define EMULATE_UNALIGNED_LOADSTORE_MULTIPLE 1
 
@@ -173,39 +171,37 @@
 // Interrupts in native mode?
 #define INTERRUPTS_IN_NATIVE_MODE 1
 
-
 // Constants
 const char ROM_FILE_NAME[] = "ROM";
 const char ROM_FILE_NAME2[] = "Mac OS ROM";
 
 #if !REAL_ADDRESSING
 // FIXME: needs to be >= 0x04000000
-const uintptr RAM_BASE = 0x10000000;		// Base address of RAM
+const uintptr RAM_BASE = 0x10000000; // Base address of RAM
 #endif
-const uintptr ROM_BASE = 0x50000000;		// Base address of ROM
+const uintptr ROM_BASE = 0x50000000; // Base address of ROM
 #if REAL_ADDRESSING
-const uint32 ROM_ALIGNMENT = 0x100000;		// ROM must be aligned to a 1MB boundary
+const uint32 ROM_ALIGNMENT = 0x100000; // ROM must be aligned to a 1MB boundary
 #endif
-const uint32 SIG_STACK_SIZE = 0x10000;		// Size of signal stack
-
+const uint32 SIG_STACK_SIZE = 0x10000; // Size of signal stack
 
 // Global variables (exported)
 #if !EMULATED_PPC
-void *TOC = NULL;		// Pointer to Thread Local Storage (r2)
-void *R13 = NULL;		// Pointer to .sdata section (r13 under Linux)
+void *TOC = NULL; // Pointer to Thread Local Storage (r2)
+void *R13 = NULL; // Pointer to .sdata section (r13 under Linux)
 #endif
-uint32 RAMBase;			// Base address of Mac RAM
-uint32 RAMSize;			// Size of Mac RAM
-uint32 ROMBase;			// Base address of Mac ROM
-uint32 KernelDataAddr;	// Address of Kernel Data
-uint32 BootGlobsAddr;	// Address of BootGlobs structure at top of Mac RAM
-uint32 DRCacheAddr;		// Address of DR Cache
-uint32 PVR;				// Theoretical PVR
-int64 CPUClockSpeed;	// Processor clock speed (Hz)
-int64 BusClockSpeed;	// Bus clock speed (Hz)
-int64 TimebaseSpeed;	// Timebase clock speed (Hz)
-uint8 *RAMBaseHost;		// Base address of Mac RAM (host address space)
-uint8 *ROMBaseHost;		// Base address of Mac ROM (host address space)
+uint32 RAMBase;		   // Base address of Mac RAM
+uint32 RAMSize;		   // Size of Mac RAM
+uint32 ROMBase;		   // Base address of Mac ROM
+uint32 KernelDataAddr; // Address of Kernel Data
+uint32 BootGlobsAddr;  // Address of BootGlobs structure at top of Mac RAM
+uint32 DRCacheAddr;	   // Address of DR Cache
+uint32 PVR;			   // Theoretical PVR
+int64 CPUClockSpeed;   // Processor clock speed (Hz)
+int64 BusClockSpeed;   // Bus clock speed (Hz)
+int64 TimebaseSpeed;   // Timebase clock speed (Hz)
+uint8 *RAMBaseHost;	   // Base address of Mac RAM (host address space)
+uint8 *ROMBaseHost;	   // Base address of Mac ROM (host address space)
 uint32 ROMEnd;
 
 #if defined(__APPLE__) && defined(__x86_64__)
@@ -214,57 +210,56 @@ uint8 gZeroPage[0x3000], gKernelData[0x2000];
 
 // Global variables
 #ifndef USE_SDL_VIDEO
-char *x_display_name = NULL;				// X11 display name
-Display *x_display = NULL;					// X11 display handle
+char *x_display_name = NULL; // X11 display name
+Display *x_display = NULL;	 // X11 display handle
 #ifdef X11_LOCK_TYPE
 X11_LOCK_TYPE x_display_lock = X11_LOCK_INIT; // X11 display lock
 #endif
 #endif
 
-static int zero_fd = 0;						// FD of /dev/zero
-static bool lm_area_mapped = false;			// Flag: Low Memory area mmap()ped
-static bool rom_area_mapped = false;		// Flag: Mac ROM mmap()ped
-static bool ram_area_mapped = false;		// Flag: Mac RAM mmap()ped
-static bool dr_cache_area_mapped = false;	// Flag: Mac DR Cache mmap()ped
-static bool dr_emulator_area_mapped = false;// Flag: Mac DR Emulator mmap()ped
-static KernelData *kernel_data;				// Pointer to Kernel Data
+static int zero_fd = 0;						 // FD of /dev/zero
+static bool lm_area_mapped = false;			 // Flag: Low Memory area mmap()ped
+static bool rom_area_mapped = false;		 // Flag: Mac ROM mmap()ped
+static bool ram_area_mapped = false;		 // Flag: Mac RAM mmap()ped
+static bool dr_cache_area_mapped = false;	 // Flag: Mac DR Cache mmap()ped
+static bool dr_emulator_area_mapped = false; // Flag: Mac DR Emulator mmap()ped
+static KernelData *kernel_data;				 // Pointer to Kernel Data
 static EmulatorData *emulator_data;
 
-static uint8 last_xpram[XPRAM_SIZE];		// Buffer for monitoring XPRAM changes
+static uint8 last_xpram[XPRAM_SIZE]; // Buffer for monitoring XPRAM changes
 
-static bool nvram_thread_active = false;	// Flag: NVRAM watchdog installed
-static volatile bool nvram_thread_cancel;	// Flag: Cancel NVRAM thread
-static pthread_t nvram_thread;				// NVRAM watchdog
-static bool tick_thread_active = false;		// Flag: MacOS thread installed
-static volatile bool tick_thread_cancel;	// Flag: Cancel 60Hz thread
-static pthread_t tick_thread;				// 60Hz thread
-static pthread_t emul_thread;				// MacOS thread
-static int use_gui = -1;   					// Override prefs and show gui
+static bool nvram_thread_active = false;  // Flag: NVRAM watchdog installed
+static volatile bool nvram_thread_cancel; // Flag: Cancel NVRAM thread
+static pthread_t nvram_thread;			  // NVRAM watchdog
+static bool tick_thread_active = false;	  // Flag: MacOS thread installed
+static volatile bool tick_thread_cancel;  // Flag: Cancel 60Hz thread
+static pthread_t tick_thread;			  // 60Hz thread
+static pthread_t emul_thread;			  // MacOS thread
+static int use_gui = -1;				  // Override prefs and show gui
 
-static bool ready_for_signals = false;		// Handler installed, signals can be sent
+static bool ready_for_signals = false; // Handler installed, signals can be sent
 
 #if EMULATED_PPC
-static uintptr sig_stack = 0;				// Stack for PowerPC interrupt routine
+static uintptr sig_stack = 0; // Stack for PowerPC interrupt routine
 #else
-static struct sigaction sigusr2_action;		// Interrupt signal (of emulator thread)
-static struct sigaction sigsegv_action;		// Data access exception signal (of emulator thread)
-static struct sigaction sigill_action;		// Illegal instruction signal (of emulator thread)
-static stack_t sig_stack;					// Stack for signal handlers
-static stack_t extra_stack;					// Stack for SIGSEGV inside interrupt handler
-static bool emul_thread_fatal = false;		// Flag: MacOS thread crashed, tick thread shall dump debug output
-static sigregs sigsegv_regs;				// Register dump when crashed
-static const char *crash_reason = NULL;		// Reason of the crash (SIGSEGV, SIGBUS, SIGILL)
+static struct sigaction sigusr2_action; // Interrupt signal (of emulator thread)
+static struct sigaction sigsegv_action; // Data access exception signal (of emulator thread)
+static struct sigaction sigill_action;	// Illegal instruction signal (of emulator thread)
+static stack_t sig_stack;				// Stack for signal handlers
+static stack_t extra_stack;				// Stack for SIGSEGV inside interrupt handler
+static bool emul_thread_fatal = false;	// Flag: MacOS thread crashed, tick thread shall dump debug output
+static sigregs sigsegv_regs;			// Register dump when crashed
+static const char *crash_reason = NULL; // Reason of the crash (SIGSEGV, SIGBUS, SIGILL)
 #endif
 
-static rpc_connection_t *gui_connection = NULL;	// RPC connection to the GUI
+static rpc_connection_t *gui_connection = NULL; // RPC connection to the GUI
 static const char *gui_connection_path = NULL;	// GUI connection identifier
 
-uint32  SheepMem::page_size;				// Size of a native page
-uintptr SheepMem::zero_page = 0;			// Address of ro page filled in with zeros
-uintptr SheepMem::base = 0x60000000;		// Address of SheepShaver data
-uintptr SheepMem::proc;						// Bottom address of SheepShave procedures
-uintptr SheepMem::data;						// Top of SheepShaver data (stack like storage)
-
+uint32 SheepMem::page_size;			 // Size of a native page
+uintptr SheepMem::zero_page = 0;	 // Address of ro page filled in with zeros
+uintptr SheepMem::base = 0x60000000; // Address of SheepShaver data
+uintptr SheepMem::proc;				 // Bottom address of SheepShave procedures
+uintptr SheepMem::data;				 // Top of SheepShaver data (stack like storage)
 
 // Prototypes
 #if !defined(__APPLE__) || !defined(__x86_64__)
@@ -287,7 +282,6 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp);
 static void sigill_handler(int sig, siginfo_t *sip, void *scp);
 #endif
 
-
 // From asm_linux.S
 #if !EMULATED_PPC
 extern "C" void *get_sp(void);
@@ -306,7 +300,6 @@ extern "C" int atomic_or(int *var, int v);
 extern void paranoia_check(void);
 #endif
 
-
 #if EMULATED_PPC
 /*
  *  Return signal stack base
@@ -316,7 +309,6 @@ uintptr SignalStackBase(void)
 {
 	return sig_stack + SIG_STACK_SIZE;
 }
-
 
 /*
  *  Atomic operations
@@ -357,7 +349,6 @@ int atomic_or(int *var, int v)
 }
 #endif
 
-
 /*
  *  Memory management helpers
  */
@@ -376,7 +367,6 @@ static inline int vm_mac_release(uint32 addr, uint32 size)
 {
 	return vm_release(Mac2HostAddr(addr), size);
 }
-
 
 /*
  *  Main program
@@ -398,9 +388,11 @@ static bool valid_vmdir(const char *path)
 	int len = strlen(path);
 	if (len && path[len - 1] == '/') // to support both ".sheepvm" and ".sheepvm/"
 		len--;
-	if (len > suffix_len && !strncmp(path + len - suffix_len, ".sheepvm", suffix_len)) {
+	if (len > suffix_len && !strncmp(path + len - suffix_len, ".sheepvm", suffix_len))
+	{
 		struct stat d;
-		if (!stat(path, &d) && S_ISDIR(d.st_mode)) {
+		if (!stat(path, &d) && S_ISDIR(d.st_mode))
+		{
 			return true;
 		}
 	}
@@ -413,21 +405,24 @@ static void get_system_info(void)
 	FILE *proc_file;
 #endif
 
-	PVR = 0x00040000;			// Default: 604
-	CPUClockSpeed = 100000000;	// Default: 100MHz
-	BusClockSpeed = 100000000;	// Default: 100MHz
-	TimebaseSpeed =  25000000;	// Default:  25MHz
+	PVR = 0x00040000;		   // Default: 604
+	CPUClockSpeed = 100000000; // Default: 100MHz
+	BusClockSpeed = 100000000; // Default: 100MHz
+	TimebaseSpeed = 25000000;  // Default:  25MHz
 
 #if EMULATED_PPC
-	PVR = 0x000c0000;			// Default: 7400 (with AltiVec)
+	PVR = 0x000c0000; // Default: 7400 (with AltiVec)
 	int pref_cpu_clock = PrefsFindInt32("cpuclock");
-	if (pref_cpu_clock) CPUClockSpeed = 1000000 * pref_cpu_clock;
+	if (pref_cpu_clock)
+		CPUClockSpeed = 1000000 * pref_cpu_clock;
 #elif defined(__APPLE__) && defined(__MACH__)
 	proc_file = popen("ioreg -c IOPlatformDevice", "r");
-	if (proc_file) {
+	if (proc_file)
+	{
 		char line[256];
 		bool powerpc_node = false;
-		while (fgets(line, sizeof(line) - 1, proc_file)) {
+		while (fgets(line, sizeof(line) - 1, proc_file))
+		{
 			// Read line
 			int len = strlen(line);
 			if (len == 0)
@@ -437,7 +432,8 @@ static void get_system_info(void)
 			// Parse line
 			if (strstr(line, "o PowerPC,"))
 				powerpc_node = true;
-			else if (powerpc_node) {
+			else if (powerpc_node)
+			{
 				uint32 value;
 				char head[256];
 				if (sscanf(line, "%[ |]\"cpu-version\" = <%x>", head, &value) == 2)
@@ -453,88 +449,94 @@ static void get_system_info(void)
 			}
 		}
 		fclose(proc_file);
-	} else {
+	}
+	else
+	{
 		char str[256];
 		sprintf(str, GetString(STR_PROC_CPUINFO_WARN), strerror(errno));
 		WarningAlert(str);
 	}
 #else
 	proc_file = fopen("/proc/cpuinfo", "r");
-	if (proc_file) {
+	if (proc_file)
+	{
 		// CPU specs from Linux kernel
 		// TODO: make it more generic with features (e.g. AltiVec) and
 		// cache information and friends for NameRegistry
-		static const struct {
+		static const struct
+		{
 			uint32 pvr_mask;
 			uint32 pvr_value;
 			const char *cpu_name;
-		}
-		cpu_specs[] = {
-			{ 0xffff0000, 0x00010000, "601" },
-			{ 0xffff0000, 0x00030000, "603" },
-			{ 0xffff0000, 0x00060000, "603e" },
-			{ 0xffff0000, 0x00070000, "603ev" },
-			{ 0xffff0000, 0x00040000, "604" },
-			{ 0xfffff000, 0x00090000, "604e" },
-			{ 0xffff0000, 0x00090000, "604r" },
-			{ 0xffff0000, 0x000a0000, "604ev" },
-			{ 0xffffffff, 0x00084202, "740/750" },
-			{ 0xfffff000, 0x00083000, "745/755" },
-			{ 0xfffffff0, 0x00080100, "750CX" },
-			{ 0xfffffff0, 0x00082200, "750CX" },
-			{ 0xfffffff0, 0x00082210, "750CXe" },
-			{ 0xffffff00, 0x70000100, "750FX" },
-			{ 0xffffffff, 0x70000200, "750FX" },
-			{ 0xffff0000, 0x70000000, "750FX" },
-			{ 0xffff0000, 0x70020000, "750GX" },
-			{ 0xffff0000, 0x00080000, "740/750" },
-			{ 0xffffffff, 0x000c1101, "7400 (1.1)" },
-			{ 0xffff0000, 0x000c0000, "7400" },
-			{ 0xffff0000, 0x800c0000, "7410" },
-			{ 0xffffffff, 0x80000200, "7450" },
-			{ 0xffffffff, 0x80000201, "7450" },
-			{ 0xffff0000, 0x80000000, "7450" },
-			{ 0xffffff00, 0x80010100, "7455" },
-			{ 0xffffffff, 0x80010200, "7455" },
-			{ 0xffff0000, 0x80010000, "7455" },
-			{ 0xffff0000, 0x80020000, "7457" },
-			{ 0xffff0000, 0x80030000, "7447A" },
-			{ 0xffff0000, 0x80040000, "7448" },
-			{ 0x7fff0000, 0x00810000, "82xx" },
-			{ 0x7fff0000, 0x00820000, "8280" },
-			{ 0xffff0000, 0x00400000, "Power3 (630)" },
-			{ 0xffff0000, 0x00410000, "Power3 (630+)" },
-			{ 0xffff0000, 0x00360000, "I-star" },
-			{ 0xffff0000, 0x00370000, "S-star" },
-			{ 0xffff0000, 0x00350000, "Power4" },
-			{ 0xffff0000, 0x00390000, "PPC970" },
-			{ 0xffff0000, 0x003c0000, "PPC970FX" },
-			{ 0xffff0000, 0x00440000, "PPC970MP" },
-			{ 0xffff0000, 0x003a0000, "POWER5 (gr)" },
-			{ 0xffff0000, 0x003b0000, "POWER5+ (gs)" },
-			{ 0xffff0000, 0x003e0000, "POWER6" },
-			{ 0xffff0000, 0x00700000, "Cell Broadband Engine" },
-			{ 0x7fff0000, 0x00900000, "PA6T" },
-			{ 0, 0, 0 }
-		};
+		} cpu_specs[] = {
+			{0xffff0000, 0x00010000, "601"},
+			{0xffff0000, 0x00030000, "603"},
+			{0xffff0000, 0x00060000, "603e"},
+			{0xffff0000, 0x00070000, "603ev"},
+			{0xffff0000, 0x00040000, "604"},
+			{0xfffff000, 0x00090000, "604e"},
+			{0xffff0000, 0x00090000, "604r"},
+			{0xffff0000, 0x000a0000, "604ev"},
+			{0xffffffff, 0x00084202, "740/750"},
+			{0xfffff000, 0x00083000, "745/755"},
+			{0xfffffff0, 0x00080100, "750CX"},
+			{0xfffffff0, 0x00082200, "750CX"},
+			{0xfffffff0, 0x00082210, "750CXe"},
+			{0xffffff00, 0x70000100, "750FX"},
+			{0xffffffff, 0x70000200, "750FX"},
+			{0xffff0000, 0x70000000, "750FX"},
+			{0xffff0000, 0x70020000, "750GX"},
+			{0xffff0000, 0x00080000, "740/750"},
+			{0xffffffff, 0x000c1101, "7400 (1.1)"},
+			{0xffff0000, 0x000c0000, "7400"},
+			{0xffff0000, 0x800c0000, "7410"},
+			{0xffffffff, 0x80000200, "7450"},
+			{0xffffffff, 0x80000201, "7450"},
+			{0xffff0000, 0x80000000, "7450"},
+			{0xffffff00, 0x80010100, "7455"},
+			{0xffffffff, 0x80010200, "7455"},
+			{0xffff0000, 0x80010000, "7455"},
+			{0xffff0000, 0x80020000, "7457"},
+			{0xffff0000, 0x80030000, "7447A"},
+			{0xffff0000, 0x80040000, "7448"},
+			{0x7fff0000, 0x00810000, "82xx"},
+			{0x7fff0000, 0x00820000, "8280"},
+			{0xffff0000, 0x00400000, "Power3 (630)"},
+			{0xffff0000, 0x00410000, "Power3 (630+)"},
+			{0xffff0000, 0x00360000, "I-star"},
+			{0xffff0000, 0x00370000, "S-star"},
+			{0xffff0000, 0x00350000, "Power4"},
+			{0xffff0000, 0x00390000, "PPC970"},
+			{0xffff0000, 0x003c0000, "PPC970FX"},
+			{0xffff0000, 0x00440000, "PPC970MP"},
+			{0xffff0000, 0x003a0000, "POWER5 (gr)"},
+			{0xffff0000, 0x003b0000, "POWER5+ (gs)"},
+			{0xffff0000, 0x003e0000, "POWER6"},
+			{0xffff0000, 0x00700000, "Cell Broadband Engine"},
+			{0x7fff0000, 0x00900000, "PA6T"},
+			{0, 0, 0}};
 
 		char line[256];
-		while(fgets(line, 255, proc_file)) {
+		while (fgets(line, 255, proc_file))
+		{
 			// Read line
 			int len = strlen(line);
 			if (len == 0)
 				continue;
-			line[len-1] = 0;
+			line[len - 1] = 0;
 
 			// Parse line
 			int i;
 			float f;
 			char value[256];
-			if (sscanf(line, "cpu : %[^,]", value) == 1) {
+			if (sscanf(line, "cpu : %[^,]", value) == 1)
+			{
 				// Search by name
 				const char *cpu_name = NULL;
-				for (int i = 0; cpu_specs[i].pvr_mask != 0; i++) {
-					if (strcmp(cpu_specs[i].cpu_name, value) == 0) {
+				for (int i = 0; cpu_specs[i].pvr_mask != 0; i++)
+				{
+					if (strcmp(cpu_specs[i].cpu_name, value) == 0)
+					{
 						cpu_name = cpu_specs[i].cpu_name;
 						PVR = cpu_specs[i].pvr_value;
 						break;
@@ -551,7 +553,9 @@ static void get_system_info(void)
 				CPUClockSpeed = BusClockSpeed = i * 1000000;
 		}
 		fclose(proc_file);
-	} else {
+	}
+	else
+	{
 		char str[256];
 		sprintf(str, GetString(STR_PROC_CPUINFO_WARN), strerror(errno));
 		WarningAlert(str);
@@ -559,8 +563,13 @@ static void get_system_info(void)
 
 	// Get actual bus frequency
 	proc_file = fopen("/proc/device-tree/clock-frequency", "r");
-	if (proc_file) {
-		union { uint8 b[4]; uint32 l; } value;
+	if (proc_file)
+	{
+		union
+		{
+			uint8 b[4];
+			uint32 l;
+		} value;
 		if (fread(value.b, sizeof(value), 1, proc_file) == 1)
 			BusClockSpeed = value.l;
 		fclose(proc_file);
@@ -569,15 +578,23 @@ static void get_system_info(void)
 	// Get actual timebase frequency
 	TimebaseSpeed = BusClockSpeed / 4;
 	DIR *cpus_dir;
-	if ((cpus_dir = opendir("/proc/device-tree/cpus")) != NULL) {
+	if ((cpus_dir = opendir("/proc/device-tree/cpus")) != NULL)
+	{
 		struct dirent *cpu_entry;
-		while ((cpu_entry = readdir(cpus_dir)) != NULL) {
-			if (strstr(cpu_entry->d_name, "PowerPC,") == cpu_entry->d_name) {
+		while ((cpu_entry = readdir(cpus_dir)) != NULL)
+		{
+			if (strstr(cpu_entry->d_name, "PowerPC,") == cpu_entry->d_name)
+			{
 				char timebase_freq_node[256];
 				sprintf(timebase_freq_node, "/proc/device-tree/cpus/%s/timebase-frequency", cpu_entry->d_name);
 				proc_file = fopen(timebase_freq_node, "r");
-				if (proc_file) {
-					union { uint8 b[4]; uint32 l; } value;
+				if (proc_file)
+				{
+					union
+					{
+						uint8 b[4];
+						uint32 l;
+					} value;
 					if (fread(value.b, sizeof(value), 1, proc_file) == 1)
 						TimebaseSpeed = value.l;
 					fclose(proc_file);
@@ -589,16 +606,17 @@ static void get_system_info(void)
 #endif
 
 	// Remap any newer G4/G5 processor to plain G4 for compatibility
-	switch (PVR >> 16) {
-	case 0x8000:				// 7450
-	case 0x8001:				// 7455
-	case 0x8002:				// 7457
-	case 0x8003:				// 7447A
-	case 0x8004:				// 7448
-	case 0x0039:				//  970
-	case 0x003c:				//  970FX
-	case 0x0044:				//  970MP
-		PVR = 0x000c0000;		// 7400
+	switch (PVR >> 16)
+	{
+	case 0x8000:		  // 7450
+	case 0x8001:		  // 7455
+	case 0x8002:		  // 7457
+	case 0x8003:		  // 7447A
+	case 0x8004:		  // 7448
+	case 0x0039:		  //  970
+	case 0x003c:		  //  970FX
+	case 0x0044:		  //  970MP
+		PVR = 0x000c0000; // 7400
 		break;
 	}
 	D(bug("PVR: %08x (assumed)\n", PVR));
@@ -610,9 +628,11 @@ static bool load_mac_rom(void)
 	uint8 *rom_tmp;
 	const char *rom_path = PrefsFindString("rom");
 	int rom_fd = open(rom_path && *rom_path ? rom_path : ROM_FILE_NAME, O_RDONLY);
-	if (rom_fd < 0) {
+	if (rom_fd < 0)
+	{
 		rom_fd = open(ROM_FILE_NAME2, O_RDONLY);
-		if (rom_fd < 0) {
+		if (rom_fd < 0)
+		{
 			ErrorAlert(GetString(STR_NO_ROM_FILE_ERR));
 			return false;
 		}
@@ -623,13 +643,17 @@ static bool load_mac_rom(void)
 	rom_tmp = new uint8[ROM_SIZE];
 	actual = read(rom_fd, (void *)rom_tmp, ROM_SIZE);
 	close(rom_fd);
-	
+
 	// Decode Mac ROM
-	if (!DecodeROM(rom_tmp, actual)) {
-		if (rom_size != 4*1024*1024) {
+	if (!DecodeROM(rom_tmp, actual))
+	{
+		if (rom_size != 4 * 1024 * 1024)
+		{
 			ErrorAlert(GetString(STR_ROM_SIZE_ERR));
 			return false;
-		} else {
+		}
+		else
+		{
 			ErrorAlert(GetString(STR_ROM_FILE_READ_ERR));
 			return false;
 		}
@@ -645,20 +669,23 @@ static bool install_signal_handlers(void)
 	// Create and install stacks for signal handlers
 	sig_stack.ss_sp = malloc(SIG_STACK_SIZE);
 	D(bug("Signal stack at %p\n", sig_stack.ss_sp));
-	if (sig_stack.ss_sp == NULL) {
+	if (sig_stack.ss_sp == NULL)
+	{
 		ErrorAlert(GetString(STR_NOT_ENOUGH_MEMORY_ERR));
 		return false;
 	}
 	sig_stack.ss_flags = 0;
 	sig_stack.ss_size = SIG_STACK_SIZE;
-	if (sigaltstack(&sig_stack, NULL) < 0) {
+	if (sigaltstack(&sig_stack, NULL) < 0)
+	{
 		sprintf(str, GetString(STR_SIGALTSTACK_ERR), strerror(errno));
 		ErrorAlert(str);
 		return false;
 	}
 	extra_stack.ss_sp = malloc(SIG_STACK_SIZE);
 	D(bug("Extra stack at %p\n", extra_stack.ss_sp));
-	if (extra_stack.ss_sp == NULL) {
+	if (extra_stack.ss_sp == NULL)
+	{
 		ErrorAlert(GetString(STR_NOT_ENOUGH_MEMORY_ERR));
 		return false;
 	}
@@ -666,26 +693,29 @@ static bool install_signal_handlers(void)
 	extra_stack.ss_size = SIG_STACK_SIZE;
 
 	// Install SIGSEGV and SIGBUS handlers
-	sigemptyset(&sigsegv_action.sa_mask);	// Block interrupts during SEGV handling
+	sigemptyset(&sigsegv_action.sa_mask); // Block interrupts during SEGV handling
 	sigaddset(&sigsegv_action.sa_mask, SIGUSR2);
 	sigsegv_action.sa_sigaction = sigsegv_handler;
 	sigsegv_action.sa_flags = SA_ONSTACK | SA_SIGINFO;
 #ifdef HAVE_SIGNAL_SA_RESTORER
 	sigsegv_action.sa_restorer = NULL;
 #endif
-	if (sigaction(SIGSEGV, &sigsegv_action, NULL) < 0) {
+	if (sigaction(SIGSEGV, &sigsegv_action, NULL) < 0)
+	{
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGSEGV", strerror(errno));
 		ErrorAlert(str);
 		return false;
 	}
-	if (sigaction(SIGBUS, &sigsegv_action, NULL) < 0) {
+	if (sigaction(SIGBUS, &sigsegv_action, NULL) < 0)
+	{
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGBUS", strerror(errno));
 		ErrorAlert(str);
 		return false;
 	}
 #else
 	// Install SIGSEGV handler for CPU emulator
-	if (!sigsegv_install_handler(sigsegv_handler)) {
+	if (!sigsegv_install_handler(sigsegv_handler))
+	{
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGSEGV", strerror(errno));
 		ErrorAlert(str);
 		return false;
@@ -723,7 +753,8 @@ static bool init_sdl()
 	setenv("SDL_HAS3BUTTONMOUSE", "1", true);
 #endif
 
-	if (SDL_Init(sdl_flags) == -1) {
+	if (SDL_Init(sdl_flags) == -1)
+	{
 		char str[256];
 		sprintf(str, "Could not initialize SDL: %s.\n", SDL_GetError());
 		ErrorAlert(str);
@@ -733,16 +764,19 @@ static bool init_sdl()
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	const int SDL_EVENT_TIMEOUT = 100;
-	for (int i = 0; i < SDL_EVENT_TIMEOUT; i++) {
+	for (int i = 0; i < SDL_EVENT_TIMEOUT; i++)
+	{
 		SDL_Event event;
 		SDL_PollEvent(&event);
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-		if (event.type == SDL_EVENT_DROP_FILE) {
+		if (event.type == SDL_EVENT_DROP_FILE)
+		{
 			sdl_vmdir = event.drop.data;
 			break;
 		}
 #else
-		if (event.type == SDL_DROPFILE) {
+		if (event.type == SDL_DROPFILE)
+		{
 			sdl_vmdir = event.drop.file;
 			break;
 		}
@@ -761,7 +795,7 @@ static bool init_sdl()
 #ifdef ENABLE_GTK
 GtkWindow *win;
 
-static void gui_startup (void)
+static void gui_startup(void)
 {
 #ifdef ENABLE_GTK_3_22
 	color_scheme_set(APP_PREFERS_LIGHT);
@@ -775,13 +809,13 @@ static void gui_startup (void)
 }
 
 #ifdef ENABLE_GTK3
-static void gui_activate (GtkApplication *app)
+static void gui_activate(GtkApplication *app)
 {
-	g_assert (GTK_IS_APPLICATION (app));
-	win = gtk_application_get_active_window (app);
+	g_assert(GTK_IS_APPLICATION(app));
+	win = gtk_application_get_active_window(app);
 	/* Ask the window manager/compositor to present the window. */
 	if (win != NULL)
-		gtk_window_present (win);
+		gtk_window_present(win);
 }
 #endif
 #endif
@@ -818,73 +852,99 @@ int main(int argc, char **argv)
 #if SDL_PLATFORM_MACOS
 	set_current_directory();
 #endif
-	
+
 #ifdef USE_SDL
 	// Initialize SDL system
 	if (!init_sdl())
 		goto quit;
-#if SDL_VERSION_ATLEAST(2,0,0)
-	if (valid_vmdir(sdl_vmdir.c_str())) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (valid_vmdir(sdl_vmdir.c_str()))
+	{
 		vmdir = sdl_vmdir.c_str();
 		printf("Using %s as vmdir.\n", vmdir);
-		if (chdir(vmdir)) {
+		if (chdir(vmdir))
+		{
 			printf("Failed to chdir to %s. Good bye.", vmdir);
 			exit(1);
 		}
 	}
 #endif
 #endif
-	
+
 	// Parse command line arguments
-	for (int i=1; i<argc; i++) {
-		if (strcmp(argv[i], "-NSDocumentRevisionsDebugMode") == 0 || strncmp(argv[i], "-psn_", 5) == 0) {
+	for (int i = 1; i < argc; i++)
+	{
+		if (strcmp(argv[i], "-NSDocumentRevisionsDebugMode") == 0 || strncmp(argv[i], "-psn_", 5) == 0)
+		{
 			argv[i] = NULL;
-		} else if (strcmp(argv[i], "--help") == 0) {
+		}
+		else if (strcmp(argv[i], "--help") == 0)
+		{
 			usage(argv[0]);
 #ifndef USE_SDL_VIDEO
-		} else if (strcmp(argv[i], "--display") == 0) {
+		}
+		else if (strcmp(argv[i], "--display") == 0)
+		{
 			i++;
 			if (i < argc)
 				x_display_name = strdup(argv[i]);
 #endif
-		} else if (strcmp(argv[i], "--gui-connection") == 0) {
+		}
+		else if (strcmp(argv[i], "--gui-connection") == 0)
+		{
 			argv[i++] = NULL;
-			if (i < argc) {
+			if (i < argc)
+			{
 				gui_connection_path = argv[i];
 				argv[i] = NULL;
 			}
-		} else if (strcmp(argv[i], "--config") == 0) {
+		}
+		else if (strcmp(argv[i], "--config") == 0)
+		{
 			argv[i++] = NULL;
-			if (i < argc) {
+			if (i < argc)
+			{
 				extern std::string UserPrefsPath;
 				UserPrefsPath = argv[i];
 				argv[i] = NULL;
 			}
-		} else if (strcmp(argv[i], "--nogui") == 0) {
+		}
+		else if (strcmp(argv[i], "--nogui") == 0)
+		{
 			// We intercept the --nogui commandline so that the settings
 			// window can change the setting from the prefs file
 			argv[i++] = NULL;
-			if (i < argc) {
-				if (strcmp(argv[i], "true") == 0) {
+			if (i < argc)
+			{
+				if (strcmp(argv[i], "true") == 0)
+				{
 					use_gui = false;
 					argv[i] = NULL;
 				}
-				else if (strcmp(argv[i], "false") == 0) {
+				else if (strcmp(argv[i], "false") == 0)
+				{
 					use_gui = true;
 					argv[i] = NULL;
 				}
-			} else {
+			}
+			else
+			{
 				use_gui = false;
 			}
-		} else if (strcmp(argv[i], "--gui") == 0 || strcmp(argv[i], "--settings") == 0) {
+		}
+		else if (strcmp(argv[i], "--gui") == 0 || strcmp(argv[i], "--settings") == 0)
+		{
 			// Alternative commands to enter the GUI
 			use_gui = true;
 			argv[i] = NULL;
-		} else if (valid_vmdir(argv[i])) {
+		}
+		else if (valid_vmdir(argv[i]))
+		{
 			vmdir = argv[i];
 			argv[i] = NULL;
 			printf("Using %s as vmdir.\n", vmdir);
-			if (chdir(vmdir)) {
+			if (chdir(vmdir))
+			{
 				printf("Failed to chdir to %s. Good bye.", vmdir);
 				exit(1);
 			}
@@ -893,22 +953,26 @@ int main(int argc, char **argv)
 	}
 
 	// Remove processed arguments
-	for (int i=1; i<argc; i++) {
+	for (int i = 1; i < argc; i++)
+	{
 		int k;
-		for (k=i; k<argc; k++)
+		for (k = i; k < argc; k++)
 			if (argv[k] != NULL)
 				break;
-		if (k > i) {
+		if (k > i)
+		{
 			k -= i;
-			for (int j=i+k; j<argc; j++)
-				argv[j-k] = argv[j];
+			for (int j = i + k; j < argc; j++)
+				argv[j - k] = argv[j];
 			argc -= k;
 		}
 	}
 
 	// Connect to the external GUI
-	if (gui_connection_path) {
-		if ((gui_connection = rpc_init_client(gui_connection_path)) == NULL) {
+	if (gui_connection_path)
+	{
+		if ((gui_connection = rpc_init_client(gui_connection_path)) == NULL)
+		{
 			fprintf(stderr, "Failed to initialize RPC client connection to the GUI\n");
 			return 1;
 		}
@@ -920,7 +984,7 @@ int main(int argc, char **argv)
 	if (use_gui == -1)
 		use_gui = !PrefsFindBool("nogui");
 
-#if SDL_PLATFORM_MACOS && SDL_VERSION_ATLEAST(2,0,0)
+#if SDL_PLATFORM_MACOS && SDL_VERSION_ATLEAST(2, 0, 0)
 	// On Mac OS X hosts, SDL2 will create its own menu bar.  This is mostly OK,
 	// except that it will also install keyboard shortcuts, such as Command + Q,
 	// which can interfere with keyboard shortcuts in the guest OS.
@@ -929,10 +993,12 @@ int main(int argc, char **argv)
 	// menu bar in-place.
 	disable_SDL2_macosx_menu_bar_keyboard_shortcuts();
 #endif
-	
+
 	// Any command line arguments left?
-	for (int i=1; i<argc; i++) {
-		if (argv[i][0] == '-') {
+	for (int i = 1; i < argc; i++)
+	{
+		if (argv[i][0] == '-')
+		{
 			fprintf(stderr, "Unrecognized option '%s'\n", argv[i]);
 			usage(argv[0]);
 		}
@@ -941,7 +1007,8 @@ int main(int argc, char **argv)
 #ifndef USE_SDL_VIDEO
 	// Open display
 	x_display = XOpenDisplay(x_display_name);
-	if (x_display == NULL) {
+	if (x_display == NULL)
+	{
 		char str[256];
 		sprintf(str, GetString(STR_NO_XSERVER_ERR), XDisplayName(x_display_name));
 		ErrorAlert(str);
@@ -959,7 +1026,7 @@ int main(int argc, char **argv)
 	mon_init();
 #endif
 
-  // Install signal handlers
+	// Install signal handlers
 	if (!install_signal_handlers())
 		goto quit;
 
@@ -973,18 +1040,20 @@ int main(int argc, char **argv)
 	SysInit();
 
 #ifdef ENABLE_GTK3
-	if (!gui_connection) {
+	if (!gui_connection)
+	{
 		// Init GTK
-		app = gtk_application_new (GetString(STR_APP_ID), G_APPLICATION_FLAGS_NONE);
-		g_set_prgname (GetString(STR_APP_DISPLAY_NAME));
-		g_signal_connect (app, "activate", G_CALLBACK (gui_activate), NULL);
-		g_signal_connect (app, "startup", G_CALLBACK (gui_startup), NULL);
-		g_application_register (G_APPLICATION (app), NULL, NULL);
-		ret = g_application_run (G_APPLICATION (app), argc, argv);
+		app = gtk_application_new(GetString(STR_APP_ID), G_APPLICATION_FLAGS_NONE);
+		g_set_prgname(GetString(STR_APP_DISPLAY_NAME));
+		g_signal_connect(app, "activate", G_CALLBACK(gui_activate), NULL);
+		g_signal_connect(app, "startup", G_CALLBACK(gui_startup), NULL);
+		g_application_register(G_APPLICATION(app), NULL, NULL);
+		ret = g_application_run(G_APPLICATION(app), argc, argv);
 	}
 #elif defined(ENABLE_GTK)
-	if (!gui_connection) {
-	// Init GTK
+	if (!gui_connection)
+	{
+		// Init GTK
 		gtk_set_locale();
 		gtk_init(&argc, &argv);
 		gui_startup();
@@ -998,7 +1067,8 @@ int main(int argc, char **argv)
 
 	// Open /dev/zero
 	zero_fd = open("/dev/zero", O_RDWR);
-	if (zero_fd < 0) {
+	if (zero_fd < 0)
+	{
 		sprintf(str, GetString(STR_NO_DEV_ZERO_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1038,30 +1108,35 @@ int main(int argc, char **argv)
 	DRCacheAddr = DR_CACHE_BASE;
 	D(bug("DR Cache at %p\n", DRCacheAddr));
 #endif
-	
+
 	// Create area for Mac RAM
 	RAMSize = PrefsFindInt32("ramsize");
-	if (RAMSize <= 1000) {
+	if (RAMSize <= 1000)
+	{
 		RAMSize *= 1024 * 1024;
 	}
-	if (RAMSize < 16 * 1024 * 1024) {
+	if (RAMSize < 16 * 1024 * 1024)
+	{
 		WarningAlert(GetString(STR_SMALL_RAM_WARN));
 		RAMSize = 16 * 1024 * 1024;
 	}
 	memory_mapped_from_zero = false;
 	ram_rom_areas_contiguous = false;
 #if REAL_ADDRESSING && HAVE_LINKER_SCRIPT
-	if (vm_mac_acquire_fixed(0, RAMSize) == 0) {
+	if (vm_mac_acquire_fixed(0, RAMSize) == 0)
+	{
 		D(bug("Could allocate RAM from 0x0000\n"));
 		RAMBase = 0;
 		RAMBaseHost = Mac2HostAddr(RAMBase);
 		memory_mapped_from_zero = true;
 	}
 #endif
-	if (!memory_mapped_from_zero) {
+	if (!memory_mapped_from_zero)
+	{
 #ifndef PAGEZERO_HACK
 		// Create Low Memory area (0x0000..0x3000)
-		if (vm_mac_acquire_fixed(0, 0x3000) < 0) {
+		if (vm_mac_acquire_fixed(0, 0x3000) < 0)
+		{
 			sprintf(str, GetString(STR_LOW_MEM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
@@ -1072,19 +1147,21 @@ int main(int argc, char **argv)
 		// Allocate RAM at any address. Since ROM must be higher than RAM, allocate the RAM
 		// and ROM areas contiguously, plus a little extra to allow for ROM address alignment.
 		RAMBaseHost = vm_mac_acquire(RAMSize + ROM_AREA_SIZE + ROM_ALIGNMENT + SIG_STACK_SIZE);
-		if (RAMBaseHost == VM_MAP_FAILED) {
+		if (RAMBaseHost == VM_MAP_FAILED)
+		{
 			sprintf(str, GetString(STR_RAM_ROM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
 		}
 		RAMBase = Host2MacAddr(RAMBaseHost);
-		ROMBase = (RAMBase + RAMSize + ROM_ALIGNMENT -1) & -ROM_ALIGNMENT;
+		ROMBase = (RAMBase + RAMSize + ROM_ALIGNMENT - 1) & -ROM_ALIGNMENT;
 		ROMBaseHost = RAMBaseHost + ROMBase - RAMBase;
 		ROMEnd = RAMBase + RAMSize + ROM_AREA_SIZE + ROM_ALIGNMENT;
 
 		ram_rom_areas_contiguous = true;
 #else
-		if (vm_mac_acquire_fixed(RAM_BASE, RAMSize) < 0) {
+		if (vm_mac_acquire_fixed(RAM_BASE, RAMSize) < 0)
+		{
 			sprintf(str, GetString(STR_RAM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
@@ -1094,7 +1171,8 @@ int main(int argc, char **argv)
 #endif
 	}
 #if !EMULATED_PPC
-	if (vm_protect(RAMBaseHost, RAMSize, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0) {
+	if (vm_protect(RAMBaseHost, RAMSize, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0)
+	{
 		sprintf(str, GetString(STR_RAM_MMAP_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1103,14 +1181,17 @@ int main(int argc, char **argv)
 	ram_area_mapped = true;
 	D(bug("RAM area at %p (%08x)\n", RAMBaseHost, RAMBase));
 
-	if (RAMBase > KernelDataAddr) {
+	if (RAMBase > KernelDataAddr)
+	{
 		ErrorAlert(GetString(STR_RAM_AREA_TOO_HIGH_ERR));
 		goto quit;
 	}
-	
+
 	// Create area for Mac ROM
-	if (!ram_rom_areas_contiguous) {
-		if (vm_mac_acquire_fixed(ROM_BASE, ROM_AREA_SIZE + SIG_STACK_SIZE) < 0) {
+	if (!ram_rom_areas_contiguous)
+	{
+		if (vm_mac_acquire_fixed(ROM_BASE, ROM_AREA_SIZE + SIG_STACK_SIZE) < 0)
+		{
 			sprintf(str, GetString(STR_ROM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
@@ -1120,7 +1201,8 @@ int main(int argc, char **argv)
 		ROMEnd = ROMBase + ROM_AREA_SIZE;
 	}
 #if !EMULATED_PPC
-	if (vm_protect(ROMBaseHost, ROM_AREA_SIZE, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0) {
+	if (vm_protect(ROMBaseHost, ROM_AREA_SIZE, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0)
+	{
 		sprintf(str, GetString(STR_ROM_MMAP_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1129,18 +1211,20 @@ int main(int argc, char **argv)
 	rom_area_mapped = true;
 	D(bug("ROM area at %p (%08x)\n", ROMBaseHost, ROMBase));
 
-	if (RAMBase > ROMBase) {
+	if (RAMBase > ROMBase)
+	{
 		ErrorAlert(GetString(STR_RAM_HIGHER_THAN_ROM_ERR));
 		goto quit;
 	}
 
 	// Create area for SheepShaver data
-	if (!SheepMem::Init()) {
+	if (!SheepMem::Init())
+	{
 		sprintf(str, GetString(STR_SHEEP_MEM_MMAP_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
 	}
-	
+
 	// Load Mac ROM
 	if (!load_mac_rom())
 		goto quit;
@@ -1169,14 +1253,15 @@ int main(int argc, char **argv)
 
 #if !EMULATED_PPC
 	// Install SIGILL handler
-	sigemptyset(&sigill_action.sa_mask);	// Block interrupts during ILL handling
+	sigemptyset(&sigill_action.sa_mask); // Block interrupts during ILL handling
 	sigaddset(&sigill_action.sa_mask, SIGUSR2);
 	sigill_action.sa_sigaction = sigill_handler;
 	sigill_action.sa_flags = SA_ONSTACK | SA_SIGINFO;
 #ifdef HAVE_SIGNAL_SA_RESTORER
 	sigill_action.sa_restorer = NULL;
 #endif
-	if (sigaction(SIGILL, &sigill_action, NULL) < 0) {
+	if (sigaction(SIGILL, &sigill_action, NULL) < 0)
+	{
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGILL", strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1191,7 +1276,8 @@ int main(int argc, char **argv)
 #ifdef HAVE_SIGNAL_SA_RESTORER
 	sigusr2_action.sa_restorer = NULL;
 #endif
-	if (sigaction(SIGUSR2, &sigusr2_action, NULL) < 0) {
+	if (sigaction(SIGUSR2, &sigusr2_action, NULL) < 0)
+	{
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGUSR2", strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1208,7 +1294,6 @@ quit:
 	return 0;
 }
 
-
 /*
  *  Cleanup and quit
  */
@@ -1221,14 +1306,16 @@ static void Quit(void)
 #endif
 
 	// Stop 60Hz thread
-	if (tick_thread_active) {
+	if (tick_thread_active)
+	{
 		tick_thread_cancel = true;
 		pthread_cancel(tick_thread);
 		pthread_join(tick_thread, NULL);
 	}
 
 	// Stop NVRAM watchdog thread
-	if (nvram_thread_active) {
+	if (nvram_thread_active)
+	{
 		nvram_thread_cancel = true;
 		pthread_cancel(nvram_thread);
 		pthread_join(nvram_thread, NULL);
@@ -1301,7 +1388,8 @@ static void Quit(void)
 #endif
 
 	// Notify GUI we are about to leave
-	if (gui_connection) {
+	if (gui_connection)
+	{
 		if (rpc_method_invoke(gui_connection, RPC_METHOD_EXIT, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR)
 			rpc_method_wait_for_reply(gui_connection, RPC_TYPE_INVALID);
 	}
@@ -1319,7 +1407,8 @@ static bool kernel_data_init(void)
 	int error_string = STR_KD_SHMGET_ERR;
 	uint32 kernel_area_size = (KERNEL_AREA_SIZE + SHMLBA - 1) & -SHMLBA;
 	int kernel_area = shmget(IPC_PRIVATE, kernel_area_size, 0600);
-	if (kernel_area != -1) {
+	if (kernel_area != -1)
+	{
 		bool mapped =
 			shm_map_address(kernel_area, KERNEL_DATA_BASE & -SHMLBA) &&
 			shm_map_address(kernel_area, KERNEL_DATA2_BASE & -SHMLBA);
@@ -1349,8 +1438,7 @@ static bool shm_map_address(int kernel_area, uint32 addr)
 	void *kernel_addr = Mac2HostAddr(addr);
 	return shmat(kernel_area, kernel_addr, 0) == kernel_addr;
 }
-#endif  // !defined(__APPLE__) || !defined(__x86_64__)
-
+#endif // !defined(__APPLE__) || !defined(__x86_64__)
 
 /*
  *  Jump into Mac ROM, start 680x0 emulator
@@ -1363,7 +1451,6 @@ void jump_to_rom(uint32 entry)
 	emul_ppc(entry);
 }
 #endif
-
 
 /*
  *  Emulator thread function
@@ -1391,7 +1478,6 @@ static void *emul_func(void *arg)
 	return NULL;
 }
 
-
 #if !EMULATED_PPC
 /*
  *  Execute 68k subroutine (must be ended with RTS)
@@ -1410,7 +1496,6 @@ void Execute68k(uint32 pc, M68kRegisters *r)
 	execute_68k(pc, r);
 }
 
-
 /*
  *  Execute 68k A-Trap from EMUL_OP routine
  *  r->a[7] is unused, the routine runs on the caller's stack
@@ -1422,7 +1507,6 @@ void Execute68kTrap(uint16 trap, M68kRegisters *r)
 	Execute68k((uint32)proc, r);
 }
 #endif
-
 
 /*
  *  Quit emulator (cause return from jump_to_rom)
@@ -1437,7 +1521,6 @@ void QuitEmulator(void)
 #endif
 }
 
-
 /*
  *  Dump 68k registers
  */
@@ -1445,14 +1528,16 @@ void QuitEmulator(void)
 void Dump68kRegs(M68kRegisters *r)
 {
 	// Display 68k registers
-	for (int i=0; i<8; i++) {
+	for (int i = 0; i < 8; i++)
+	{
 		printf("d%d: %08x", i, r->d[i]);
 		if (i == 3 || i == 7)
 			printf("\n");
 		else
 			printf(", ");
 	}
-	for (int i=0; i<8; i++) {
+	for (int i = 0; i < 8; i++)
+	{
 		printf("a%d: %08x", i, r->a[i]);
 		if (i == 3 || i == 7)
 			printf("\n");
@@ -1460,7 +1545,6 @@ void Dump68kRegs(M68kRegisters *r)
 			printf(", ");
 	}
 }
-
 
 /*
  *  Make code executable
@@ -1477,14 +1561,14 @@ void MakeExecutable(int dummy, uint32 start, uint32 length)
 #endif
 }
 
-
 /*
  *  NVRAM watchdog thread (saves NVRAM every minute)
  */
 
 static void nvram_watchdog(void)
 {
-	if (memcmp(last_xpram, XPRAM, XPRAM_SIZE)) {
+	if (memcmp(last_xpram, XPRAM, XPRAM_SIZE))
+	{
 		memcpy(last_xpram, XPRAM, XPRAM_SIZE);
 		SaveXPRAM();
 	}
@@ -1492,14 +1576,14 @@ static void nvram_watchdog(void)
 
 static void *nvram_func(void *arg)
 {
-	while (!nvram_thread_cancel) {
-		for (int i=0; i<60 && !nvram_thread_cancel; i++)
-			Delay_usec(999999);		// Only wait 1 second so we quit promptly when nvram_thread_cancel becomes true
+	while (!nvram_thread_cancel)
+	{
+		for (int i = 0; i < 60 && !nvram_thread_cancel; i++)
+			Delay_usec(999999); // Only wait 1 second so we quit promptly when nvram_thread_cancel becomes true
 		nvram_watchdog();
 	}
 	return NULL;
 }
-
 
 /*
  *  60Hz thread (really 60.15Hz)
@@ -1513,7 +1597,8 @@ static void *tick_func(void *arg)
 	int64 ticks = 0;
 	uint64 next = start;
 
-	while (!tick_thread_cancel) {
+	while (!tick_thread_cancel)
+	{
 
 		// Wait
 		next += 16625;
@@ -1522,12 +1607,14 @@ static void *tick_func(void *arg)
 			Delay_usec(delay);
 		else if (delay < -16625)
 			next = GetTicks_usec();
-		if (tick_inhibit) continue;
+		if (tick_inhibit)
+			continue;
 		ticks++;
 
 #if !EMULATED_PPC
 		// Did we crash?
-		if (emul_thread_fatal) {
+		if (emul_thread_fatal)
+		{
 
 			// Yes, dump registers
 			sigregs *r = &sigsegv_regs;
@@ -1535,27 +1622,27 @@ static void *tick_func(void *arg)
 			if (crash_reason == NULL)
 				crash_reason = "SIGSEGV";
 			sprintf(str, "%s\n"
-				"   pc %08lx     lr %08lx    ctr %08lx    msr %08lx\n"
-				"  xer %08lx     cr %08lx  \n"
-				"   r0 %08lx     r1 %08lx     r2 %08lx     r3 %08lx\n"
-				"   r4 %08lx     r5 %08lx     r6 %08lx     r7 %08lx\n"
-				"   r8 %08lx     r9 %08lx    r10 %08lx    r11 %08lx\n"
-				"  r12 %08lx    r13 %08lx    r14 %08lx    r15 %08lx\n"
-				"  r16 %08lx    r17 %08lx    r18 %08lx    r19 %08lx\n"
-				"  r20 %08lx    r21 %08lx    r22 %08lx    r23 %08lx\n"
-				"  r24 %08lx    r25 %08lx    r26 %08lx    r27 %08lx\n"
-				"  r28 %08lx    r29 %08lx    r30 %08lx    r31 %08lx\n",
-				crash_reason,
-				r->nip, r->link, r->ctr, r->msr,
-				r->xer, r->ccr,
-				r->gpr[0], r->gpr[1], r->gpr[2], r->gpr[3],
-				r->gpr[4], r->gpr[5], r->gpr[6], r->gpr[7],
-				r->gpr[8], r->gpr[9], r->gpr[10], r->gpr[11],
-				r->gpr[12], r->gpr[13], r->gpr[14], r->gpr[15],
-				r->gpr[16], r->gpr[17], r->gpr[18], r->gpr[19],
-				r->gpr[20], r->gpr[21], r->gpr[22], r->gpr[23],
-				r->gpr[24], r->gpr[25], r->gpr[26], r->gpr[27],
-				r->gpr[28], r->gpr[29], r->gpr[30], r->gpr[31]);
+						 "   pc %08lx     lr %08lx    ctr %08lx    msr %08lx\n"
+						 "  xer %08lx     cr %08lx  \n"
+						 "   r0 %08lx     r1 %08lx     r2 %08lx     r3 %08lx\n"
+						 "   r4 %08lx     r5 %08lx     r6 %08lx     r7 %08lx\n"
+						 "   r8 %08lx     r9 %08lx    r10 %08lx    r11 %08lx\n"
+						 "  r12 %08lx    r13 %08lx    r14 %08lx    r15 %08lx\n"
+						 "  r16 %08lx    r17 %08lx    r18 %08lx    r19 %08lx\n"
+						 "  r20 %08lx    r21 %08lx    r22 %08lx    r23 %08lx\n"
+						 "  r24 %08lx    r25 %08lx    r26 %08lx    r27 %08lx\n"
+						 "  r28 %08lx    r29 %08lx    r30 %08lx    r31 %08lx\n",
+					crash_reason,
+					r->nip, r->link, r->ctr, r->msr,
+					r->xer, r->ccr,
+					r->gpr[0], r->gpr[1], r->gpr[2], r->gpr[3],
+					r->gpr[4], r->gpr[5], r->gpr[6], r->gpr[7],
+					r->gpr[8], r->gpr[9], r->gpr[10], r->gpr[11],
+					r->gpr[12], r->gpr[13], r->gpr[14], r->gpr[15],
+					r->gpr[16], r->gpr[17], r->gpr[18], r->gpr[19],
+					r->gpr[20], r->gpr[21], r->gpr[22], r->gpr[23],
+					r->gpr[24], r->gpr[25], r->gpr[26], r->gpr[27],
+					r->gpr[28], r->gpr[29], r->gpr[30], r->gpr[31]);
 			printf(str);
 			VideoQuitFullScreen();
 
@@ -1570,13 +1657,15 @@ static void *tick_func(void *arg)
 #endif
 
 		// Pseudo Mac 1Hz interrupt, update local time
-		if (++tick_counter > 60) {
+		if (++tick_counter > 60)
+		{
 			tick_counter = 0;
 			WriteMacInt32(0x20c, TimerDateTime());
 		}
 
 		// Trigger 60Hz interrupt
-		if (ReadMacInt32(XLM_IRQ_NEST) == 0) {
+		if (ReadMacInt32(XLM_IRQ_NEST) == 0)
+		{
 			SetInterruptFlag(INTFLAG_VIA);
 			TriggerInterrupt();
 		}
@@ -1586,7 +1675,6 @@ static void *tick_func(void *arg)
 	D(bug("%lld ticks in %lld usec = %f ticks/sec\n", ticks, end - start, ticks * 1000000.0 / (end - start)));
 	return NULL;
 }
-
 
 /*
  *  Pthread configuration
@@ -1598,28 +1686,30 @@ void Set_pthread_attr(pthread_attr_t *attr, int priority)
 	pthread_attr_init(attr);
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING)
 	// Some of these only work for superuser
-	if (geteuid() == 0) {
+	if (geteuid() == 0)
+	{
 		pthread_attr_setinheritsched(attr, PTHREAD_EXPLICIT_SCHED);
 		pthread_attr_setschedpolicy(attr, SCHED_FIFO);
 		struct sched_param fifo_param;
-		fifo_param.sched_priority = ((sched_get_priority_min(SCHED_FIFO) + 
-					      sched_get_priority_max(SCHED_FIFO)) / 2 +
-					     priority);
+		fifo_param.sched_priority = ((sched_get_priority_min(SCHED_FIFO) +
+									  sched_get_priority_max(SCHED_FIFO)) /
+										 2 +
+									 priority);
 		pthread_attr_setschedparam(attr, &fifo_param);
 	}
-	if (pthread_attr_setscope(attr, PTHREAD_SCOPE_SYSTEM) != 0) {
+	if (pthread_attr_setscope(attr, PTHREAD_SCOPE_SYSTEM) != 0)
+	{
 #ifdef PTHREAD_SCOPE_BOUND_NP
-	    // If system scope is not available (eg. we're not running
-	    // with CAP_SCHED_MGT capability on an SGI box), try bound
-	    // scope.  It exposes pthread scheduling to the kernel,
-	    // without setting realtime priority.
-	    pthread_attr_setscope(attr, PTHREAD_SCOPE_BOUND_NP);
+		// If system scope is not available (eg. we're not running
+		// with CAP_SCHED_MGT capability on an SGI box), try bound
+		// scope.  It exposes pthread scheduling to the kernel,
+		// without setting realtime priority.
+		pthread_attr_setscope(attr, PTHREAD_SCOPE_BOUND_NP);
 #endif
 	}
 #endif
 #endif
 }
-
 
 /*
  *  Mutexes
@@ -1627,28 +1717,31 @@ void Set_pthread_attr(pthread_attr_t *attr, int priority)
 
 #ifdef HAVE_PTHREADS
 
-struct B2_mutex {
-	B2_mutex() { 
-	    pthread_mutexattr_t attr;
-	    pthread_mutexattr_init(&attr);
-	    // Initialize the mutex for priority inheritance --
-	    // required for accurate timing.
+struct B2_mutex
+{
+	B2_mutex()
+	{
+		pthread_mutexattr_t attr;
+		pthread_mutexattr_init(&attr);
+		// Initialize the mutex for priority inheritance --
+		// required for accurate timing.
 #if defined(HAVE_PTHREAD_MUTEXATTR_SETPROTOCOL) && !defined(__CYGWIN__)
-	    pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
+		pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
 #endif
 #if defined(HAVE_PTHREAD_MUTEXATTR_SETTYPE) && defined(PTHREAD_MUTEX_NORMAL)
-	    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
+		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
 #endif
 #ifdef HAVE_PTHREAD_MUTEXATTR_SETPSHARED
-	    pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
+		pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
 #endif
-	    pthread_mutex_init(&m, &attr);
-	    pthread_mutexattr_destroy(&attr);
+		pthread_mutex_init(&m, &attr);
+		pthread_mutexattr_destroy(&attr);
 	}
-	~B2_mutex() { 
-	    pthread_mutex_trylock(&m); // Make sure it's locked before
-	    pthread_mutex_unlock(&m);  // unlocking it.
-	    pthread_mutex_destroy(&m);
+	~B2_mutex()
+	{
+		pthread_mutex_trylock(&m); // Make sure it's locked before
+		pthread_mutex_unlock(&m);  // unlocking it.
+		pthread_mutex_destroy(&m);
 	}
 	pthread_mutex_t m;
 };
@@ -1675,7 +1768,8 @@ void B2_delete_mutex(B2_mutex *mutex)
 
 #else
 
-struct B2_mutex {
+struct B2_mutex
+{
 	int dummy;
 };
 
@@ -1699,7 +1793,6 @@ void B2_delete_mutex(B2_mutex *mutex)
 
 #endif
 
-
 /*
  *  Trigger signal USR2 from another thread
  */
@@ -1707,13 +1800,13 @@ void B2_delete_mutex(B2_mutex *mutex)
 #if !EMULATED_PPC
 void TriggerInterrupt(void)
 {
-	if (ready_for_signals) {
+	if (ready_for_signals)
+	{
 		idle_resume();
 		pthread_kill(emul_thread, SIGUSR2);
 	}
 }
 #endif
-
 
 /*
  *  Interrupt flags (must be handled atomically!)
@@ -1731,7 +1824,6 @@ void ClearInterruptFlag(uint32 flag)
 	atomic_and((int *)&InterruptFlags, ~flag);
 }
 
-
 /*
  *  Disable interrupts
  */
@@ -1745,7 +1837,6 @@ void DisableInterrupt(void)
 #endif
 }
 
-
 /*
  *  Enable interrupts
  */
@@ -1758,7 +1849,6 @@ void EnableInterrupt(void)
 	atomic_add((int *)XLM_IRQ_NEST, -1);
 #endif
 }
-
 
 /*
  *  USR2 handler
@@ -1791,79 +1881,83 @@ void sigusr2_handler(int sig, siginfo_t *sip, void *scp)
 	WriteMacInt32(0x110, 0);
 
 	// Interrupt action depends on current run mode
-	switch (ReadMacInt32(XLM_RUN_MODE)) {
-		case MODE_68K:
-			// 68k emulator active, trigger 68k interrupt level 1
-			WriteMacInt16(ReadMacInt32(0x67c), 1);
-			r->cr() |= ReadMacInt32(0x674);
-			break;
+	switch (ReadMacInt32(XLM_RUN_MODE))
+	{
+	case MODE_68K:
+		// 68k emulator active, trigger 68k interrupt level 1
+		WriteMacInt16(ReadMacInt32(0x67c), 1);
+		r->cr() |= ReadMacInt32(0x674);
+		break;
 
 #if INTERRUPTS_IN_NATIVE_MODE
-		case MODE_NATIVE:
-			// 68k emulator inactive, in nanokernel?
-			if (r->gpr(1) != KernelDataAddr) {
+	case MODE_NATIVE:
+		// 68k emulator inactive, in nanokernel?
+		if (r->gpr(1) != KernelDataAddr)
+		{
 
-				// Set extra stack for SIGSEGV handler
-				sigaltstack(&extra_stack, NULL);
-				
-				// Prepare for 68k interrupt level 1
-				WriteMacInt16(ReadMacInt32(0x67c), 1);
-				WriteMacInt32(ReadMacInt32(0x658) + 0xdc, ReadMacInt32(ReadMacInt32(0x658) + 0xdc) | ReadMacInt32(0x674));
+			// Set extra stack for SIGSEGV handler
+			sigaltstack(&extra_stack, NULL);
 
-				// Execute nanokernel interrupt routine (this will activate the 68k emulator)
-				DisableInterrupt();
-				if (ROMType == ROMTYPE_NEWWORLD)
-					ppc_interrupt(ROMBase + 0x312b1c, KernelDataAddr);
-				else
-					ppc_interrupt(ROMBase + 0x312a3c, KernelDataAddr);
+			// Prepare for 68k interrupt level 1
+			WriteMacInt16(ReadMacInt32(0x67c), 1);
+			WriteMacInt32(ReadMacInt32(0x658) + 0xdc, ReadMacInt32(ReadMacInt32(0x658) + 0xdc) | ReadMacInt32(0x674));
 
-				// Reset normal stack
-				sigaltstack(&sig_stack, NULL);
-			}
-			break;
+			// Execute nanokernel interrupt routine (this will activate the 68k emulator)
+			DisableInterrupt();
+			if (ROMType == ROMTYPE_NEWWORLD)
+				ppc_interrupt(ROMBase + 0x312b1c, KernelDataAddr);
+			else
+				ppc_interrupt(ROMBase + 0x312a3c, KernelDataAddr);
+
+			// Reset normal stack
+			sigaltstack(&sig_stack, NULL);
+		}
+		break;
 #endif
 
 #if INTERRUPTS_IN_EMUL_OP_MODE
-		case MODE_EMUL_OP:
-			// 68k emulator active, within EMUL_OP routine, execute 68k interrupt routine directly when interrupt level is 0
-			if ((ReadMacInt32(XLM_68K_R25) & 7) == 0) {
+	case MODE_EMUL_OP:
+		// 68k emulator active, within EMUL_OP routine, execute 68k interrupt routine directly when interrupt level is 0
+		if ((ReadMacInt32(XLM_68K_R25) & 7) == 0)
+		{
 
-				// Set extra stack for SIGSEGV handler
-				sigaltstack(&extra_stack, NULL);
+			// Set extra stack for SIGSEGV handler
+			sigaltstack(&extra_stack, NULL);
 #if 1
-				// Execute full 68k interrupt routine
-				M68kRegisters r;
-				uint32 old_r25 = ReadMacInt32(XLM_68K_R25);	// Save interrupt level
-				WriteMacInt32(XLM_68K_R25, 0x21);			// Execute with interrupt level 1
-				static const uint16 proc[] = {
-					0x3f3c, 0x0000,		// move.w	#$0000,-(sp)	(fake format word)
-					0x487a, 0x000a,		// pea		@1(pc)			(return address)
-					0x40e7,				// move		sr,-(sp)		(saved SR)
-					0x2078, 0x0064,		// move.l	$64,a0
-					0x4ed0,				// jmp		(a0)
-					M68K_RTS			// @1
-				};
-				Execute68k((uint32)proc, &r);
-				WriteMacInt32(XLM_68K_R25, old_r25);		// Restore interrupt level
+			// Execute full 68k interrupt routine
+			M68kRegisters r;
+			uint32 old_r25 = ReadMacInt32(XLM_68K_R25); // Save interrupt level
+			WriteMacInt32(XLM_68K_R25, 0x21);			// Execute with interrupt level 1
+			static const uint16 proc[] = {
+				0x3f3c, 0x0000, // move.w	#$0000,-(sp)	(fake format word)
+				0x487a, 0x000a, // pea		@1(pc)			(return address)
+				0x40e7,			// move		sr,-(sp)		(saved SR)
+				0x2078, 0x0064, // move.l	$64,a0
+				0x4ed0,			// jmp		(a0)
+				M68K_RTS		// @1
+			};
+			Execute68k((uint32)proc, &r);
+			WriteMacInt32(XLM_68K_R25, old_r25); // Restore interrupt level
 #else
-				// Only update cursor
-				if (HasMacStarted()) {
-					if (InterruptFlags & INTFLAG_VIA) {
-						ClearInterruptFlag(INTFLAG_VIA);
-						ADBInterrupt();
-						ExecuteNative(NATIVE_VIDEO_VBL);
-					}
+			// Only update cursor
+			if (HasMacStarted())
+			{
+				if (InterruptFlags & INTFLAG_VIA)
+				{
+					ClearInterruptFlag(INTFLAG_VIA);
+					ADBInterrupt();
+					ExecuteNative(NATIVE_VIDEO_VBL);
 				}
-#endif
-				// Reset normal stack
-				sigaltstack(&sig_stack, NULL);
 			}
-			break;
+#endif
+			// Reset normal stack
+			sigaltstack(&sig_stack, NULL);
+		}
+		break;
 #endif
 	}
 }
 #endif
-
 
 /*
  *  SIGSEGV handler
@@ -1876,7 +1970,7 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 
 	// Get effective address
 	uint32 addr = r->dar();
-	
+
 #ifdef SYSTEM_CLOBBERS_R2
 	// Restore pointer to Thread Local Storage
 	set_r2(TOC);
@@ -1888,51 +1982,65 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 
 #if ENABLE_VOSF
 	// Handle screen fault
-#if SIGSEGV_CHECK_VERSION(1,0,0)
+#if SIGSEGV_CHECK_VERSION(1, 0, 0)
 	sigsegv_info_t si;
 	si.addr = (sigsegv_address_t)addr;
 	si.pc = (sigsegv_address_t)r->pc();
 #endif
-	extern bool Screen_fault_handler(sigsegv_info_t *sip);
+	extern bool Screen_fault_handler(sigsegv_info_t * sip);
 	if (Screen_fault_handler(&si))
 		return;
 #endif
 
 	// Fault in Mac ROM or RAM or DR Cache?
 	bool mac_fault = (r->pc() >= ROMBase) && (r->pc() < (ROMBase + ROM_AREA_SIZE)) || (r->pc() >= RAMBase) && (r->pc() < (RAMBase + RAMSize)) || (r->pc() >= DR_CACHE_BASE && r->pc() < (DR_CACHE_BASE + DR_CACHE_SIZE));
-	if (mac_fault) {
+	if (mac_fault)
+	{
 
 		// "VM settings" during MacOS 8 installation
-		if (r->pc() == ROMBase + 0x488160 && r->gpr(20) == 0xf8000000) {
+		if (r->pc() == ROMBase + 0x488160 && r->gpr(20) == 0xf8000000)
+		{
 			r->pc() += 4;
 			r->gpr(8) = 0;
 			return;
-	
-		// MacOS 8.5 installation
-		} else if (r->pc() == ROMBase + 0x488140 && r->gpr(16) == 0xf8000000) {
+
+			// MacOS 8.5 installation
+		}
+		else if (r->pc() == ROMBase + 0x488140 && r->gpr(16) == 0xf8000000)
+		{
 			r->pc() += 4;
 			r->gpr(8) = 0;
 			return;
-	
-		// MacOS 8 serial drivers on startup
-		} else if (r->pc() == ROMBase + 0x48e080 && (r->gpr(8) == 0xf3012002 || r->gpr(8) == 0xf3012000)) {
+
+			// MacOS 8 serial drivers on startup
+		}
+		else if (r->pc() == ROMBase + 0x48e080 && (r->gpr(8) == 0xf3012002 || r->gpr(8) == 0xf3012000))
+		{
 			r->pc() += 4;
 			r->gpr(8) = 0;
 			return;
-	
-		// MacOS 8.1 serial drivers on startup
-		} else if (r->pc() == ROMBase + 0x48c5e0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000)) {
+
+			// MacOS 8.1 serial drivers on startup
+		}
+		else if (r->pc() == ROMBase + 0x48c5e0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000))
+		{
 			r->pc() += 4;
 			return;
-		} else if (r->pc() == ROMBase + 0x4a10a0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000)) {
+		}
+		else if (r->pc() == ROMBase + 0x4a10a0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000))
+		{
 			r->pc() += 4;
 			return;
-	
-		// MacOS 8.6 serial drivers on startup (with DR Cache and OldWorld ROM)
-		} else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(16) == 0xf3012002 || r->gpr(16) == 0xf3012000)) {
+
+			// MacOS 8.6 serial drivers on startup (with DR Cache and OldWorld ROM)
+		}
+		else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(16) == 0xf3012002 || r->gpr(16) == 0xf3012000))
+		{
 			r->pc() += 4;
 			return;
-		} else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000)) {
+		}
+		else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000))
+		{
 			r->pc() += 4;
 			return;
 		}
@@ -1947,119 +2055,213 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		int32 imm = (int16)(opcode & 0xffff);
 
 		// Analyze opcode
-		enum {
+		enum
+		{
 			TYPE_UNKNOWN,
 			TYPE_LOAD,
 			TYPE_STORE
 		} transfer_type = TYPE_UNKNOWN;
-		enum {
+		enum
+		{
 			SIZE_UNKNOWN,
 			SIZE_BYTE,
 			SIZE_HALFWORD,
 			SIZE_WORD
 		} transfer_size = SIZE_UNKNOWN;
-		enum {
+		enum
+		{
 			MODE_UNKNOWN,
 			MODE_NORM,
 			MODE_U,
 			MODE_X,
 			MODE_UX
 		} addr_mode = MODE_UNKNOWN;
-		switch (primop) {
-			case 31:
-				switch (exop) {
-					case 23:	// lwzx
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_X; break;
-					case 55:	// lwzux
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_UX; break;
-					case 87:	// lbzx
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_X; break;
-					case 119:	// lbzux
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_UX; break;
-					case 151:	// stwx
-						transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_X; break;
-					case 183:	// stwux
-						transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_UX; break;
-					case 215:	// stbx
-						transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_X; break;
-					case 247:	// stbux
-						transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_UX; break;
-					case 279:	// lhzx
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_X; break;
-					case 311:	// lhzux
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_UX; break;
-					case 343:	// lhax
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_X; break;
-					case 375:	// lhaux
-						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_UX; break;
-					case 407:	// sthx
-						transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_X; break;
-					case 439:	// sthux
-						transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_UX; break;
-				}
+		switch (primop)
+		{
+		case 31:
+			switch (exop)
+			{
+			case 23: // lwzx
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_WORD;
+				addr_mode = MODE_X;
 				break;
-	
-			case 32:	// lwz
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_NORM; break;
-			case 33:	// lwzu
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_U; break;
-			case 34:	// lbz
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_NORM; break;
-			case 35:	// lbzu
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_U; break;
-			case 36:	// stw
-				transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_NORM; break;
-			case 37:	// stwu
-				transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_U; break;
-			case 38:	// stb
-				transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_NORM; break;
-			case 39:	// stbu
-				transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_U; break;
-			case 40:	// lhz
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_NORM; break;
-			case 41:	// lhzu
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_U; break;
-			case 42:	// lha
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_NORM; break;
-			case 43:	// lhau
-				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_U; break;
-			case 44:	// sth
-				transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_NORM; break;
-			case 45:	// sthu
-				transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_U; break;
+			case 55: // lwzux
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_WORD;
+				addr_mode = MODE_UX;
+				break;
+			case 87: // lbzx
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_BYTE;
+				addr_mode = MODE_X;
+				break;
+			case 119: // lbzux
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_BYTE;
+				addr_mode = MODE_UX;
+				break;
+			case 151: // stwx
+				transfer_type = TYPE_STORE;
+				transfer_size = SIZE_WORD;
+				addr_mode = MODE_X;
+				break;
+			case 183: // stwux
+				transfer_type = TYPE_STORE;
+				transfer_size = SIZE_WORD;
+				addr_mode = MODE_UX;
+				break;
+			case 215: // stbx
+				transfer_type = TYPE_STORE;
+				transfer_size = SIZE_BYTE;
+				addr_mode = MODE_X;
+				break;
+			case 247: // stbux
+				transfer_type = TYPE_STORE;
+				transfer_size = SIZE_BYTE;
+				addr_mode = MODE_UX;
+				break;
+			case 279: // lhzx
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_HALFWORD;
+				addr_mode = MODE_X;
+				break;
+			case 311: // lhzux
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_HALFWORD;
+				addr_mode = MODE_UX;
+				break;
+			case 343: // lhax
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_HALFWORD;
+				addr_mode = MODE_X;
+				break;
+			case 375: // lhaux
+				transfer_type = TYPE_LOAD;
+				transfer_size = SIZE_HALFWORD;
+				addr_mode = MODE_UX;
+				break;
+			case 407: // sthx
+				transfer_type = TYPE_STORE;
+				transfer_size = SIZE_HALFWORD;
+				addr_mode = MODE_X;
+				break;
+			case 439: // sthux
+				transfer_type = TYPE_STORE;
+				transfer_size = SIZE_HALFWORD;
+				addr_mode = MODE_UX;
+				break;
+			}
+			break;
+
+		case 32: // lwz
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_WORD;
+			addr_mode = MODE_NORM;
+			break;
+		case 33: // lwzu
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_WORD;
+			addr_mode = MODE_U;
+			break;
+		case 34: // lbz
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_BYTE;
+			addr_mode = MODE_NORM;
+			break;
+		case 35: // lbzu
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_BYTE;
+			addr_mode = MODE_U;
+			break;
+		case 36: // stw
+			transfer_type = TYPE_STORE;
+			transfer_size = SIZE_WORD;
+			addr_mode = MODE_NORM;
+			break;
+		case 37: // stwu
+			transfer_type = TYPE_STORE;
+			transfer_size = SIZE_WORD;
+			addr_mode = MODE_U;
+			break;
+		case 38: // stb
+			transfer_type = TYPE_STORE;
+			transfer_size = SIZE_BYTE;
+			addr_mode = MODE_NORM;
+			break;
+		case 39: // stbu
+			transfer_type = TYPE_STORE;
+			transfer_size = SIZE_BYTE;
+			addr_mode = MODE_U;
+			break;
+		case 40: // lhz
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_HALFWORD;
+			addr_mode = MODE_NORM;
+			break;
+		case 41: // lhzu
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_HALFWORD;
+			addr_mode = MODE_U;
+			break;
+		case 42: // lha
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_HALFWORD;
+			addr_mode = MODE_NORM;
+			break;
+		case 43: // lhau
+			transfer_type = TYPE_LOAD;
+			transfer_size = SIZE_HALFWORD;
+			addr_mode = MODE_U;
+			break;
+		case 44: // sth
+			transfer_type = TYPE_STORE;
+			transfer_size = SIZE_HALFWORD;
+			addr_mode = MODE_NORM;
+			break;
+		case 45: // sthu
+			transfer_type = TYPE_STORE;
+			transfer_size = SIZE_HALFWORD;
+			addr_mode = MODE_U;
+			break;
 #if EMULATE_UNALIGNED_LOADSTORE_MULTIPLE
-			case 46:	// lmw
-				if ((addr % 4) != 0) {
-					uint32 ea = addr;
-					D(bug("WARNING: unaligned lmw to EA=%08x from IP=%08x\n", ea, r->pc()));
-					for (int i = rd; i <= 31; i++) {
-						r->gpr(i) = ReadMacInt32(ea);
-						ea += 4;
-					}
-					r->pc() += 4;
-					goto rti;
+		case 46: // lmw
+			if ((addr % 4) != 0)
+			{
+				uint32 ea = addr;
+				D(bug("WARNING: unaligned lmw to EA=%08x from IP=%08x\n", ea, r->pc()));
+				for (int i = rd; i <= 31; i++)
+				{
+					r->gpr(i) = ReadMacInt32(ea);
+					ea += 4;
 				}
-				break;
-			case 47:	// stmw
-				if ((addr % 4) != 0) {
-					uint32 ea = addr;
-					D(bug("WARNING: unaligned stmw to EA=%08x from IP=%08x\n", ea, r->pc()));
-					for (int i = rd; i <= 31; i++) {
-						WriteMacInt32(ea, r->gpr(i));
-						ea += 4;
-					}
-					r->pc() += 4;
-					goto rti;
+				r->pc() += 4;
+				goto rti;
+			}
+			break;
+		case 47: // stmw
+			if ((addr % 4) != 0)
+			{
+				uint32 ea = addr;
+				D(bug("WARNING: unaligned stmw to EA=%08x from IP=%08x\n", ea, r->pc()));
+				for (int i = rd; i <= 31; i++)
+				{
+					WriteMacInt32(ea, r->gpr(i));
+					ea += 4;
 				}
-				break;
+				r->pc() += 4;
+				goto rti;
+			}
+			break;
 #endif
 		}
-	
+
 		// Ignore ROM writes (including to the zero page, which is read-only)
 		if (transfer_type == TYPE_STORE &&
 			((addr >= ROMBase && addr < ROMBase + ROM_SIZE) ||
-			 (addr >= SheepMem::ZeroPage() && addr < SheepMem::ZeroPage() + SheepMem::PageSize()))) {
-//			D(bug("WARNING: %s write access to ROM at %08lx, pc %08lx\n", transfer_size == SIZE_BYTE ? "Byte" : transfer_size == SIZE_HALFWORD ? "Halfword" : "Word", addr, r->pc()));
+			 (addr >= SheepMem::ZeroPage() && addr < SheepMem::ZeroPage() + SheepMem::PageSize())))
+		{
+			//			D(bug("WARNING: %s write access to ROM at %08lx, pc %08lx\n", transfer_size == SIZE_BYTE ? "Byte" : transfer_size == SIZE_HALFWORD ? "Halfword" : "Word", addr, r->pc()));
 			if (addr_mode == MODE_U || addr_mode == MODE_UX)
 				r->gpr(ra) = addr;
 			r->pc() += 4;
@@ -2067,7 +2269,8 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		}
 
 		// Ignore illegal memory accesses?
-		if (PrefsFindBool("ignoresegv")) {
+		if (PrefsFindBool("ignoresegv"))
+		{
 			if (addr_mode == MODE_U || addr_mode == MODE_UX)
 				r->gpr(ra) = addr;
 			if (transfer_type == TYPE_LOAD)
@@ -2077,10 +2280,13 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		}
 
 		// In GUI mode, show error alert
-		if (use_gui) {
+		if (use_gui)
+		{
 			char str[256];
 			if (transfer_type == TYPE_LOAD || transfer_type == TYPE_STORE)
-				sprintf(str, GetString(STR_MEM_ACCESS_ERR), transfer_size == SIZE_BYTE ? "byte" : transfer_size == SIZE_HALFWORD ? "halfword" : "word", transfer_type == TYPE_LOAD ? GetString(STR_MEM_ACCESS_READ) : GetString(STR_MEM_ACCESS_WRITE), addr, r->pc(), r->gpr(24), r->gpr(1));
+				sprintf(str, GetString(STR_MEM_ACCESS_ERR), transfer_size == SIZE_BYTE ? "byte" : transfer_size == SIZE_HALFWORD ? "halfword"
+																																 : "word",
+						transfer_type == TYPE_LOAD ? GetString(STR_MEM_ACCESS_READ) : GetString(STR_MEM_ACCESS_WRITE), addr, r->pc(), r->gpr(24), r->gpr(1));
 			else
 				sprintf(str, GetString(STR_UNKNOWN_SEGV_ERR), r->pc(), r->gpr(24), r->gpr(1), opcode);
 			ErrorAlert(str);
@@ -2091,7 +2297,8 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 
 	// For all other errors, jump into debugger (sort of...)
 	crash_reason = (sig == SIGBUS) ? "SIGBUS" : "SIGSEGV";
-	if (!ready_for_signals) {
+	if (!ready_for_signals)
+	{
 		printf("%s\n");
 		printf(" sigcontext %p, machine_regs %p\n", scp, r);
 		printf(
@@ -2119,15 +2326,17 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		exit(1);
 		QuitEmulator();
 		return;
-	} else {
+	}
+	else
+	{
 		// We crashed. Save registers, tell tick thread and loop forever
 		build_sigregs(&sigsegv_regs, r);
 		emul_thread_fatal = true;
-		for (;;) ;
+		for (;;)
+			;
 	}
 rti:;
 }
-
 
 /*
  *  SIGILL handler
@@ -2149,7 +2358,8 @@ static void sigill_handler(int sig, siginfo_t *sip, void *scp)
 
 	// Fault in Mac ROM or RAM?
 	bool mac_fault = (r->pc() >= ROMBase) && (r->pc() < (ROMBase + ROM_AREA_SIZE)) || (r->pc() >= RAMBase) && (r->pc() < (RAMBase + RAMSize));
-	if (mac_fault) {
+	if (mac_fault)
+	{
 
 		// Get opcode and divide into fields
 		uint32 opcode = *((uint32 *)r->pc());
@@ -2160,103 +2370,130 @@ static void sigill_handler(int sig, siginfo_t *sip, void *scp)
 		uint32 rd = (opcode >> 21) & 0x1f;
 		int32 imm = (int16)(opcode & 0xffff);
 
-		switch (primop) {
-			case 9:		// POWER instructions
-			case 22:
-power_inst:		sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(1), opcode);
-				ErrorAlert(str);
-				QuitEmulator();
-				return;
+		switch (primop)
+		{
+		case 9: // POWER instructions
+		case 22:
+		power_inst:
+			sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(1), opcode);
+			ErrorAlert(str);
+			QuitEmulator();
+			return;
 
-			case 31:
-				switch (exop) {
-					case 83:	// mfmsr
-						r->gpr(rd) = 0xf072;
-						r->pc() += 4;
-						goto rti;
+		case 31:
+			switch (exop)
+			{
+			case 83: // mfmsr
+				r->gpr(rd) = 0xf072;
+				r->pc() += 4;
+				goto rti;
 
-					case 210:	// mtsr
-					case 242:	// mtsrin
-					case 306:	// tlbie
-						r->pc() += 4;
-						goto rti;
+			case 210: // mtsr
+			case 242: // mtsrin
+			case 306: // tlbie
+				r->pc() += 4;
+				goto rti;
 
-					case 339: {	// mfspr
-						int spr = ra | (rb << 5);
-						switch (spr) {
-							case 0:		// MQ
-							case 22:	// DEC
-							case 952:	// MMCR0
-							case 953:	// PMC1
-							case 954:	// PMC2
-							case 955:	// SIA
-							case 956:	// MMCR1
-							case 957:	// PMC3
-							case 958:	// PMC4
-							case 959:	// SDA
-								r->pc() += 4;
-								goto rti;
-							case 25:	// SDR1
-								r->gpr(rd) = 0xdead001f;
-								r->pc() += 4;
-								goto rti;
-							case 287:	// PVR
-								r->gpr(rd) = PVR;
-								r->pc() += 4;
-								goto rti;
-						}
-						break;
-					}
-
-					case 467: {	// mtspr
-						int spr = ra | (rb << 5);
-						switch (spr) {
-							case 0:		// MQ
-							case 22:	// DEC
-							case 275:	// SPRG3
-							case 528:	// IBAT0U
-							case 529:	// IBAT0L
-							case 530:	// IBAT1U
-							case 531:	// IBAT1L
-							case 532:	// IBAT2U
-							case 533:	// IBAT2L
-							case 534:	// IBAT3U
-							case 535:	// IBAT3L
-							case 536:	// DBAT0U
-							case 537:	// DBAT0L
-							case 538:	// DBAT1U
-							case 539:	// DBAT1L
-							case 540:	// DBAT2U
-							case 541:	// DBAT2L
-							case 542:	// DBAT3U
-							case 543:	// DBAT3L
-							case 952:	// MMCR0
-							case 953:	// PMC1
-							case 954:	// PMC2
-							case 955:	// SIA
-							case 956:	// MMCR1
-							case 957:	// PMC3
-							case 958:	// PMC4
-							case 959:	// SDA
-								r->pc() += 4;
-								goto rti;
-						}
-						break;
-					}
-
-					case 29: case 107: case 152: case 153:	// POWER instructions
-					case 184: case 216: case 217: case 248:
-					case 264: case 277: case 331: case 360:
-					case 363: case 488: case 531: case 537:
-					case 541: case 664: case 665: case 696:
-					case 728: case 729: case 760: case 920:
-					case 921: case 952:
-						goto power_inst;
+			case 339:
+			{ // mfspr
+				int spr = ra | (rb << 5);
+				switch (spr)
+				{
+				case 0:	  // MQ
+				case 22:  // DEC
+				case 952: // MMCR0
+				case 953: // PMC1
+				case 954: // PMC2
+				case 955: // SIA
+				case 956: // MMCR1
+				case 957: // PMC3
+				case 958: // PMC4
+				case 959: // SDA
+					r->pc() += 4;
+					goto rti;
+				case 25: // SDR1
+					r->gpr(rd) = 0xdead001f;
+					r->pc() += 4;
+					goto rti;
+				case 287: // PVR
+					r->gpr(rd) = PVR;
+					r->pc() += 4;
+					goto rti;
 				}
+				break;
+			}
+
+			case 467:
+			{ // mtspr
+				int spr = ra | (rb << 5);
+				switch (spr)
+				{
+				case 0:	  // MQ
+				case 22:  // DEC
+				case 275: // SPRG3
+				case 528: // IBAT0U
+				case 529: // IBAT0L
+				case 530: // IBAT1U
+				case 531: // IBAT1L
+				case 532: // IBAT2U
+				case 533: // IBAT2L
+				case 534: // IBAT3U
+				case 535: // IBAT3L
+				case 536: // DBAT0U
+				case 537: // DBAT0L
+				case 538: // DBAT1U
+				case 539: // DBAT1L
+				case 540: // DBAT2U
+				case 541: // DBAT2L
+				case 542: // DBAT3U
+				case 543: // DBAT3L
+				case 952: // MMCR0
+				case 953: // PMC1
+				case 954: // PMC2
+				case 955: // SIA
+				case 956: // MMCR1
+				case 957: // PMC3
+				case 958: // PMC4
+				case 959: // SDA
+					r->pc() += 4;
+					goto rti;
+				}
+				break;
+			}
+
+			case 29:
+			case 107:
+			case 152:
+			case 153: // POWER instructions
+			case 184:
+			case 216:
+			case 217:
+			case 248:
+			case 264:
+			case 277:
+			case 331:
+			case 360:
+			case 363:
+			case 488:
+			case 531:
+			case 537:
+			case 541:
+			case 664:
+			case 665:
+			case 696:
+			case 728:
+			case 729:
+			case 760:
+			case 920:
+			case 921:
+			case 952:
+				goto power_inst;
+			}
 		}
 
 		// In GUI mode, show error alert
-		if (use_gui) {
+		if (use_gui)
+		{
 			sprintf(str, GetString(STR_UNKNOWN_SEGV_ERR), r->pc(), r->gpr(24), r->gpr(1), opcode);
 			ErrorAlert(str);
 			QuitEmulator();
@@ -2266,7 +2503,8 @@ power_inst:		sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(
 
 	// For all other errors, jump into debugger (sort of...)
 	crash_reason = "SIGILL";
-	if (!ready_for_signals) {
+	if (!ready_for_signals)
+	{
 		printf("%s\n");
 		printf(" sigcontext %p, machine_regs %p\n", scp, r);
 		printf(
@@ -2294,11 +2532,14 @@ power_inst:		sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(
 		exit(1);
 		QuitEmulator();
 		return;
-	} else {
+	}
+	else
+	{
 		// We crashed. Save registers, tell tick thread and loop forever
 		build_sigregs(&sigsegv_regs, r);
 		emul_thread_fatal = true;
-		for (;;) ;
+		for (;;)
+			;
 	}
 rti:;
 }
@@ -2343,7 +2584,8 @@ bool SheepMem::Init(void)
 
 void SheepMem::Exit(void)
 {
-	if (data) {
+	if (data)
+	{
 		// Delete SheepShaver globals
 		vm_mac_release(base, size);
 
@@ -2353,7 +2595,6 @@ void SheepMem::Exit(void)
 #endif
 	}
 }
-
 
 /*
  *  Display alert
@@ -2370,11 +2611,11 @@ static GCallback dl_destroyed(GtkWidget *dialog)
 void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 {
 	GtkWidget *dialog = gtk_message_dialog_new(NULL,
-	                                           GTK_DIALOG_MODAL,
-	                                           GTK_MESSAGE_WARNING,
-	                                           GTK_BUTTONS_NONE,
-	                                           GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+											   GTK_DIALOG_MODAL,
+											   GTK_MESSAGE_WARNING,
+											   GTK_BUTTONS_NONE,
+											   GetString(title_id), NULL);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);
@@ -2383,21 +2624,22 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 }
 #endif
 
-
 /*
  *  Display error alert
  */
 
 void ErrorAlert(const char *text)
 {
-	if (gui_connection) {
+	if (gui_connection)
+	{
 		if (rpc_method_invoke(gui_connection, RPC_METHOD_ERROR_ALERT, RPC_TYPE_STRING, text, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR &&
 			rpc_method_wait_for_reply(gui_connection, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR)
 			return;
 	}
 #ifdef ENABLE_GTK
 #ifndef USE_SDL_VIDEO
-	if (x_display == NULL) {
+	if (x_display == NULL)
+	{
 		printf(GetString(STR_SHELL_ERROR_PREFIX), text);
 		return;
 	}
@@ -2409,21 +2651,22 @@ void ErrorAlert(const char *text)
 #endif
 }
 
-
 /*
  *  Display warning alert
  */
 
 void WarningAlert(const char *text)
 {
-	if (gui_connection) {
+	if (gui_connection)
+	{
 		if (rpc_method_invoke(gui_connection, RPC_METHOD_WARNING_ALERT, RPC_TYPE_STRING, text, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR &&
 			rpc_method_wait_for_reply(gui_connection, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR)
 			return;
 	}
 #ifdef ENABLE_GTK
 #ifndef USE_SDL_VIDEO
-	if (x_display == NULL) {
+	if (x_display == NULL)
+	{
 		printf(GetString(STR_SHELL_WARNING_PREFIX), text);
 		return;
 	}
@@ -2434,7 +2677,6 @@ void WarningAlert(const char *text)
 #endif
 }
 
-
 /*
  *  Display choice alert
  */
@@ -2442,5 +2684,5 @@ void WarningAlert(const char *text)
 bool ChoiceAlert(const char *text, const char *pos, const char *neg)
 {
 	printf(GetString(STR_SHELL_WARNING_PREFIX), text);
-	return false;	//!!
+	return false; //!!
 }

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -118,6 +118,7 @@
 #define DEBUG 0
 #include "debug.h"
 
+
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif
@@ -125,7 +126,7 @@
 #ifdef USE_SDL
 #include <SDL.h>
 #if !SDL_VERSION_ATLEAST(3, 0, 0)
-#define SDL_PLATFORM_MACOS __MACOSX__
+#define SDL_PLATFORM_MACOS      __MACOSX__
 #endif
 #endif
 
@@ -159,6 +160,7 @@
 #include "mon.h"
 #endif
 
+
 // Enable emulation of unaligned lmw/stmw?
 #define EMULATE_UNALIGNED_LOADSTORE_MULTIPLE 1
 
@@ -171,37 +173,39 @@
 // Interrupts in native mode?
 #define INTERRUPTS_IN_NATIVE_MODE 1
 
+
 // Constants
 const char ROM_FILE_NAME[] = "ROM";
 const char ROM_FILE_NAME2[] = "Mac OS ROM";
 
 #if !REAL_ADDRESSING
 // FIXME: needs to be >= 0x04000000
-const uintptr RAM_BASE = 0x10000000; // Base address of RAM
+const uintptr RAM_BASE = 0x10000000;		// Base address of RAM
 #endif
-const uintptr ROM_BASE = 0x50000000; // Base address of ROM
+const uintptr ROM_BASE = 0x50000000;		// Base address of ROM
 #if REAL_ADDRESSING
-const uint32 ROM_ALIGNMENT = 0x100000; // ROM must be aligned to a 1MB boundary
+const uint32 ROM_ALIGNMENT = 0x100000;		// ROM must be aligned to a 1MB boundary
 #endif
-const uint32 SIG_STACK_SIZE = 0x10000; // Size of signal stack
+const uint32 SIG_STACK_SIZE = 0x10000;		// Size of signal stack
+
 
 // Global variables (exported)
 #if !EMULATED_PPC
-void *TOC = NULL; // Pointer to Thread Local Storage (r2)
-void *R13 = NULL; // Pointer to .sdata section (r13 under Linux)
+void *TOC = NULL;		// Pointer to Thread Local Storage (r2)
+void *R13 = NULL;		// Pointer to .sdata section (r13 under Linux)
 #endif
-uint32 RAMBase;		   // Base address of Mac RAM
-uint32 RAMSize;		   // Size of Mac RAM
-uint32 ROMBase;		   // Base address of Mac ROM
-uint32 KernelDataAddr; // Address of Kernel Data
-uint32 BootGlobsAddr;  // Address of BootGlobs structure at top of Mac RAM
-uint32 DRCacheAddr;	   // Address of DR Cache
-uint32 PVR;			   // Theoretical PVR
-int64 CPUClockSpeed;   // Processor clock speed (Hz)
-int64 BusClockSpeed;   // Bus clock speed (Hz)
-int64 TimebaseSpeed;   // Timebase clock speed (Hz)
-uint8 *RAMBaseHost;	   // Base address of Mac RAM (host address space)
-uint8 *ROMBaseHost;	   // Base address of Mac ROM (host address space)
+uint32 RAMBase;			// Base address of Mac RAM
+uint32 RAMSize;			// Size of Mac RAM
+uint32 ROMBase;			// Base address of Mac ROM
+uint32 KernelDataAddr;	// Address of Kernel Data
+uint32 BootGlobsAddr;	// Address of BootGlobs structure at top of Mac RAM
+uint32 DRCacheAddr;		// Address of DR Cache
+uint32 PVR;				// Theoretical PVR
+int64 CPUClockSpeed;	// Processor clock speed (Hz)
+int64 BusClockSpeed;	// Bus clock speed (Hz)
+int64 TimebaseSpeed;	// Timebase clock speed (Hz)
+uint8 *RAMBaseHost;		// Base address of Mac RAM (host address space)
+uint8 *ROMBaseHost;		// Base address of Mac ROM (host address space)
 uint32 ROMEnd;
 
 #if defined(__APPLE__) && defined(__x86_64__)
@@ -210,56 +214,57 @@ uint8 gZeroPage[0x3000], gKernelData[0x2000];
 
 // Global variables
 #ifndef USE_SDL_VIDEO
-char *x_display_name = NULL; // X11 display name
-Display *x_display = NULL;	 // X11 display handle
+char *x_display_name = NULL;				// X11 display name
+Display *x_display = NULL;					// X11 display handle
 #ifdef X11_LOCK_TYPE
 X11_LOCK_TYPE x_display_lock = X11_LOCK_INIT; // X11 display lock
 #endif
 #endif
 
-static int zero_fd = 0;						 // FD of /dev/zero
-static bool lm_area_mapped = false;			 // Flag: Low Memory area mmap()ped
-static bool rom_area_mapped = false;		 // Flag: Mac ROM mmap()ped
-static bool ram_area_mapped = false;		 // Flag: Mac RAM mmap()ped
-static bool dr_cache_area_mapped = false;	 // Flag: Mac DR Cache mmap()ped
-static bool dr_emulator_area_mapped = false; // Flag: Mac DR Emulator mmap()ped
-static KernelData *kernel_data;				 // Pointer to Kernel Data
+static int zero_fd = 0;						// FD of /dev/zero
+static bool lm_area_mapped = false;			// Flag: Low Memory area mmap()ped
+static bool rom_area_mapped = false;		// Flag: Mac ROM mmap()ped
+static bool ram_area_mapped = false;		// Flag: Mac RAM mmap()ped
+static bool dr_cache_area_mapped = false;	// Flag: Mac DR Cache mmap()ped
+static bool dr_emulator_area_mapped = false;// Flag: Mac DR Emulator mmap()ped
+static KernelData *kernel_data;				// Pointer to Kernel Data
 static EmulatorData *emulator_data;
 
-static uint8 last_xpram[XPRAM_SIZE]; // Buffer for monitoring XPRAM changes
+static uint8 last_xpram[XPRAM_SIZE];		// Buffer for monitoring XPRAM changes
 
-static bool nvram_thread_active = false;  // Flag: NVRAM watchdog installed
-static volatile bool nvram_thread_cancel; // Flag: Cancel NVRAM thread
-static pthread_t nvram_thread;			  // NVRAM watchdog
-static bool tick_thread_active = false;	  // Flag: MacOS thread installed
-static volatile bool tick_thread_cancel;  // Flag: Cancel 60Hz thread
-static pthread_t tick_thread;			  // 60Hz thread
-static pthread_t emul_thread;			  // MacOS thread
-static int use_gui = -1;				  // Override prefs and show gui
+static bool nvram_thread_active = false;	// Flag: NVRAM watchdog installed
+static volatile bool nvram_thread_cancel;	// Flag: Cancel NVRAM thread
+static pthread_t nvram_thread;				// NVRAM watchdog
+static bool tick_thread_active = false;		// Flag: MacOS thread installed
+static volatile bool tick_thread_cancel;	// Flag: Cancel 60Hz thread
+static pthread_t tick_thread;				// 60Hz thread
+static pthread_t emul_thread;				// MacOS thread
+static int use_gui = -1;   					// Override prefs and show gui
 
-static bool ready_for_signals = false; // Handler installed, signals can be sent
+static bool ready_for_signals = false;		// Handler installed, signals can be sent
 
 #if EMULATED_PPC
-static uintptr sig_stack = 0; // Stack for PowerPC interrupt routine
+static uintptr sig_stack = 0;				// Stack for PowerPC interrupt routine
 #else
-static struct sigaction sigusr2_action; // Interrupt signal (of emulator thread)
-static struct sigaction sigsegv_action; // Data access exception signal (of emulator thread)
-static struct sigaction sigill_action;	// Illegal instruction signal (of emulator thread)
-static stack_t sig_stack;				// Stack for signal handlers
-static stack_t extra_stack;				// Stack for SIGSEGV inside interrupt handler
-static bool emul_thread_fatal = false;	// Flag: MacOS thread crashed, tick thread shall dump debug output
-static sigregs sigsegv_regs;			// Register dump when crashed
-static const char *crash_reason = NULL; // Reason of the crash (SIGSEGV, SIGBUS, SIGILL)
+static struct sigaction sigusr2_action;		// Interrupt signal (of emulator thread)
+static struct sigaction sigsegv_action;		// Data access exception signal (of emulator thread)
+static struct sigaction sigill_action;		// Illegal instruction signal (of emulator thread)
+static stack_t sig_stack;					// Stack for signal handlers
+static stack_t extra_stack;					// Stack for SIGSEGV inside interrupt handler
+static bool emul_thread_fatal = false;		// Flag: MacOS thread crashed, tick thread shall dump debug output
+static sigregs sigsegv_regs;				// Register dump when crashed
+static const char *crash_reason = NULL;		// Reason of the crash (SIGSEGV, SIGBUS, SIGILL)
 #endif
 
-static rpc_connection_t *gui_connection = NULL; // RPC connection to the GUI
+static rpc_connection_t *gui_connection = NULL;	// RPC connection to the GUI
 static const char *gui_connection_path = NULL;	// GUI connection identifier
 
-uint32 SheepMem::page_size;			 // Size of a native page
-uintptr SheepMem::zero_page = 0;	 // Address of ro page filled in with zeros
-uintptr SheepMem::base = 0x60000000; // Address of SheepShaver data
-uintptr SheepMem::proc;				 // Bottom address of SheepShave procedures
-uintptr SheepMem::data;				 // Top of SheepShaver data (stack like storage)
+uint32  SheepMem::page_size;				// Size of a native page
+uintptr SheepMem::zero_page = 0;			// Address of ro page filled in with zeros
+uintptr SheepMem::base = 0x60000000;		// Address of SheepShaver data
+uintptr SheepMem::proc;						// Bottom address of SheepShave procedures
+uintptr SheepMem::data;						// Top of SheepShaver data (stack like storage)
+
 
 // Prototypes
 #if !defined(__APPLE__) || !defined(__x86_64__)
@@ -282,6 +287,7 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp);
 static void sigill_handler(int sig, siginfo_t *sip, void *scp);
 #endif
 
+
 // From asm_linux.S
 #if !EMULATED_PPC
 extern "C" void *get_sp(void);
@@ -300,6 +306,7 @@ extern "C" int atomic_or(int *var, int v);
 extern void paranoia_check(void);
 #endif
 
+
 #if EMULATED_PPC
 /*
  *  Return signal stack base
@@ -309,6 +316,7 @@ uintptr SignalStackBase(void)
 {
 	return sig_stack + SIG_STACK_SIZE;
 }
+
 
 /*
  *  Atomic operations
@@ -349,6 +357,7 @@ int atomic_or(int *var, int v)
 }
 #endif
 
+
 /*
  *  Memory management helpers
  */
@@ -367,6 +376,7 @@ static inline int vm_mac_release(uint32 addr, uint32 size)
 {
 	return vm_release(Mac2HostAddr(addr), size);
 }
+
 
 /*
  *  Main program
@@ -388,11 +398,9 @@ static bool valid_vmdir(const char *path)
 	int len = strlen(path);
 	if (len && path[len - 1] == '/') // to support both ".sheepvm" and ".sheepvm/"
 		len--;
-	if (len > suffix_len && !strncmp(path + len - suffix_len, ".sheepvm", suffix_len))
-	{
+	if (len > suffix_len && !strncmp(path + len - suffix_len, ".sheepvm", suffix_len)) {
 		struct stat d;
-		if (!stat(path, &d) && S_ISDIR(d.st_mode))
-		{
+		if (!stat(path, &d) && S_ISDIR(d.st_mode)) {
 			return true;
 		}
 	}
@@ -405,24 +413,21 @@ static void get_system_info(void)
 	FILE *proc_file;
 #endif
 
-	PVR = 0x00040000;		   // Default: 604
-	CPUClockSpeed = 100000000; // Default: 100MHz
-	BusClockSpeed = 100000000; // Default: 100MHz
-	TimebaseSpeed = 25000000;  // Default:  25MHz
+	PVR = 0x00040000;			// Default: 604
+	CPUClockSpeed = 100000000;	// Default: 100MHz
+	BusClockSpeed = 100000000;	// Default: 100MHz
+	TimebaseSpeed =  25000000;	// Default:  25MHz
 
 #if EMULATED_PPC
-	PVR = 0x000c0000; // Default: 7400 (with AltiVec)
+	PVR = 0x000c0000;			// Default: 7400 (with AltiVec)
 	int pref_cpu_clock = PrefsFindInt32("cpuclock");
-	if (pref_cpu_clock)
-		CPUClockSpeed = 1000000 * pref_cpu_clock;
+	if (pref_cpu_clock) CPUClockSpeed = 1000000 * pref_cpu_clock;
 #elif defined(__APPLE__) && defined(__MACH__)
 	proc_file = popen("ioreg -c IOPlatformDevice", "r");
-	if (proc_file)
-	{
+	if (proc_file) {
 		char line[256];
 		bool powerpc_node = false;
-		while (fgets(line, sizeof(line) - 1, proc_file))
-		{
+		while (fgets(line, sizeof(line) - 1, proc_file)) {
 			// Read line
 			int len = strlen(line);
 			if (len == 0)
@@ -432,8 +437,7 @@ static void get_system_info(void)
 			// Parse line
 			if (strstr(line, "o PowerPC,"))
 				powerpc_node = true;
-			else if (powerpc_node)
-			{
+			else if (powerpc_node) {
 				uint32 value;
 				char head[256];
 				if (sscanf(line, "%[ |]\"cpu-version\" = <%x>", head, &value) == 2)
@@ -449,94 +453,88 @@ static void get_system_info(void)
 			}
 		}
 		fclose(proc_file);
-	}
-	else
-	{
+	} else {
 		char str[256];
 		sprintf(str, GetString(STR_PROC_CPUINFO_WARN), strerror(errno));
 		WarningAlert(str);
 	}
 #else
 	proc_file = fopen("/proc/cpuinfo", "r");
-	if (proc_file)
-	{
+	if (proc_file) {
 		// CPU specs from Linux kernel
 		// TODO: make it more generic with features (e.g. AltiVec) and
 		// cache information and friends for NameRegistry
-		static const struct
-		{
+		static const struct {
 			uint32 pvr_mask;
 			uint32 pvr_value;
 			const char *cpu_name;
-		} cpu_specs[] = {
-			{0xffff0000, 0x00010000, "601"},
-			{0xffff0000, 0x00030000, "603"},
-			{0xffff0000, 0x00060000, "603e"},
-			{0xffff0000, 0x00070000, "603ev"},
-			{0xffff0000, 0x00040000, "604"},
-			{0xfffff000, 0x00090000, "604e"},
-			{0xffff0000, 0x00090000, "604r"},
-			{0xffff0000, 0x000a0000, "604ev"},
-			{0xffffffff, 0x00084202, "740/750"},
-			{0xfffff000, 0x00083000, "745/755"},
-			{0xfffffff0, 0x00080100, "750CX"},
-			{0xfffffff0, 0x00082200, "750CX"},
-			{0xfffffff0, 0x00082210, "750CXe"},
-			{0xffffff00, 0x70000100, "750FX"},
-			{0xffffffff, 0x70000200, "750FX"},
-			{0xffff0000, 0x70000000, "750FX"},
-			{0xffff0000, 0x70020000, "750GX"},
-			{0xffff0000, 0x00080000, "740/750"},
-			{0xffffffff, 0x000c1101, "7400 (1.1)"},
-			{0xffff0000, 0x000c0000, "7400"},
-			{0xffff0000, 0x800c0000, "7410"},
-			{0xffffffff, 0x80000200, "7450"},
-			{0xffffffff, 0x80000201, "7450"},
-			{0xffff0000, 0x80000000, "7450"},
-			{0xffffff00, 0x80010100, "7455"},
-			{0xffffffff, 0x80010200, "7455"},
-			{0xffff0000, 0x80010000, "7455"},
-			{0xffff0000, 0x80020000, "7457"},
-			{0xffff0000, 0x80030000, "7447A"},
-			{0xffff0000, 0x80040000, "7448"},
-			{0x7fff0000, 0x00810000, "82xx"},
-			{0x7fff0000, 0x00820000, "8280"},
-			{0xffff0000, 0x00400000, "Power3 (630)"},
-			{0xffff0000, 0x00410000, "Power3 (630+)"},
-			{0xffff0000, 0x00360000, "I-star"},
-			{0xffff0000, 0x00370000, "S-star"},
-			{0xffff0000, 0x00350000, "Power4"},
-			{0xffff0000, 0x00390000, "PPC970"},
-			{0xffff0000, 0x003c0000, "PPC970FX"},
-			{0xffff0000, 0x00440000, "PPC970MP"},
-			{0xffff0000, 0x003a0000, "POWER5 (gr)"},
-			{0xffff0000, 0x003b0000, "POWER5+ (gs)"},
-			{0xffff0000, 0x003e0000, "POWER6"},
-			{0xffff0000, 0x00700000, "Cell Broadband Engine"},
-			{0x7fff0000, 0x00900000, "PA6T"},
-			{0, 0, 0}};
+		}
+		cpu_specs[] = {
+			{ 0xffff0000, 0x00010000, "601" },
+			{ 0xffff0000, 0x00030000, "603" },
+			{ 0xffff0000, 0x00060000, "603e" },
+			{ 0xffff0000, 0x00070000, "603ev" },
+			{ 0xffff0000, 0x00040000, "604" },
+			{ 0xfffff000, 0x00090000, "604e" },
+			{ 0xffff0000, 0x00090000, "604r" },
+			{ 0xffff0000, 0x000a0000, "604ev" },
+			{ 0xffffffff, 0x00084202, "740/750" },
+			{ 0xfffff000, 0x00083000, "745/755" },
+			{ 0xfffffff0, 0x00080100, "750CX" },
+			{ 0xfffffff0, 0x00082200, "750CX" },
+			{ 0xfffffff0, 0x00082210, "750CXe" },
+			{ 0xffffff00, 0x70000100, "750FX" },
+			{ 0xffffffff, 0x70000200, "750FX" },
+			{ 0xffff0000, 0x70000000, "750FX" },
+			{ 0xffff0000, 0x70020000, "750GX" },
+			{ 0xffff0000, 0x00080000, "740/750" },
+			{ 0xffffffff, 0x000c1101, "7400 (1.1)" },
+			{ 0xffff0000, 0x000c0000, "7400" },
+			{ 0xffff0000, 0x800c0000, "7410" },
+			{ 0xffffffff, 0x80000200, "7450" },
+			{ 0xffffffff, 0x80000201, "7450" },
+			{ 0xffff0000, 0x80000000, "7450" },
+			{ 0xffffff00, 0x80010100, "7455" },
+			{ 0xffffffff, 0x80010200, "7455" },
+			{ 0xffff0000, 0x80010000, "7455" },
+			{ 0xffff0000, 0x80020000, "7457" },
+			{ 0xffff0000, 0x80030000, "7447A" },
+			{ 0xffff0000, 0x80040000, "7448" },
+			{ 0x7fff0000, 0x00810000, "82xx" },
+			{ 0x7fff0000, 0x00820000, "8280" },
+			{ 0xffff0000, 0x00400000, "Power3 (630)" },
+			{ 0xffff0000, 0x00410000, "Power3 (630+)" },
+			{ 0xffff0000, 0x00360000, "I-star" },
+			{ 0xffff0000, 0x00370000, "S-star" },
+			{ 0xffff0000, 0x00350000, "Power4" },
+			{ 0xffff0000, 0x00390000, "PPC970" },
+			{ 0xffff0000, 0x003c0000, "PPC970FX" },
+			{ 0xffff0000, 0x00440000, "PPC970MP" },
+			{ 0xffff0000, 0x003a0000, "POWER5 (gr)" },
+			{ 0xffff0000, 0x003b0000, "POWER5+ (gs)" },
+			{ 0xffff0000, 0x003e0000, "POWER6" },
+			{ 0xffff0000, 0x00700000, "Cell Broadband Engine" },
+			{ 0x7fff0000, 0x00900000, "PA6T" },
+			{ 0, 0, 0 }
+		};
 
 		char line[256];
-		while (fgets(line, 255, proc_file))
-		{
+		while(fgets(line, 255, proc_file)) {
 			// Read line
 			int len = strlen(line);
 			if (len == 0)
 				continue;
-			line[len - 1] = 0;
+			line[len-1] = 0;
 
 			// Parse line
 			int i;
 			float f;
 			char value[256];
-			if (sscanf(line, "cpu : %[^,]", value) == 1)
-			{
+			if (sscanf(line, "cpu : %[^,]", value) == 1) {
 				// Search by name
 				const char *cpu_name = NULL;
-				for (int i = 0; cpu_specs[i].pvr_mask != 0; i++)
-				{
-					if (strcmp(cpu_specs[i].cpu_name, value) == 0)
-					{
+				for (int i = 0; cpu_specs[i].pvr_mask != 0; i++) {
+					if (strcmp(cpu_specs[i].cpu_name, value) == 0) {
 						cpu_name = cpu_specs[i].cpu_name;
 						PVR = cpu_specs[i].pvr_value;
 						break;
@@ -553,9 +551,7 @@ static void get_system_info(void)
 				CPUClockSpeed = BusClockSpeed = i * 1000000;
 		}
 		fclose(proc_file);
-	}
-	else
-	{
+	} else {
 		char str[256];
 		sprintf(str, GetString(STR_PROC_CPUINFO_WARN), strerror(errno));
 		WarningAlert(str);
@@ -563,13 +559,8 @@ static void get_system_info(void)
 
 	// Get actual bus frequency
 	proc_file = fopen("/proc/device-tree/clock-frequency", "r");
-	if (proc_file)
-	{
-		union
-		{
-			uint8 b[4];
-			uint32 l;
-		} value;
+	if (proc_file) {
+		union { uint8 b[4]; uint32 l; } value;
 		if (fread(value.b, sizeof(value), 1, proc_file) == 1)
 			BusClockSpeed = value.l;
 		fclose(proc_file);
@@ -578,23 +569,15 @@ static void get_system_info(void)
 	// Get actual timebase frequency
 	TimebaseSpeed = BusClockSpeed / 4;
 	DIR *cpus_dir;
-	if ((cpus_dir = opendir("/proc/device-tree/cpus")) != NULL)
-	{
+	if ((cpus_dir = opendir("/proc/device-tree/cpus")) != NULL) {
 		struct dirent *cpu_entry;
-		while ((cpu_entry = readdir(cpus_dir)) != NULL)
-		{
-			if (strstr(cpu_entry->d_name, "PowerPC,") == cpu_entry->d_name)
-			{
+		while ((cpu_entry = readdir(cpus_dir)) != NULL) {
+			if (strstr(cpu_entry->d_name, "PowerPC,") == cpu_entry->d_name) {
 				char timebase_freq_node[256];
 				sprintf(timebase_freq_node, "/proc/device-tree/cpus/%s/timebase-frequency", cpu_entry->d_name);
 				proc_file = fopen(timebase_freq_node, "r");
-				if (proc_file)
-				{
-					union
-					{
-						uint8 b[4];
-						uint32 l;
-					} value;
+				if (proc_file) {
+					union { uint8 b[4]; uint32 l; } value;
 					if (fread(value.b, sizeof(value), 1, proc_file) == 1)
 						TimebaseSpeed = value.l;
 					fclose(proc_file);
@@ -606,17 +589,16 @@ static void get_system_info(void)
 #endif
 
 	// Remap any newer G4/G5 processor to plain G4 for compatibility
-	switch (PVR >> 16)
-	{
-	case 0x8000:		  // 7450
-	case 0x8001:		  // 7455
-	case 0x8002:		  // 7457
-	case 0x8003:		  // 7447A
-	case 0x8004:		  // 7448
-	case 0x0039:		  //  970
-	case 0x003c:		  //  970FX
-	case 0x0044:		  //  970MP
-		PVR = 0x000c0000; // 7400
+	switch (PVR >> 16) {
+	case 0x8000:				// 7450
+	case 0x8001:				// 7455
+	case 0x8002:				// 7457
+	case 0x8003:				// 7447A
+	case 0x8004:				// 7448
+	case 0x0039:				//  970
+	case 0x003c:				//  970FX
+	case 0x0044:				//  970MP
+		PVR = 0x000c0000;		// 7400
 		break;
 	}
 	D(bug("PVR: %08x (assumed)\n", PVR));
@@ -628,11 +610,9 @@ static bool load_mac_rom(void)
 	uint8 *rom_tmp;
 	const char *rom_path = PrefsFindString("rom");
 	int rom_fd = open(rom_path && *rom_path ? rom_path : ROM_FILE_NAME, O_RDONLY);
-	if (rom_fd < 0)
-	{
+	if (rom_fd < 0) {
 		rom_fd = open(ROM_FILE_NAME2, O_RDONLY);
-		if (rom_fd < 0)
-		{
+		if (rom_fd < 0) {
 			ErrorAlert(GetString(STR_NO_ROM_FILE_ERR));
 			return false;
 		}
@@ -643,17 +623,13 @@ static bool load_mac_rom(void)
 	rom_tmp = new uint8[ROM_SIZE];
 	actual = read(rom_fd, (void *)rom_tmp, ROM_SIZE);
 	close(rom_fd);
-
+	
 	// Decode Mac ROM
-	if (!DecodeROM(rom_tmp, actual))
-	{
-		if (rom_size != 4 * 1024 * 1024)
-		{
+	if (!DecodeROM(rom_tmp, actual)) {
+		if (rom_size != 4*1024*1024) {
 			ErrorAlert(GetString(STR_ROM_SIZE_ERR));
 			return false;
-		}
-		else
-		{
+		} else {
 			ErrorAlert(GetString(STR_ROM_FILE_READ_ERR));
 			return false;
 		}
@@ -669,23 +645,20 @@ static bool install_signal_handlers(void)
 	// Create and install stacks for signal handlers
 	sig_stack.ss_sp = malloc(SIG_STACK_SIZE);
 	D(bug("Signal stack at %p\n", sig_stack.ss_sp));
-	if (sig_stack.ss_sp == NULL)
-	{
+	if (sig_stack.ss_sp == NULL) {
 		ErrorAlert(GetString(STR_NOT_ENOUGH_MEMORY_ERR));
 		return false;
 	}
 	sig_stack.ss_flags = 0;
 	sig_stack.ss_size = SIG_STACK_SIZE;
-	if (sigaltstack(&sig_stack, NULL) < 0)
-	{
+	if (sigaltstack(&sig_stack, NULL) < 0) {
 		sprintf(str, GetString(STR_SIGALTSTACK_ERR), strerror(errno));
 		ErrorAlert(str);
 		return false;
 	}
 	extra_stack.ss_sp = malloc(SIG_STACK_SIZE);
 	D(bug("Extra stack at %p\n", extra_stack.ss_sp));
-	if (extra_stack.ss_sp == NULL)
-	{
+	if (extra_stack.ss_sp == NULL) {
 		ErrorAlert(GetString(STR_NOT_ENOUGH_MEMORY_ERR));
 		return false;
 	}
@@ -693,29 +666,26 @@ static bool install_signal_handlers(void)
 	extra_stack.ss_size = SIG_STACK_SIZE;
 
 	// Install SIGSEGV and SIGBUS handlers
-	sigemptyset(&sigsegv_action.sa_mask); // Block interrupts during SEGV handling
+	sigemptyset(&sigsegv_action.sa_mask);	// Block interrupts during SEGV handling
 	sigaddset(&sigsegv_action.sa_mask, SIGUSR2);
 	sigsegv_action.sa_sigaction = sigsegv_handler;
 	sigsegv_action.sa_flags = SA_ONSTACK | SA_SIGINFO;
 #ifdef HAVE_SIGNAL_SA_RESTORER
 	sigsegv_action.sa_restorer = NULL;
 #endif
-	if (sigaction(SIGSEGV, &sigsegv_action, NULL) < 0)
-	{
+	if (sigaction(SIGSEGV, &sigsegv_action, NULL) < 0) {
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGSEGV", strerror(errno));
 		ErrorAlert(str);
 		return false;
 	}
-	if (sigaction(SIGBUS, &sigsegv_action, NULL) < 0)
-	{
+	if (sigaction(SIGBUS, &sigsegv_action, NULL) < 0) {
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGBUS", strerror(errno));
 		ErrorAlert(str);
 		return false;
 	}
 #else
 	// Install SIGSEGV handler for CPU emulator
-	if (!sigsegv_install_handler(sigsegv_handler))
-	{
+	if (!sigsegv_install_handler(sigsegv_handler)) {
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGSEGV", strerror(errno));
 		ErrorAlert(str);
 		return false;
@@ -753,8 +723,7 @@ static bool init_sdl()
 	setenv("SDL_HAS3BUTTONMOUSE", "1", true);
 #endif
 
-	if (SDL_Init(sdl_flags) == -1)
-	{
+	if (SDL_Init(sdl_flags) == -1) {
 		char str[256];
 		sprintf(str, "Could not initialize SDL: %s.\n", SDL_GetError());
 		ErrorAlert(str);
@@ -764,19 +733,16 @@ static bool init_sdl()
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	const int SDL_EVENT_TIMEOUT = 100;
-	for (int i = 0; i < SDL_EVENT_TIMEOUT; i++)
-	{
+	for (int i = 0; i < SDL_EVENT_TIMEOUT; i++) {
 		SDL_Event event;
 		SDL_PollEvent(&event);
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-		if (event.type == SDL_EVENT_DROP_FILE)
-		{
+		if (event.type == SDL_EVENT_DROP_FILE) {
 			sdl_vmdir = event.drop.data;
 			break;
 		}
 #else
-		if (event.type == SDL_DROPFILE)
-		{
+		if (event.type == SDL_DROPFILE) {
 			sdl_vmdir = event.drop.file;
 			break;
 		}
@@ -795,7 +761,7 @@ static bool init_sdl()
 #ifdef ENABLE_GTK
 GtkWindow *win;
 
-static void gui_startup(void)
+static void gui_startup (void)
 {
 #ifdef ENABLE_GTK_3_22
 	color_scheme_set(APP_PREFERS_LIGHT);
@@ -809,13 +775,13 @@ static void gui_startup(void)
 }
 
 #ifdef ENABLE_GTK3
-static void gui_activate(GtkApplication *app)
+static void gui_activate (GtkApplication *app)
 {
-	g_assert(GTK_IS_APPLICATION(app));
-	win = gtk_application_get_active_window(app);
+	g_assert (GTK_IS_APPLICATION (app));
+	win = gtk_application_get_active_window (app);
 	/* Ask the window manager/compositor to present the window. */
 	if (win != NULL)
-		gtk_window_present(win);
+		gtk_window_present (win);
 }
 #endif
 #endif
@@ -852,99 +818,73 @@ int main(int argc, char **argv)
 #if SDL_PLATFORM_MACOS
 	set_current_directory();
 #endif
-
+	
 #ifdef USE_SDL
 	// Initialize SDL system
 	if (!init_sdl())
 		goto quit;
-#if SDL_VERSION_ATLEAST(2, 0, 0)
-	if (valid_vmdir(sdl_vmdir.c_str()))
-	{
+#if SDL_VERSION_ATLEAST(2,0,0)
+	if (valid_vmdir(sdl_vmdir.c_str())) {
 		vmdir = sdl_vmdir.c_str();
 		printf("Using %s as vmdir.\n", vmdir);
-		if (chdir(vmdir))
-		{
+		if (chdir(vmdir)) {
 			printf("Failed to chdir to %s. Good bye.", vmdir);
 			exit(1);
 		}
 	}
 #endif
 #endif
-
+	
 	// Parse command line arguments
-	for (int i = 1; i < argc; i++)
-	{
-		if (strcmp(argv[i], "-NSDocumentRevisionsDebugMode") == 0 || strncmp(argv[i], "-psn_", 5) == 0)
-		{
+	for (int i=1; i<argc; i++) {
+		if (strcmp(argv[i], "-NSDocumentRevisionsDebugMode") == 0 || strncmp(argv[i], "-psn_", 5) == 0) {
 			argv[i] = NULL;
-		}
-		else if (strcmp(argv[i], "--help") == 0)
-		{
+		} else if (strcmp(argv[i], "--help") == 0) {
 			usage(argv[0]);
 #ifndef USE_SDL_VIDEO
-		}
-		else if (strcmp(argv[i], "--display") == 0)
-		{
+		} else if (strcmp(argv[i], "--display") == 0) {
 			i++;
 			if (i < argc)
 				x_display_name = strdup(argv[i]);
 #endif
-		}
-		else if (strcmp(argv[i], "--gui-connection") == 0)
-		{
+		} else if (strcmp(argv[i], "--gui-connection") == 0) {
 			argv[i++] = NULL;
-			if (i < argc)
-			{
+			if (i < argc) {
 				gui_connection_path = argv[i];
 				argv[i] = NULL;
 			}
-		}
-		else if (strcmp(argv[i], "--config") == 0)
-		{
+		} else if (strcmp(argv[i], "--config") == 0) {
 			argv[i++] = NULL;
-			if (i < argc)
-			{
+			if (i < argc) {
 				extern std::string UserPrefsPath;
 				UserPrefsPath = argv[i];
 				argv[i] = NULL;
 			}
-		}
-		else if (strcmp(argv[i], "--nogui") == 0)
-		{
+		} else if (strcmp(argv[i], "--nogui") == 0) {
 			// We intercept the --nogui commandline so that the settings
 			// window can change the setting from the prefs file
 			argv[i++] = NULL;
-			if (i < argc)
-			{
-				if (strcmp(argv[i], "true") == 0)
-				{
+			if (i < argc) {
+				if (strcmp(argv[i], "true") == 0) {
 					use_gui = false;
 					argv[i] = NULL;
 				}
-				else if (strcmp(argv[i], "false") == 0)
-				{
+				else if (strcmp(argv[i], "false") == 0) {
 					use_gui = true;
 					argv[i] = NULL;
 				}
-			}
-			else
-			{
+			} else {
 				use_gui = false;
 			}
-		}
-		else if (strcmp(argv[i], "--gui") == 0 || strcmp(argv[i], "--settings") == 0)
-		{
+		} else if (strcmp(argv[i], "--gui") == 0 || strcmp(argv[i], "--settings") == 0) {
 			// Alternative commands to enter the GUI
 			use_gui = true;
 			argv[i] = NULL;
-		}
-		else if (valid_vmdir(argv[i]))
-		{
+		} else if (valid_vmdir(argv[i])) {
 			vmdir = argv[i];
 			argv[i] = NULL;
 			printf("Using %s as vmdir.\n", vmdir);
-			if (chdir(vmdir))
-			{
+			if (chdir(vmdir)) {
 				printf("Failed to chdir to %s. Good bye.", vmdir);
 				exit(1);
 			}
@@ -953,26 +893,22 @@ int main(int argc, char **argv)
 	}
 
 	// Remove processed arguments
-	for (int i = 1; i < argc; i++)
-	{
+	for (int i=1; i<argc; i++) {
 		int k;
-		for (k = i; k < argc; k++)
+		for (k=i; k<argc; k++)
 			if (argv[k] != NULL)
 				break;
-		if (k > i)
-		{
+		if (k > i) {
 			k -= i;
-			for (int j = i + k; j < argc; j++)
-				argv[j - k] = argv[j];
+			for (int j=i+k; j<argc; j++)
+				argv[j-k] = argv[j];
 			argc -= k;
 		}
 	}
 
 	// Connect to the external GUI
-	if (gui_connection_path)
-	{
-		if ((gui_connection = rpc_init_client(gui_connection_path)) == NULL)
-		{
+	if (gui_connection_path) {
+		if ((gui_connection = rpc_init_client(gui_connection_path)) == NULL) {
 			fprintf(stderr, "Failed to initialize RPC client connection to the GUI\n");
 			return 1;
 		}
@@ -984,7 +920,7 @@ int main(int argc, char **argv)
 	if (use_gui == -1)
 		use_gui = !PrefsFindBool("nogui");
 
-#if SDL_PLATFORM_MACOS && SDL_VERSION_ATLEAST(2, 0, 0)
+#if SDL_PLATFORM_MACOS && SDL_VERSION_ATLEAST(2,0,0)
 	// On Mac OS X hosts, SDL2 will create its own menu bar.  This is mostly OK,
 	// except that it will also install keyboard shortcuts, such as Command + Q,
 	// which can interfere with keyboard shortcuts in the guest OS.
@@ -993,12 +929,10 @@ int main(int argc, char **argv)
 	// menu bar in-place.
 	disable_SDL2_macosx_menu_bar_keyboard_shortcuts();
 #endif
-
+	
 	// Any command line arguments left?
-	for (int i = 1; i < argc; i++)
-	{
-		if (argv[i][0] == '-')
-		{
+	for (int i=1; i<argc; i++) {
+		if (argv[i][0] == '-') {
 			fprintf(stderr, "Unrecognized option '%s'\n", argv[i]);
 			usage(argv[0]);
 		}
@@ -1007,8 +941,7 @@ int main(int argc, char **argv)
 #ifndef USE_SDL_VIDEO
 	// Open display
 	x_display = XOpenDisplay(x_display_name);
-	if (x_display == NULL)
-	{
+	if (x_display == NULL) {
 		char str[256];
 		sprintf(str, GetString(STR_NO_XSERVER_ERR), XDisplayName(x_display_name));
 		ErrorAlert(str);
@@ -1026,7 +959,7 @@ int main(int argc, char **argv)
 	mon_init();
 #endif
 
-	// Install signal handlers
+  // Install signal handlers
 	if (!install_signal_handlers())
 		goto quit;
 
@@ -1040,20 +973,18 @@ int main(int argc, char **argv)
 	SysInit();
 
 #ifdef ENABLE_GTK3
-	if (!gui_connection)
-	{
+	if (!gui_connection) {
 		// Init GTK
-		app = gtk_application_new(GetString(STR_APP_ID), G_APPLICATION_FLAGS_NONE);
-		g_set_prgname(GetString(STR_APP_DISPLAY_NAME));
-		g_signal_connect(app, "activate", G_CALLBACK(gui_activate), NULL);
-		g_signal_connect(app, "startup", G_CALLBACK(gui_startup), NULL);
-		g_application_register(G_APPLICATION(app), NULL, NULL);
-		ret = g_application_run(G_APPLICATION(app), argc, argv);
+		app = gtk_application_new (GetString(STR_APP_ID), G_APPLICATION_FLAGS_NONE);
+		g_set_prgname (GetString(STR_APP_DISPLAY_NAME));
+		g_signal_connect (app, "activate", G_CALLBACK (gui_activate), NULL);
+		g_signal_connect (app, "startup", G_CALLBACK (gui_startup), NULL);
+		g_application_register (G_APPLICATION (app), NULL, NULL);
+		ret = g_application_run (G_APPLICATION (app), argc, argv);
 	}
 #elif defined(ENABLE_GTK)
-	if (!gui_connection)
-	{
-		// Init GTK
+	if (!gui_connection) {
+	// Init GTK
 		gtk_set_locale();
 		gtk_init(&argc, &argv);
 		gui_startup();
@@ -1067,8 +998,7 @@ int main(int argc, char **argv)
 
 	// Open /dev/zero
 	zero_fd = open("/dev/zero", O_RDWR);
-	if (zero_fd < 0)
-	{
+	if (zero_fd < 0) {
 		sprintf(str, GetString(STR_NO_DEV_ZERO_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1108,35 +1038,30 @@ int main(int argc, char **argv)
 	DRCacheAddr = DR_CACHE_BASE;
 	D(bug("DR Cache at %p\n", DRCacheAddr));
 #endif
-
+	
 	// Create area for Mac RAM
 	RAMSize = PrefsFindInt32("ramsize");
-	if (RAMSize <= 1000)
-	{
+	if (RAMSize <= 1000) {
 		RAMSize *= 1024 * 1024;
 	}
-	if (RAMSize < 16 * 1024 * 1024)
-	{
+	if (RAMSize < 16 * 1024 * 1024) {
 		WarningAlert(GetString(STR_SMALL_RAM_WARN));
 		RAMSize = 16 * 1024 * 1024;
 	}
 	memory_mapped_from_zero = false;
 	ram_rom_areas_contiguous = false;
 #if REAL_ADDRESSING && HAVE_LINKER_SCRIPT
-	if (vm_mac_acquire_fixed(0, RAMSize) == 0)
-	{
+	if (vm_mac_acquire_fixed(0, RAMSize) == 0) {
 		D(bug("Could allocate RAM from 0x0000\n"));
 		RAMBase = 0;
 		RAMBaseHost = Mac2HostAddr(RAMBase);
 		memory_mapped_from_zero = true;
 	}
 #endif
-	if (!memory_mapped_from_zero)
-	{
+	if (!memory_mapped_from_zero) {
 #ifndef PAGEZERO_HACK
 		// Create Low Memory area (0x0000..0x3000)
-		if (vm_mac_acquire_fixed(0, 0x3000) < 0)
-		{
+		if (vm_mac_acquire_fixed(0, 0x3000) < 0) {
 			sprintf(str, GetString(STR_LOW_MEM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
@@ -1147,21 +1072,19 @@ int main(int argc, char **argv)
 		// Allocate RAM at any address. Since ROM must be higher than RAM, allocate the RAM
 		// and ROM areas contiguously, plus a little extra to allow for ROM address alignment.
 		RAMBaseHost = vm_mac_acquire(RAMSize + ROM_AREA_SIZE + ROM_ALIGNMENT + SIG_STACK_SIZE);
-		if (RAMBaseHost == VM_MAP_FAILED)
-		{
+		if (RAMBaseHost == VM_MAP_FAILED) {
 			sprintf(str, GetString(STR_RAM_ROM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
 		}
 		RAMBase = Host2MacAddr(RAMBaseHost);
-		ROMBase = (RAMBase + RAMSize + ROM_ALIGNMENT - 1) & -ROM_ALIGNMENT;
+		ROMBase = (RAMBase + RAMSize + ROM_ALIGNMENT -1) & -ROM_ALIGNMENT;
 		ROMBaseHost = RAMBaseHost + ROMBase - RAMBase;
 		ROMEnd = RAMBase + RAMSize + ROM_AREA_SIZE + ROM_ALIGNMENT;
 
 		ram_rom_areas_contiguous = true;
 #else
-		if (vm_mac_acquire_fixed(RAM_BASE, RAMSize) < 0)
-		{
+		if (vm_mac_acquire_fixed(RAM_BASE, RAMSize) < 0) {
 			sprintf(str, GetString(STR_RAM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
@@ -1171,8 +1094,7 @@ int main(int argc, char **argv)
 #endif
 	}
 #if !EMULATED_PPC
-	if (vm_protect(RAMBaseHost, RAMSize, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0)
-	{
+	if (vm_protect(RAMBaseHost, RAMSize, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0) {
 		sprintf(str, GetString(STR_RAM_MMAP_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1181,17 +1103,14 @@ int main(int argc, char **argv)
 	ram_area_mapped = true;
 	D(bug("RAM area at %p (%08x)\n", RAMBaseHost, RAMBase));
 
-	if (RAMBase > KernelDataAddr)
-	{
+	if (RAMBase > KernelDataAddr) {
 		ErrorAlert(GetString(STR_RAM_AREA_TOO_HIGH_ERR));
 		goto quit;
 	}
-
+	
 	// Create area for Mac ROM
-	if (!ram_rom_areas_contiguous)
-	{
-		if (vm_mac_acquire_fixed(ROM_BASE, ROM_AREA_SIZE + SIG_STACK_SIZE) < 0)
-		{
+	if (!ram_rom_areas_contiguous) {
+		if (vm_mac_acquire_fixed(ROM_BASE, ROM_AREA_SIZE + SIG_STACK_SIZE) < 0) {
 			sprintf(str, GetString(STR_ROM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			goto quit;
@@ -1201,8 +1120,7 @@ int main(int argc, char **argv)
 		ROMEnd = ROMBase + ROM_AREA_SIZE;
 	}
 #if !EMULATED_PPC
-	if (vm_protect(ROMBaseHost, ROM_AREA_SIZE, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0)
-	{
+	if (vm_protect(ROMBaseHost, ROM_AREA_SIZE, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE) < 0) {
 		sprintf(str, GetString(STR_ROM_MMAP_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1211,20 +1129,18 @@ int main(int argc, char **argv)
 	rom_area_mapped = true;
 	D(bug("ROM area at %p (%08x)\n", ROMBaseHost, ROMBase));
 
-	if (RAMBase > ROMBase)
-	{
+	if (RAMBase > ROMBase) {
 		ErrorAlert(GetString(STR_RAM_HIGHER_THAN_ROM_ERR));
 		goto quit;
 	}
 
 	// Create area for SheepShaver data
-	if (!SheepMem::Init())
-	{
+	if (!SheepMem::Init()) {
 		sprintf(str, GetString(STR_SHEEP_MEM_MMAP_ERR), strerror(errno));
 		ErrorAlert(str);
 		goto quit;
 	}
-
+	
 	// Load Mac ROM
 	if (!load_mac_rom())
 		goto quit;
@@ -1253,15 +1169,14 @@ int main(int argc, char **argv)
 
 #if !EMULATED_PPC
 	// Install SIGILL handler
-	sigemptyset(&sigill_action.sa_mask); // Block interrupts during ILL handling
+	sigemptyset(&sigill_action.sa_mask);	// Block interrupts during ILL handling
 	sigaddset(&sigill_action.sa_mask, SIGUSR2);
 	sigill_action.sa_sigaction = sigill_handler;
 	sigill_action.sa_flags = SA_ONSTACK | SA_SIGINFO;
 #ifdef HAVE_SIGNAL_SA_RESTORER
 	sigill_action.sa_restorer = NULL;
 #endif
-	if (sigaction(SIGILL, &sigill_action, NULL) < 0)
-	{
+	if (sigaction(SIGILL, &sigill_action, NULL) < 0) {
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGILL", strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1276,8 +1191,7 @@ int main(int argc, char **argv)
 #ifdef HAVE_SIGNAL_SA_RESTORER
 	sigusr2_action.sa_restorer = NULL;
 #endif
-	if (sigaction(SIGUSR2, &sigusr2_action, NULL) < 0)
-	{
+	if (sigaction(SIGUSR2, &sigusr2_action, NULL) < 0) {
 		sprintf(str, GetString(STR_SIG_INSTALL_ERR), "SIGUSR2", strerror(errno));
 		ErrorAlert(str);
 		goto quit;
@@ -1294,6 +1208,7 @@ quit:
 	return 0;
 }
 
+
 /*
  *  Cleanup and quit
  */
@@ -1306,16 +1221,14 @@ static void Quit(void)
 #endif
 
 	// Stop 60Hz thread
-	if (tick_thread_active)
-	{
+	if (tick_thread_active) {
 		tick_thread_cancel = true;
 		pthread_cancel(tick_thread);
 		pthread_join(tick_thread, NULL);
 	}
 
 	// Stop NVRAM watchdog thread
-	if (nvram_thread_active)
-	{
+	if (nvram_thread_active) {
 		nvram_thread_cancel = true;
 		pthread_cancel(nvram_thread);
 		pthread_join(nvram_thread, NULL);
@@ -1388,8 +1301,7 @@ static void Quit(void)
 #endif
 
 	// Notify GUI we are about to leave
-	if (gui_connection)
-	{
+	if (gui_connection) {
 		if (rpc_method_invoke(gui_connection, RPC_METHOD_EXIT, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR)
 			rpc_method_wait_for_reply(gui_connection, RPC_TYPE_INVALID);
 	}
@@ -1407,8 +1319,7 @@ static bool kernel_data_init(void)
 	int error_string = STR_KD_SHMGET_ERR;
 	uint32 kernel_area_size = (KERNEL_AREA_SIZE + SHMLBA - 1) & -SHMLBA;
 	int kernel_area = shmget(IPC_PRIVATE, kernel_area_size, 0600);
-	if (kernel_area != -1)
-	{
+	if (kernel_area != -1) {
 		bool mapped =
 			shm_map_address(kernel_area, KERNEL_DATA_BASE & -SHMLBA) &&
 			shm_map_address(kernel_area, KERNEL_DATA2_BASE & -SHMLBA);
@@ -1438,7 +1349,8 @@ static bool shm_map_address(int kernel_area, uint32 addr)
 	void *kernel_addr = Mac2HostAddr(addr);
 	return shmat(kernel_area, kernel_addr, 0) == kernel_addr;
 }
-#endif // !defined(__APPLE__) || !defined(__x86_64__)
+#endif  // !defined(__APPLE__) || !defined(__x86_64__)
+
 
 /*
  *  Jump into Mac ROM, start 680x0 emulator
@@ -1451,6 +1363,7 @@ void jump_to_rom(uint32 entry)
 	emul_ppc(entry);
 }
 #endif
+
 
 /*
  *  Emulator thread function
@@ -1478,6 +1391,7 @@ static void *emul_func(void *arg)
 	return NULL;
 }
 
+
 #if !EMULATED_PPC
 /*
  *  Execute 68k subroutine (must be ended with RTS)
@@ -1496,6 +1410,7 @@ void Execute68k(uint32 pc, M68kRegisters *r)
 	execute_68k(pc, r);
 }
 
+
 /*
  *  Execute 68k A-Trap from EMUL_OP routine
  *  r->a[7] is unused, the routine runs on the caller's stack
@@ -1507,6 +1422,7 @@ void Execute68kTrap(uint16 trap, M68kRegisters *r)
 	Execute68k((uint32)proc, r);
 }
 #endif
+
 
 /*
  *  Quit emulator (cause return from jump_to_rom)
@@ -1521,6 +1437,7 @@ void QuitEmulator(void)
 #endif
 }
 
+
 /*
  *  Dump 68k registers
  */
@@ -1528,16 +1445,14 @@ void QuitEmulator(void)
 void Dump68kRegs(M68kRegisters *r)
 {
 	// Display 68k registers
-	for (int i = 0; i < 8; i++)
-	{
+	for (int i=0; i<8; i++) {
 		printf("d%d: %08x", i, r->d[i]);
 		if (i == 3 || i == 7)
 			printf("\n");
 		else
 			printf(", ");
 	}
-	for (int i = 0; i < 8; i++)
-	{
+	for (int i=0; i<8; i++) {
 		printf("a%d: %08x", i, r->a[i]);
 		if (i == 3 || i == 7)
 			printf("\n");
@@ -1545,6 +1460,7 @@ void Dump68kRegs(M68kRegisters *r)
 			printf(", ");
 	}
 }
+
 
 /*
  *  Make code executable
@@ -1561,14 +1477,14 @@ void MakeExecutable(int dummy, uint32 start, uint32 length)
 #endif
 }
 
+
 /*
  *  NVRAM watchdog thread (saves NVRAM every minute)
  */
 
 static void nvram_watchdog(void)
 {
-	if (memcmp(last_xpram, XPRAM, XPRAM_SIZE))
-	{
+	if (memcmp(last_xpram, XPRAM, XPRAM_SIZE)) {
 		memcpy(last_xpram, XPRAM, XPRAM_SIZE);
 		SaveXPRAM();
 	}
@@ -1576,14 +1492,14 @@ static void nvram_watchdog(void)
 
 static void *nvram_func(void *arg)
 {
-	while (!nvram_thread_cancel)
-	{
-		for (int i = 0; i < 60 && !nvram_thread_cancel; i++)
-			Delay_usec(999999); // Only wait 1 second so we quit promptly when nvram_thread_cancel becomes true
+	while (!nvram_thread_cancel) {
+		for (int i=0; i<60 && !nvram_thread_cancel; i++)
+			Delay_usec(999999);		// Only wait 1 second so we quit promptly when nvram_thread_cancel becomes true
 		nvram_watchdog();
 	}
 	return NULL;
 }
+
 
 /*
  *  60Hz thread (really 60.15Hz)
@@ -1597,8 +1513,7 @@ static void *tick_func(void *arg)
 	int64 ticks = 0;
 	uint64 next = start;
 
-	while (!tick_thread_cancel)
-	{
+	while (!tick_thread_cancel) {
 
 		// Wait
 		next += 16625;
@@ -1607,14 +1522,12 @@ static void *tick_func(void *arg)
 			Delay_usec(delay);
 		else if (delay < -16625)
 			next = GetTicks_usec();
-		if (tick_inhibit)
-			continue;
+		if (tick_inhibit) continue;
 		ticks++;
 
 #if !EMULATED_PPC
 		// Did we crash?
-		if (emul_thread_fatal)
-		{
+		if (emul_thread_fatal) {
 
 			// Yes, dump registers
 			sigregs *r = &sigsegv_regs;
@@ -1622,27 +1535,27 @@ static void *tick_func(void *arg)
 			if (crash_reason == NULL)
 				crash_reason = "SIGSEGV";
 			sprintf(str, "%s\n"
-						 "   pc %08lx     lr %08lx    ctr %08lx    msr %08lx\n"
-						 "  xer %08lx     cr %08lx  \n"
-						 "   r0 %08lx     r1 %08lx     r2 %08lx     r3 %08lx\n"
-						 "   r4 %08lx     r5 %08lx     r6 %08lx     r7 %08lx\n"
-						 "   r8 %08lx     r9 %08lx    r10 %08lx    r11 %08lx\n"
-						 "  r12 %08lx    r13 %08lx    r14 %08lx    r15 %08lx\n"
-						 "  r16 %08lx    r17 %08lx    r18 %08lx    r19 %08lx\n"
-						 "  r20 %08lx    r21 %08lx    r22 %08lx    r23 %08lx\n"
-						 "  r24 %08lx    r25 %08lx    r26 %08lx    r27 %08lx\n"
-						 "  r28 %08lx    r29 %08lx    r30 %08lx    r31 %08lx\n",
-					crash_reason,
-					r->nip, r->link, r->ctr, r->msr,
-					r->xer, r->ccr,
-					r->gpr[0], r->gpr[1], r->gpr[2], r->gpr[3],
-					r->gpr[4], r->gpr[5], r->gpr[6], r->gpr[7],
-					r->gpr[8], r->gpr[9], r->gpr[10], r->gpr[11],
-					r->gpr[12], r->gpr[13], r->gpr[14], r->gpr[15],
-					r->gpr[16], r->gpr[17], r->gpr[18], r->gpr[19],
-					r->gpr[20], r->gpr[21], r->gpr[22], r->gpr[23],
-					r->gpr[24], r->gpr[25], r->gpr[26], r->gpr[27],
-					r->gpr[28], r->gpr[29], r->gpr[30], r->gpr[31]);
+				"   pc %08lx     lr %08lx    ctr %08lx    msr %08lx\n"
+				"  xer %08lx     cr %08lx  \n"
+				"   r0 %08lx     r1 %08lx     r2 %08lx     r3 %08lx\n"
+				"   r4 %08lx     r5 %08lx     r6 %08lx     r7 %08lx\n"
+				"   r8 %08lx     r9 %08lx    r10 %08lx    r11 %08lx\n"
+				"  r12 %08lx    r13 %08lx    r14 %08lx    r15 %08lx\n"
+				"  r16 %08lx    r17 %08lx    r18 %08lx    r19 %08lx\n"
+				"  r20 %08lx    r21 %08lx    r22 %08lx    r23 %08lx\n"
+				"  r24 %08lx    r25 %08lx    r26 %08lx    r27 %08lx\n"
+				"  r28 %08lx    r29 %08lx    r30 %08lx    r31 %08lx\n",
+				crash_reason,
+				r->nip, r->link, r->ctr, r->msr,
+				r->xer, r->ccr,
+				r->gpr[0], r->gpr[1], r->gpr[2], r->gpr[3],
+				r->gpr[4], r->gpr[5], r->gpr[6], r->gpr[7],
+				r->gpr[8], r->gpr[9], r->gpr[10], r->gpr[11],
+				r->gpr[12], r->gpr[13], r->gpr[14], r->gpr[15],
+				r->gpr[16], r->gpr[17], r->gpr[18], r->gpr[19],
+				r->gpr[20], r->gpr[21], r->gpr[22], r->gpr[23],
+				r->gpr[24], r->gpr[25], r->gpr[26], r->gpr[27],
+				r->gpr[28], r->gpr[29], r->gpr[30], r->gpr[31]);
 			printf(str);
 			VideoQuitFullScreen();
 
@@ -1657,15 +1570,13 @@ static void *tick_func(void *arg)
 #endif
 
 		// Pseudo Mac 1Hz interrupt, update local time
-		if (++tick_counter > 60)
-		{
+		if (++tick_counter > 60) {
 			tick_counter = 0;
 			WriteMacInt32(0x20c, TimerDateTime());
 		}
 
 		// Trigger 60Hz interrupt
-		if (ReadMacInt32(XLM_IRQ_NEST) == 0)
-		{
+		if (ReadMacInt32(XLM_IRQ_NEST) == 0) {
 			SetInterruptFlag(INTFLAG_VIA);
 			TriggerInterrupt();
 		}
@@ -1675,6 +1586,7 @@ static void *tick_func(void *arg)
 	D(bug("%lld ticks in %lld usec = %f ticks/sec\n", ticks, end - start, ticks * 1000000.0 / (end - start)));
 	return NULL;
 }
+
 
 /*
  *  Pthread configuration
@@ -1686,30 +1598,28 @@ void Set_pthread_attr(pthread_attr_t *attr, int priority)
 	pthread_attr_init(attr);
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING)
 	// Some of these only work for superuser
-	if (geteuid() == 0)
-	{
+	if (geteuid() == 0) {
 		pthread_attr_setinheritsched(attr, PTHREAD_EXPLICIT_SCHED);
 		pthread_attr_setschedpolicy(attr, SCHED_FIFO);
 		struct sched_param fifo_param;
-		fifo_param.sched_priority = ((sched_get_priority_min(SCHED_FIFO) +
-									  sched_get_priority_max(SCHED_FIFO)) /
-										 2 +
-									 priority);
+		fifo_param.sched_priority = ((sched_get_priority_min(SCHED_FIFO) + 
+					      sched_get_priority_max(SCHED_FIFO)) / 2 +
+					     priority);
 		pthread_attr_setschedparam(attr, &fifo_param);
 	}
-	if (pthread_attr_setscope(attr, PTHREAD_SCOPE_SYSTEM) != 0)
-	{
+	if (pthread_attr_setscope(attr, PTHREAD_SCOPE_SYSTEM) != 0) {
 #ifdef PTHREAD_SCOPE_BOUND_NP
-		// If system scope is not available (eg. we're not running
-		// with CAP_SCHED_MGT capability on an SGI box), try bound
-		// scope.  It exposes pthread scheduling to the kernel,
-		// without setting realtime priority.
-		pthread_attr_setscope(attr, PTHREAD_SCOPE_BOUND_NP);
+	    // If system scope is not available (eg. we're not running
+	    // with CAP_SCHED_MGT capability on an SGI box), try bound
+	    // scope.  It exposes pthread scheduling to the kernel,
+	    // without setting realtime priority.
+	    pthread_attr_setscope(attr, PTHREAD_SCOPE_BOUND_NP);
 #endif
 	}
 #endif
 #endif
 }
+
 
 /*
  *  Mutexes
@@ -1717,31 +1627,28 @@ void Set_pthread_attr(pthread_attr_t *attr, int priority)
 
 #ifdef HAVE_PTHREADS
 
-struct B2_mutex
-{
-	B2_mutex()
-	{
-		pthread_mutexattr_t attr;
-		pthread_mutexattr_init(&attr);
-		// Initialize the mutex for priority inheritance --
-		// required for accurate timing.
+struct B2_mutex {
+	B2_mutex() { 
+	    pthread_mutexattr_t attr;
+	    pthread_mutexattr_init(&attr);
+	    // Initialize the mutex for priority inheritance --
+	    // required for accurate timing.
 #if defined(HAVE_PTHREAD_MUTEXATTR_SETPROTOCOL) && !defined(__CYGWIN__)
-		pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
+	    pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
 #endif
 #if defined(HAVE_PTHREAD_MUTEXATTR_SETTYPE) && defined(PTHREAD_MUTEX_NORMAL)
-		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
+	    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
 #endif
 #ifdef HAVE_PTHREAD_MUTEXATTR_SETPSHARED
-		pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
+	    pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
 #endif
-		pthread_mutex_init(&m, &attr);
-		pthread_mutexattr_destroy(&attr);
+	    pthread_mutex_init(&m, &attr);
+	    pthread_mutexattr_destroy(&attr);
 	}
-	~B2_mutex()
-	{
-		pthread_mutex_trylock(&m); // Make sure it's locked before
-		pthread_mutex_unlock(&m);  // unlocking it.
-		pthread_mutex_destroy(&m);
+	~B2_mutex() { 
+	    pthread_mutex_trylock(&m); // Make sure it's locked before
+	    pthread_mutex_unlock(&m);  // unlocking it.
+	    pthread_mutex_destroy(&m);
 	}
 	pthread_mutex_t m;
 };
@@ -1768,8 +1675,7 @@ void B2_delete_mutex(B2_mutex *mutex)
 
 #else
 
-struct B2_mutex
-{
+struct B2_mutex {
 	int dummy;
 };
 
@@ -1793,6 +1699,7 @@ void B2_delete_mutex(B2_mutex *mutex)
 
 #endif
 
+
 /*
  *  Trigger signal USR2 from another thread
  */
@@ -1800,13 +1707,13 @@ void B2_delete_mutex(B2_mutex *mutex)
 #if !EMULATED_PPC
 void TriggerInterrupt(void)
 {
-	if (ready_for_signals)
-	{
+	if (ready_for_signals) {
 		idle_resume();
 		pthread_kill(emul_thread, SIGUSR2);
 	}
 }
 #endif
+
 
 /*
  *  Interrupt flags (must be handled atomically!)
@@ -1824,6 +1731,7 @@ void ClearInterruptFlag(uint32 flag)
 	atomic_and((int *)&InterruptFlags, ~flag);
 }
 
+
 /*
  *  Disable interrupts
  */
@@ -1837,6 +1745,7 @@ void DisableInterrupt(void)
 #endif
 }
 
+
 /*
  *  Enable interrupts
  */
@@ -1849,6 +1758,7 @@ void EnableInterrupt(void)
 	atomic_add((int *)XLM_IRQ_NEST, -1);
 #endif
 }
+
 
 /*
  *  USR2 handler
@@ -1881,83 +1791,79 @@ void sigusr2_handler(int sig, siginfo_t *sip, void *scp)
 	WriteMacInt32(0x110, 0);
 
 	// Interrupt action depends on current run mode
-	switch (ReadMacInt32(XLM_RUN_MODE))
-	{
-	case MODE_68K:
-		// 68k emulator active, trigger 68k interrupt level 1
-		WriteMacInt16(ReadMacInt32(0x67c), 1);
-		r->cr() |= ReadMacInt32(0x674);
-		break;
+	switch (ReadMacInt32(XLM_RUN_MODE)) {
+		case MODE_68K:
+			// 68k emulator active, trigger 68k interrupt level 1
+			WriteMacInt16(ReadMacInt32(0x67c), 1);
+			r->cr() |= ReadMacInt32(0x674);
+			break;
 
 #if INTERRUPTS_IN_NATIVE_MODE
-	case MODE_NATIVE:
-		// 68k emulator inactive, in nanokernel?
-		if (r->gpr(1) != KernelDataAddr)
-		{
+		case MODE_NATIVE:
+			// 68k emulator inactive, in nanokernel?
+			if (r->gpr(1) != KernelDataAddr) {
 
-			// Set extra stack for SIGSEGV handler
-			sigaltstack(&extra_stack, NULL);
+				// Set extra stack for SIGSEGV handler
+				sigaltstack(&extra_stack, NULL);
+				
+				// Prepare for 68k interrupt level 1
+				WriteMacInt16(ReadMacInt32(0x67c), 1);
+				WriteMacInt32(ReadMacInt32(0x658) + 0xdc, ReadMacInt32(ReadMacInt32(0x658) + 0xdc) | ReadMacInt32(0x674));
 
-			// Prepare for 68k interrupt level 1
-			WriteMacInt16(ReadMacInt32(0x67c), 1);
-			WriteMacInt32(ReadMacInt32(0x658) + 0xdc, ReadMacInt32(ReadMacInt32(0x658) + 0xdc) | ReadMacInt32(0x674));
+				// Execute nanokernel interrupt routine (this will activate the 68k emulator)
+				DisableInterrupt();
+				if (ROMType == ROMTYPE_NEWWORLD)
+					ppc_interrupt(ROMBase + 0x312b1c, KernelDataAddr);
+				else
+					ppc_interrupt(ROMBase + 0x312a3c, KernelDataAddr);
 
-			// Execute nanokernel interrupt routine (this will activate the 68k emulator)
-			DisableInterrupt();
-			if (ROMType == ROMTYPE_NEWWORLD)
-				ppc_interrupt(ROMBase + 0x312b1c, KernelDataAddr);
-			else
-				ppc_interrupt(ROMBase + 0x312a3c, KernelDataAddr);
-
-			// Reset normal stack
-			sigaltstack(&sig_stack, NULL);
-		}
-		break;
+				// Reset normal stack
+				sigaltstack(&sig_stack, NULL);
+			}
+			break;
 #endif
 
 #if INTERRUPTS_IN_EMUL_OP_MODE
-	case MODE_EMUL_OP:
-		// 68k emulator active, within EMUL_OP routine, execute 68k interrupt routine directly when interrupt level is 0
-		if ((ReadMacInt32(XLM_68K_R25) & 7) == 0)
-		{
+		case MODE_EMUL_OP:
+			// 68k emulator active, within EMUL_OP routine, execute 68k interrupt routine directly when interrupt level is 0
+			if ((ReadMacInt32(XLM_68K_R25) & 7) == 0) {
 
-			// Set extra stack for SIGSEGV handler
-			sigaltstack(&extra_stack, NULL);
+				// Set extra stack for SIGSEGV handler
+				sigaltstack(&extra_stack, NULL);
 #if 1
-			// Execute full 68k interrupt routine
-			M68kRegisters r;
-			uint32 old_r25 = ReadMacInt32(XLM_68K_R25); // Save interrupt level
-			WriteMacInt32(XLM_68K_R25, 0x21);			// Execute with interrupt level 1
-			static const uint16 proc[] = {
-				0x3f3c, 0x0000, // move.w	#$0000,-(sp)	(fake format word)
-				0x487a, 0x000a, // pea		@1(pc)			(return address)
-				0x40e7,			// move		sr,-(sp)		(saved SR)
-				0x2078, 0x0064, // move.l	$64,a0
-				0x4ed0,			// jmp		(a0)
-				M68K_RTS		// @1
-			};
-			Execute68k((uint32)proc, &r);
-			WriteMacInt32(XLM_68K_R25, old_r25); // Restore interrupt level
+				// Execute full 68k interrupt routine
+				M68kRegisters r;
+				uint32 old_r25 = ReadMacInt32(XLM_68K_R25);	// Save interrupt level
+				WriteMacInt32(XLM_68K_R25, 0x21);			// Execute with interrupt level 1
+				static const uint16 proc[] = {
+					0x3f3c, 0x0000,		// move.w	#$0000,-(sp)	(fake format word)
+					0x487a, 0x000a,		// pea		@1(pc)			(return address)
+					0x40e7,				// move		sr,-(sp)		(saved SR)
+					0x2078, 0x0064,		// move.l	$64,a0
+					0x4ed0,				// jmp		(a0)
+					M68K_RTS			// @1
+				};
+				Execute68k((uint32)proc, &r);
+				WriteMacInt32(XLM_68K_R25, old_r25);		// Restore interrupt level
 #else
-			// Only update cursor
-			if (HasMacStarted())
-			{
-				if (InterruptFlags & INTFLAG_VIA)
-				{
-					ClearInterruptFlag(INTFLAG_VIA);
-					ADBInterrupt();
-					ExecuteNative(NATIVE_VIDEO_VBL);
+				// Only update cursor
+				if (HasMacStarted()) {
+					if (InterruptFlags & INTFLAG_VIA) {
+						ClearInterruptFlag(INTFLAG_VIA);
+						ADBInterrupt();
+						ExecuteNative(NATIVE_VIDEO_VBL);
+					}
 				}
-			}
 #endif
-			// Reset normal stack
-			sigaltstack(&sig_stack, NULL);
-		}
-		break;
+				// Reset normal stack
+				sigaltstack(&sig_stack, NULL);
+			}
+			break;
 #endif
 	}
 }
 #endif
+
 
 /*
  *  SIGSEGV handler
@@ -1970,7 +1876,7 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 
 	// Get effective address
 	uint32 addr = r->dar();
-
+	
 #ifdef SYSTEM_CLOBBERS_R2
 	// Restore pointer to Thread Local Storage
 	set_r2(TOC);
@@ -1982,65 +1888,51 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 
 #if ENABLE_VOSF
 	// Handle screen fault
-#if SIGSEGV_CHECK_VERSION(1, 0, 0)
+#if SIGSEGV_CHECK_VERSION(1,0,0)
 	sigsegv_info_t si;
 	si.addr = (sigsegv_address_t)addr;
 	si.pc = (sigsegv_address_t)r->pc();
 #endif
-	extern bool Screen_fault_handler(sigsegv_info_t * sip);
+	extern bool Screen_fault_handler(sigsegv_info_t *sip);
 	if (Screen_fault_handler(&si))
 		return;
 #endif
 
 	// Fault in Mac ROM or RAM or DR Cache?
 	bool mac_fault = (r->pc() >= ROMBase) && (r->pc() < (ROMBase + ROM_AREA_SIZE)) || (r->pc() >= RAMBase) && (r->pc() < (RAMBase + RAMSize)) || (r->pc() >= DR_CACHE_BASE && r->pc() < (DR_CACHE_BASE + DR_CACHE_SIZE));
-	if (mac_fault)
-	{
+	if (mac_fault) {
 
 		// "VM settings" during MacOS 8 installation
-		if (r->pc() == ROMBase + 0x488160 && r->gpr(20) == 0xf8000000)
-		{
+		if (r->pc() == ROMBase + 0x488160 && r->gpr(20) == 0xf8000000) {
 			r->pc() += 4;
 			r->gpr(8) = 0;
 			return;
-
-			// MacOS 8.5 installation
-		}
-		else if (r->pc() == ROMBase + 0x488140 && r->gpr(16) == 0xf8000000)
-		{
+	
+		// MacOS 8.5 installation
+		} else if (r->pc() == ROMBase + 0x488140 && r->gpr(16) == 0xf8000000) {
 			r->pc() += 4;
 			r->gpr(8) = 0;
 			return;
-
-			// MacOS 8 serial drivers on startup
-		}
-		else if (r->pc() == ROMBase + 0x48e080 && (r->gpr(8) == 0xf3012002 || r->gpr(8) == 0xf3012000))
-		{
+	
+		// MacOS 8 serial drivers on startup
+		} else if (r->pc() == ROMBase + 0x48e080 && (r->gpr(8) == 0xf3012002 || r->gpr(8) == 0xf3012000)) {
 			r->pc() += 4;
 			r->gpr(8) = 0;
 			return;
-
-			// MacOS 8.1 serial drivers on startup
-		}
-		else if (r->pc() == ROMBase + 0x48c5e0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000))
-		{
+	
+		// MacOS 8.1 serial drivers on startup
+		} else if (r->pc() == ROMBase + 0x48c5e0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000)) {
 			r->pc() += 4;
 			return;
-		}
-		else if (r->pc() == ROMBase + 0x4a10a0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000))
-		{
+		} else if (r->pc() == ROMBase + 0x4a10a0 && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000)) {
 			r->pc() += 4;
 			return;
-
-			// MacOS 8.6 serial drivers on startup (with DR Cache and OldWorld ROM)
-		}
-		else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(16) == 0xf3012002 || r->gpr(16) == 0xf3012000))
-		{
+	
+		// MacOS 8.6 serial drivers on startup (with DR Cache and OldWorld ROM)
+		} else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(16) == 0xf3012002 || r->gpr(16) == 0xf3012000)) {
 			r->pc() += 4;
 			return;
-		}
-		else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000))
-		{
+		} else if ((r->pc() - DR_CACHE_BASE) < DR_CACHE_SIZE && (r->gpr(20) == 0xf3012002 || r->gpr(20) == 0xf3012000)) {
 			r->pc() += 4;
 			return;
 		}
@@ -2055,213 +1947,119 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		int32 imm = (int16)(opcode & 0xffff);
 
 		// Analyze opcode
-		enum
-		{
+		enum {
 			TYPE_UNKNOWN,
 			TYPE_LOAD,
 			TYPE_STORE
 		} transfer_type = TYPE_UNKNOWN;
-		enum
-		{
+		enum {
 			SIZE_UNKNOWN,
 			SIZE_BYTE,
 			SIZE_HALFWORD,
 			SIZE_WORD
 		} transfer_size = SIZE_UNKNOWN;
-		enum
-		{
+		enum {
 			MODE_UNKNOWN,
 			MODE_NORM,
 			MODE_U,
 			MODE_X,
 			MODE_UX
 		} addr_mode = MODE_UNKNOWN;
-		switch (primop)
-		{
-		case 31:
-			switch (exop)
-			{
-			case 23: // lwzx
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_WORD;
-				addr_mode = MODE_X;
+		switch (primop) {
+			case 31:
+				switch (exop) {
+					case 23:	// lwzx
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_X; break;
+					case 55:	// lwzux
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_UX; break;
+					case 87:	// lbzx
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_X; break;
+					case 119:	// lbzux
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_UX; break;
+					case 151:	// stwx
+						transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_X; break;
+					case 183:	// stwux
+						transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_UX; break;
+					case 215:	// stbx
+						transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_X; break;
+					case 247:	// stbux
+						transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_UX; break;
+					case 279:	// lhzx
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_X; break;
+					case 311:	// lhzux
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_UX; break;
+					case 343:	// lhax
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_X; break;
+					case 375:	// lhaux
+						transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_UX; break;
+					case 407:	// sthx
+						transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_X; break;
+					case 439:	// sthux
+						transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_UX; break;
+				}
 				break;
-			case 55: // lwzux
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_WORD;
-				addr_mode = MODE_UX;
-				break;
-			case 87: // lbzx
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_BYTE;
-				addr_mode = MODE_X;
-				break;
-			case 119: // lbzux
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_BYTE;
-				addr_mode = MODE_UX;
-				break;
-			case 151: // stwx
-				transfer_type = TYPE_STORE;
-				transfer_size = SIZE_WORD;
-				addr_mode = MODE_X;
-				break;
-			case 183: // stwux
-				transfer_type = TYPE_STORE;
-				transfer_size = SIZE_WORD;
-				addr_mode = MODE_UX;
-				break;
-			case 215: // stbx
-				transfer_type = TYPE_STORE;
-				transfer_size = SIZE_BYTE;
-				addr_mode = MODE_X;
-				break;
-			case 247: // stbux
-				transfer_type = TYPE_STORE;
-				transfer_size = SIZE_BYTE;
-				addr_mode = MODE_UX;
-				break;
-			case 279: // lhzx
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_HALFWORD;
-				addr_mode = MODE_X;
-				break;
-			case 311: // lhzux
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_HALFWORD;
-				addr_mode = MODE_UX;
-				break;
-			case 343: // lhax
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_HALFWORD;
-				addr_mode = MODE_X;
-				break;
-			case 375: // lhaux
-				transfer_type = TYPE_LOAD;
-				transfer_size = SIZE_HALFWORD;
-				addr_mode = MODE_UX;
-				break;
-			case 407: // sthx
-				transfer_type = TYPE_STORE;
-				transfer_size = SIZE_HALFWORD;
-				addr_mode = MODE_X;
-				break;
-			case 439: // sthux
-				transfer_type = TYPE_STORE;
-				transfer_size = SIZE_HALFWORD;
-				addr_mode = MODE_UX;
-				break;
-			}
-			break;
-
-		case 32: // lwz
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_WORD;
-			addr_mode = MODE_NORM;
-			break;
-		case 33: // lwzu
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_WORD;
-			addr_mode = MODE_U;
-			break;
-		case 34: // lbz
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_BYTE;
-			addr_mode = MODE_NORM;
-			break;
-		case 35: // lbzu
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_BYTE;
-			addr_mode = MODE_U;
-			break;
-		case 36: // stw
-			transfer_type = TYPE_STORE;
-			transfer_size = SIZE_WORD;
-			addr_mode = MODE_NORM;
-			break;
-		case 37: // stwu
-			transfer_type = TYPE_STORE;
-			transfer_size = SIZE_WORD;
-			addr_mode = MODE_U;
-			break;
-		case 38: // stb
-			transfer_type = TYPE_STORE;
-			transfer_size = SIZE_BYTE;
-			addr_mode = MODE_NORM;
-			break;
-		case 39: // stbu
-			transfer_type = TYPE_STORE;
-			transfer_size = SIZE_BYTE;
-			addr_mode = MODE_U;
-			break;
-		case 40: // lhz
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_HALFWORD;
-			addr_mode = MODE_NORM;
-			break;
-		case 41: // lhzu
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_HALFWORD;
-			addr_mode = MODE_U;
-			break;
-		case 42: // lha
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_HALFWORD;
-			addr_mode = MODE_NORM;
-			break;
-		case 43: // lhau
-			transfer_type = TYPE_LOAD;
-			transfer_size = SIZE_HALFWORD;
-			addr_mode = MODE_U;
-			break;
-		case 44: // sth
-			transfer_type = TYPE_STORE;
-			transfer_size = SIZE_HALFWORD;
-			addr_mode = MODE_NORM;
-			break;
-		case 45: // sthu
-			transfer_type = TYPE_STORE;
-			transfer_size = SIZE_HALFWORD;
-			addr_mode = MODE_U;
-			break;
+	
+			case 32:	// lwz
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_NORM; break;
+			case 33:	// lwzu
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_WORD; addr_mode = MODE_U; break;
+			case 34:	// lbz
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_NORM; break;
+			case 35:	// lbzu
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_BYTE; addr_mode = MODE_U; break;
+			case 36:	// stw
+				transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_NORM; break;
+			case 37:	// stwu
+				transfer_type = TYPE_STORE; transfer_size = SIZE_WORD; addr_mode = MODE_U; break;
+			case 38:	// stb
+				transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_NORM; break;
+			case 39:	// stbu
+				transfer_type = TYPE_STORE; transfer_size = SIZE_BYTE; addr_mode = MODE_U; break;
+			case 40:	// lhz
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_NORM; break;
+			case 41:	// lhzu
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_U; break;
+			case 42:	// lha
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_NORM; break;
+			case 43:	// lhau
+				transfer_type = TYPE_LOAD; transfer_size = SIZE_HALFWORD; addr_mode = MODE_U; break;
+			case 44:	// sth
+				transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_NORM; break;
+			case 45:	// sthu
+				transfer_type = TYPE_STORE; transfer_size = SIZE_HALFWORD; addr_mode = MODE_U; break;
 #if EMULATE_UNALIGNED_LOADSTORE_MULTIPLE
-		case 46: // lmw
-			if ((addr % 4) != 0)
-			{
-				uint32 ea = addr;
-				D(bug("WARNING: unaligned lmw to EA=%08x from IP=%08x\n", ea, r->pc()));
-				for (int i = rd; i <= 31; i++)
-				{
-					r->gpr(i) = ReadMacInt32(ea);
-					ea += 4;
+			case 46:	// lmw
+				if ((addr % 4) != 0) {
+					uint32 ea = addr;
+					D(bug("WARNING: unaligned lmw to EA=%08x from IP=%08x\n", ea, r->pc()));
+					for (int i = rd; i <= 31; i++) {
+						r->gpr(i) = ReadMacInt32(ea);
+						ea += 4;
+					}
+					r->pc() += 4;
+					goto rti;
 				}
-				r->pc() += 4;
-				goto rti;
-			}
-			break;
-		case 47: // stmw
-			if ((addr % 4) != 0)
-			{
-				uint32 ea = addr;
-				D(bug("WARNING: unaligned stmw to EA=%08x from IP=%08x\n", ea, r->pc()));
-				for (int i = rd; i <= 31; i++)
-				{
-					WriteMacInt32(ea, r->gpr(i));
-					ea += 4;
+				break;
+			case 47:	// stmw
+				if ((addr % 4) != 0) {
+					uint32 ea = addr;
+					D(bug("WARNING: unaligned stmw to EA=%08x from IP=%08x\n", ea, r->pc()));
+					for (int i = rd; i <= 31; i++) {
+						WriteMacInt32(ea, r->gpr(i));
+						ea += 4;
+					}
+					r->pc() += 4;
+					goto rti;
 				}
-				r->pc() += 4;
-				goto rti;
-			}
-			break;
+				break;
 #endif
 		}
-
+	
 		// Ignore ROM writes (including to the zero page, which is read-only)
 		if (transfer_type == TYPE_STORE &&
 			((addr >= ROMBase && addr < ROMBase + ROM_SIZE) ||
-			 (addr >= SheepMem::ZeroPage() && addr < SheepMem::ZeroPage() + SheepMem::PageSize())))
-		{
-			//			D(bug("WARNING: %s write access to ROM at %08lx, pc %08lx\n", transfer_size == SIZE_BYTE ? "Byte" : transfer_size == SIZE_HALFWORD ? "Halfword" : "Word", addr, r->pc()));
+			 (addr >= SheepMem::ZeroPage() && addr < SheepMem::ZeroPage() + SheepMem::PageSize()))) {
+//			D(bug("WARNING: %s write access to ROM at %08lx, pc %08lx\n", transfer_size == SIZE_BYTE ? "Byte" : transfer_size == SIZE_HALFWORD ? "Halfword" : "Word", addr, r->pc()));
 			if (addr_mode == MODE_U || addr_mode == MODE_UX)
 				r->gpr(ra) = addr;
 			r->pc() += 4;
@@ -2269,8 +2067,7 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		}
 
 		// Ignore illegal memory accesses?
-		if (PrefsFindBool("ignoresegv"))
-		{
+		if (PrefsFindBool("ignoresegv")) {
 			if (addr_mode == MODE_U || addr_mode == MODE_UX)
 				r->gpr(ra) = addr;
 			if (transfer_type == TYPE_LOAD)
@@ -2280,13 +2077,10 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		}
 
 		// In GUI mode, show error alert
-		if (use_gui)
-		{
+		if (use_gui) {
 			char str[256];
 			if (transfer_type == TYPE_LOAD || transfer_type == TYPE_STORE)
-				sprintf(str, GetString(STR_MEM_ACCESS_ERR), transfer_size == SIZE_BYTE ? "byte" : transfer_size == SIZE_HALFWORD ? "halfword"
-																																 : "word",
-						transfer_type == TYPE_LOAD ? GetString(STR_MEM_ACCESS_READ) : GetString(STR_MEM_ACCESS_WRITE), addr, r->pc(), r->gpr(24), r->gpr(1));
+				sprintf(str, GetString(STR_MEM_ACCESS_ERR), transfer_size == SIZE_BYTE ? "byte" : transfer_size == SIZE_HALFWORD ? "halfword" : "word", transfer_type == TYPE_LOAD ? GetString(STR_MEM_ACCESS_READ) : GetString(STR_MEM_ACCESS_WRITE), addr, r->pc(), r->gpr(24), r->gpr(1));
 			else
 				sprintf(str, GetString(STR_UNKNOWN_SEGV_ERR), r->pc(), r->gpr(24), r->gpr(1), opcode);
 			ErrorAlert(str);
@@ -2297,8 +2091,7 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 
 	// For all other errors, jump into debugger (sort of...)
 	crash_reason = (sig == SIGBUS) ? "SIGBUS" : "SIGSEGV";
-	if (!ready_for_signals)
-	{
+	if (!ready_for_signals) {
 		printf("%s\n");
 		printf(" sigcontext %p, machine_regs %p\n", scp, r);
 		printf(
@@ -2326,17 +2119,15 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 		exit(1);
 		QuitEmulator();
 		return;
-	}
-	else
-	{
+	} else {
 		// We crashed. Save registers, tell tick thread and loop forever
 		build_sigregs(&sigsegv_regs, r);
 		emul_thread_fatal = true;
-		for (;;)
-			;
+		for (;;) ;
 	}
 rti:;
 }
+
 
 /*
  *  SIGILL handler
@@ -2358,8 +2149,7 @@ static void sigill_handler(int sig, siginfo_t *sip, void *scp)
 
 	// Fault in Mac ROM or RAM?
 	bool mac_fault = (r->pc() >= ROMBase) && (r->pc() < (ROMBase + ROM_AREA_SIZE)) || (r->pc() >= RAMBase) && (r->pc() < (RAMBase + RAMSize));
-	if (mac_fault)
-	{
+	if (mac_fault) {
 
 		// Get opcode and divide into fields
 		uint32 opcode = *((uint32 *)r->pc());
@@ -2370,130 +2160,103 @@ static void sigill_handler(int sig, siginfo_t *sip, void *scp)
 		uint32 rd = (opcode >> 21) & 0x1f;
 		int32 imm = (int16)(opcode & 0xffff);
 
-		switch (primop)
-		{
-		case 9: // POWER instructions
-		case 22:
-		power_inst:
-			sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(1), opcode);
-			ErrorAlert(str);
-			QuitEmulator();
-			return;
+		switch (primop) {
+			case 9:		// POWER instructions
+			case 22:
+power_inst:		sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(1), opcode);
+				ErrorAlert(str);
+				QuitEmulator();
+				return;
 
-		case 31:
-			switch (exop)
-			{
-			case 83: // mfmsr
-				r->gpr(rd) = 0xf072;
-				r->pc() += 4;
-				goto rti;
+			case 31:
+				switch (exop) {
+					case 83:	// mfmsr
+						r->gpr(rd) = 0xf072;
+						r->pc() += 4;
+						goto rti;
 
-			case 210: // mtsr
-			case 242: // mtsrin
-			case 306: // tlbie
-				r->pc() += 4;
-				goto rti;
+					case 210:	// mtsr
+					case 242:	// mtsrin
+					case 306:	// tlbie
+						r->pc() += 4;
+						goto rti;
 
-			case 339:
-			{ // mfspr
-				int spr = ra | (rb << 5);
-				switch (spr)
-				{
-				case 0:	  // MQ
-				case 22:  // DEC
-				case 952: // MMCR0
-				case 953: // PMC1
-				case 954: // PMC2
-				case 955: // SIA
-				case 956: // MMCR1
-				case 957: // PMC3
-				case 958: // PMC4
-				case 959: // SDA
-					r->pc() += 4;
-					goto rti;
-				case 25: // SDR1
-					r->gpr(rd) = 0xdead001f;
-					r->pc() += 4;
-					goto rti;
-				case 287: // PVR
-					r->gpr(rd) = PVR;
-					r->pc() += 4;
-					goto rti;
+					case 339: {	// mfspr
+						int spr = ra | (rb << 5);
+						switch (spr) {
+							case 0:		// MQ
+							case 22:	// DEC
+							case 952:	// MMCR0
+							case 953:	// PMC1
+							case 954:	// PMC2
+							case 955:	// SIA
+							case 956:	// MMCR1
+							case 957:	// PMC3
+							case 958:	// PMC4
+							case 959:	// SDA
+								r->pc() += 4;
+								goto rti;
+							case 25:	// SDR1
+								r->gpr(rd) = 0xdead001f;
+								r->pc() += 4;
+								goto rti;
+							case 287:	// PVR
+								r->gpr(rd) = PVR;
+								r->pc() += 4;
+								goto rti;
+						}
+						break;
+					}
+
+					case 467: {	// mtspr
+						int spr = ra | (rb << 5);
+						switch (spr) {
+							case 0:		// MQ
+							case 22:	// DEC
+							case 275:	// SPRG3
+							case 528:	// IBAT0U
+							case 529:	// IBAT0L
+							case 530:	// IBAT1U
+							case 531:	// IBAT1L
+							case 532:	// IBAT2U
+							case 533:	// IBAT2L
+							case 534:	// IBAT3U
+							case 535:	// IBAT3L
+							case 536:	// DBAT0U
+							case 537:	// DBAT0L
+							case 538:	// DBAT1U
+							case 539:	// DBAT1L
+							case 540:	// DBAT2U
+							case 541:	// DBAT2L
+							case 542:	// DBAT3U
+							case 543:	// DBAT3L
+							case 952:	// MMCR0
+							case 953:	// PMC1
+							case 954:	// PMC2
+							case 955:	// SIA
+							case 956:	// MMCR1
+							case 957:	// PMC3
+							case 958:	// PMC4
+							case 959:	// SDA
+								r->pc() += 4;
+								goto rti;
+						}
+						break;
+					}
+
+					case 29: case 107: case 152: case 153:	// POWER instructions
+					case 184: case 216: case 217: case 248:
+					case 264: case 277: case 331: case 360:
+					case 363: case 488: case 531: case 537:
+					case 541: case 664: case 665: case 696:
+					case 728: case 729: case 760: case 920:
+					case 921: case 952:
+						goto power_inst;
 				}
-				break;
-			}
-
-			case 467:
-			{ // mtspr
-				int spr = ra | (rb << 5);
-				switch (spr)
-				{
-				case 0:	  // MQ
-				case 22:  // DEC
-				case 275: // SPRG3
-				case 528: // IBAT0U
-				case 529: // IBAT0L
-				case 530: // IBAT1U
-				case 531: // IBAT1L
-				case 532: // IBAT2U
-				case 533: // IBAT2L
-				case 534: // IBAT3U
-				case 535: // IBAT3L
-				case 536: // DBAT0U
-				case 537: // DBAT0L
-				case 538: // DBAT1U
-				case 539: // DBAT1L
-				case 540: // DBAT2U
-				case 541: // DBAT2L
-				case 542: // DBAT3U
-				case 543: // DBAT3L
-				case 952: // MMCR0
-				case 953: // PMC1
-				case 954: // PMC2
-				case 955: // SIA
-				case 956: // MMCR1
-				case 957: // PMC3
-				case 958: // PMC4
-				case 959: // SDA
-					r->pc() += 4;
-					goto rti;
-				}
-				break;
-			}
-
-			case 29:
-			case 107:
-			case 152:
-			case 153: // POWER instructions
-			case 184:
-			case 216:
-			case 217:
-			case 248:
-			case 264:
-			case 277:
-			case 331:
-			case 360:
-			case 363:
-			case 488:
-			case 531:
-			case 537:
-			case 541:
-			case 664:
-			case 665:
-			case 696:
-			case 728:
-			case 729:
-			case 760:
-			case 920:
-			case 921:
-			case 952:
-				goto power_inst;
-			}
 		}
 
 		// In GUI mode, show error alert
-		if (use_gui)
-		{
+		if (use_gui) {
 			sprintf(str, GetString(STR_UNKNOWN_SEGV_ERR), r->pc(), r->gpr(24), r->gpr(1), opcode);
 			ErrorAlert(str);
 			QuitEmulator();
@@ -2503,8 +2266,7 @@ static void sigill_handler(int sig, siginfo_t *sip, void *scp)
 
 	// For all other errors, jump into debugger (sort of...)
 	crash_reason = "SIGILL";
-	if (!ready_for_signals)
-	{
+	if (!ready_for_signals) {
 		printf("%s\n");
 		printf(" sigcontext %p, machine_regs %p\n", scp, r);
 		printf(
@@ -2532,14 +2294,11 @@ static void sigill_handler(int sig, siginfo_t *sip, void *scp)
 		exit(1);
 		QuitEmulator();
 		return;
-	}
-	else
-	{
+	} else {
 		// We crashed. Save registers, tell tick thread and loop forever
 		build_sigregs(&sigsegv_regs, r);
 		emul_thread_fatal = true;
-		for (;;)
-			;
+		for (;;) ;
 	}
 rti:;
 }
@@ -2584,8 +2343,7 @@ bool SheepMem::Init(void)
 
 void SheepMem::Exit(void)
 {
-	if (data)
-	{
+	if (data) {
 		// Delete SheepShaver globals
 		vm_mac_release(base, size);
 
@@ -2595,6 +2353,7 @@ void SheepMem::Exit(void)
 #endif
 	}
 }
+
 
 /*
  *  Display alert
@@ -2611,11 +2370,11 @@ static GCallback dl_destroyed(GtkWidget *dialog)
 void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 {
 	GtkWidget *dialog = gtk_message_dialog_new(NULL,
-											   GTK_DIALOG_MODAL,
-											   GTK_MESSAGE_WARNING,
-											   GTK_BUTTONS_NONE,
-											   GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
+	                                           GTK_DIALOG_MODAL,
+	                                           GTK_MESSAGE_WARNING,
+	                                           GTK_BUTTONS_NONE,
+	                                           GetString(title_id), NULL);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);
@@ -2624,22 +2383,21 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 }
 #endif
 
+
 /*
  *  Display error alert
  */
 
 void ErrorAlert(const char *text)
 {
-	if (gui_connection)
-	{
+	if (gui_connection) {
 		if (rpc_method_invoke(gui_connection, RPC_METHOD_ERROR_ALERT, RPC_TYPE_STRING, text, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR &&
 			rpc_method_wait_for_reply(gui_connection, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR)
 			return;
 	}
 #ifdef ENABLE_GTK
 #ifndef USE_SDL_VIDEO
-	if (x_display == NULL)
-	{
+	if (x_display == NULL) {
 		printf(GetString(STR_SHELL_ERROR_PREFIX), text);
 		return;
 	}
@@ -2651,22 +2409,21 @@ void ErrorAlert(const char *text)
 #endif
 }
 
+
 /*
  *  Display warning alert
  */
 
 void WarningAlert(const char *text)
 {
-	if (gui_connection)
-	{
+	if (gui_connection) {
 		if (rpc_method_invoke(gui_connection, RPC_METHOD_WARNING_ALERT, RPC_TYPE_STRING, text, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR &&
 			rpc_method_wait_for_reply(gui_connection, RPC_TYPE_INVALID) == RPC_ERROR_NO_ERROR)
 			return;
 	}
 #ifdef ENABLE_GTK
 #ifndef USE_SDL_VIDEO
-	if (x_display == NULL)
-	{
+	if (x_display == NULL) {
 		printf(GetString(STR_SHELL_WARNING_PREFIX), text);
 		return;
 	}
@@ -2677,6 +2434,7 @@ void WarningAlert(const char *text)
 #endif
 }
 
+
 /*
  *  Display choice alert
  */
@@ -2684,5 +2442,5 @@ void WarningAlert(const char *text)
 bool ChoiceAlert(const char *text, const char *pos, const char *neg)
 {
 	printf(GetString(STR_SHELL_WARNING_PREFIX), text);
-	return false; //!!
+	return false;	//!!
 }

--- a/SheepShaver/src/Unix/prefs_editor_gtk.cpp
+++ b/SheepShaver/src/Unix/prefs_editor_gtk.cpp
@@ -1724,7 +1724,7 @@ void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 	                                           GTK_MESSAGE_WARNING,
 	                                           GTK_BUTTONS_NONE,
 	                                           GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);

--- a/SheepShaver/src/Unix/prefs_editor_gtk.cpp
+++ b/SheepShaver/src/Unix/prefs_editor_gtk.cpp
@@ -43,12 +43,10 @@
 #define DEBUG 0
 #include "debug.h"
 
-
 // Global variables
-static GtkWidget *win;				// Preferences window
-static bool start_clicked = false;	// Return value of PrefsEditor() function
+static GtkWidget *win;					// Preferences window
+static bool start_clicked = false;		// Return value of PrefsEditor() function
 static int screen_width, screen_height; // Screen dimensions
-
 
 // Prototypes
 static void create_volumes_pane(GtkWidget *top);
@@ -58,29 +56,30 @@ static void create_serial_pane(GtkWidget *top);
 static void create_memory_pane(GtkWidget *top);
 static void create_jit_pane(GtkWidget *top);
 static void read_settings(void);
-static void add_volume_entry_with_type(const char * filename, bool cdrom);
-static void add_volume_entry_guessed(const char * filename);
-
+static void add_volume_entry_with_type(const char *filename, bool cdrom);
+static void add_volume_entry_guessed(const char *filename);
 
 /*
  *  Utility functions
  */
 
-#if ! GLIB_CHECK_VERSION(2,0,0)
-#define G_OBJECT(obj)							GTK_OBJECT(obj)
-#define g_object_get_data(obj, key)				gtk_object_get_data((obj), (key))
-#define g_object_set_data(obj, key, data)		gtk_object_set_data((obj), (key), (data))
+#if !GLIB_CHECK_VERSION(2, 0, 0)
+#define G_OBJECT(obj) GTK_OBJECT(obj)
+#define g_object_get_data(obj, key) gtk_object_get_data((obj), (key))
+#define g_object_set_data(obj, key, data) gtk_object_set_data((obj), (key), (data))
 #endif
 
-struct opt_desc {
-	opt_desc(int l, GCallback f, GtkWidget **s=NULL) : label_id(l), func(f), save_ref(s) {}
+struct opt_desc
+{
+	opt_desc(int l, GCallback f, GtkWidget **s = NULL) : label_id(l), func(f), save_ref(s) {}
 
 	int label_id;
 	GCallback func;
-	GtkWidget ** save_ref;
+	GtkWidget **save_ref;
 };
 
-struct combo_desc {
+struct combo_desc
+{
 	int label_id;
 };
 
@@ -90,22 +89,22 @@ static void cb_browse_response(GtkWidget *chooser, int response, GtkEntry *entry
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
 		gchar *filename;
-		filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (chooser));
+		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
 		gtk_entry_set_text(GTK_ENTRY(entry), filename);
-		g_free (filename);
+		g_free(filename);
 	}
-	gtk_widget_destroy (chooser);
+	gtk_widget_destroy(chooser);
 }
 
 // Open the file chooser dialog to select a file
 static void cb_browse(GtkWidget *button, GtkWidget *entry)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_BROWSE_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_OPEN,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Open", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_OPEN,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Open", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_dirname(gtk_entry_get_text(GTK_ENTRY(entry))));
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
@@ -118,11 +117,11 @@ static void cb_browse(GtkWidget *button, GtkWidget *entry)
 static void cb_browse_dir(GtkWidget *button, GtkWidget *entry)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_BROWSE_FOLDER_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Select", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Select", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), gtk_entry_get_text(GTK_ENTRY(entry)));
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_transient_for(GTK_WINDOW(chooser), GTK_WINDOW(win));
@@ -178,12 +177,14 @@ static GtkWidget *make_button_box(GtkWidget *top, int border, const opt_desc *bu
 	gtk_button_box_set_spacing(GTK_BUTTON_BOX(bb), 4);
 	gtk_box_pack_start(GTK_BOX(top), bb, FALSE, FALSE, 0);
 
-	while (buttons->label_id) {
+	while (buttons->label_id)
+	{
 		button = gtk_button_new_with_label(GetString(buttons->label_id));
 		gtk_widget_show(button);
-		g_signal_connect_object(button, "clicked", buttons->func, NULL, (GConnectFlags) 0);
+		g_signal_connect_object(button, "clicked", buttons->func, NULL, (GConnectFlags)0);
 		gtk_box_pack_start(GTK_BOX(bb), button, TRUE, TRUE, 0);
-		if (buttons->save_ref) {
+		if (buttons->save_ref)
+		{
 			*(buttons->save_ref) = button;
 		}
 		buttons++;
@@ -218,13 +219,13 @@ static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, c
 	combo = gtk_combo_box_entry_new_text();
 	gtk_widget_show(combo);
 	gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
-	while(list)
+	while (list)
 	{
-		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), ((gchar *) list->data));
+		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), ((gchar *)list->data));
 		list = list->next;
 	}
 	if (pref != NULL)
-		gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN (combo))), pref);
+		gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(combo))), pref);
 
 	gtk_table_attach(GTK_TABLE(table), combo, 1, 2, row, row + 1, (GtkAttachOptions)(GTK_FILL | GTK_EXPAND), (GtkAttachOptions)0, 4, 4);
 
@@ -234,7 +235,8 @@ static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, c
 static GtkWidget *table_make_combobox(GtkWidget *table, int row, int label_id, const char *default_value, const combo_desc *options)
 {
 	GList *glist = NULL;
-	while (options->label_id) {
+	while (options->label_id)
+	{
 		glist = g_list_append(glist, (void *)GetString(options->label_id));
 		options++;
 	}
@@ -283,7 +285,8 @@ static GtkWidget *make_option_menu(GtkWidget *top, int label_id, const combo_des
 
 	combo = gtk_combo_box_new_text();
 	gtk_widget_show(combo);
-	while (options->label_id) {
+	while (options->label_id)
+	{
 		gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(options->label_id));
 		options++;
 	}
@@ -314,7 +317,7 @@ static GtkWidget *make_file_entry(GtkWidget *top, int label_id, const char *pref
 	button = make_browse_button(entry, only_dirs);
 
 	gtk_widget_show(entry);
-#if GLIB_CHECK_VERSION(2,26,0)
+#if GLIB_CHECK_VERSION(2, 26, 0)
 	g_object_bind_property(entry, "sensitive", button, "sensitive", G_BINDING_SYNC_CREATE);
 #endif
 	gtk_box_pack_start(GTK_BOX(box), entry, TRUE, TRUE, 0);
@@ -334,7 +337,7 @@ static GtkWidget *make_checkbox(GtkWidget *top, int label_id, const char *prefs_
 	gtk_toggle_button_set_state(GTK_TOGGLE_BUTTON(button), PrefsFindBool(prefs_item));
 	g_signal_connect(button, "toggled", func, NULL);
 	if (top)
-	    gtk_box_pack_start(GTK_BOX(top), button, FALSE, FALSE, 0);
+		gtk_box_pack_start(GTK_BOX(top), button, FALSE, FALSE, 0);
 	return button;
 }
 
@@ -347,7 +350,6 @@ static GtkWidget *make_checkbox(GtkWidget *top, int label_id, bool active, GCall
 	gtk_box_pack_start(GTK_BOX(top), button, FALSE, FALSE, 0);
 	return button;
 }
-
 
 /*
  *  Show preferences editor
@@ -403,20 +405,19 @@ static void mn_about(...)
 		"Christian Bauer",
 		"Marc Hellwig",
 		"Gwenolé Beauchesne",
-		NULL
-	};
+		NULL};
 	char version[64];
 	sprintf(version, "%d.%d", VERSION_MAJOR, VERSION_MINOR);
 	gtk_show_about_dialog(GTK_WINDOW(win), "version", version,
-	                     "copyright", GetString(STR_ABOUT_COPYRIGHT),
-	                     "authors", authors,
-	                     "comments", GetString(STR_ABOUT_COMMENTS),
-	                     "website", GetString(STR_ABOUT_WEBSITE),
-	                     "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
-	                     "license", GetString(STR_ABOUT_LICENSE),
-	                     "wrap-license", true,
-	                     "logo-icon-name", "SheepShaver",
-	                     NULL);
+						  "copyright", GetString(STR_ABOUT_COPYRIGHT),
+						  "authors", authors,
+						  "comments", GetString(STR_ABOUT_COMMENTS),
+						  "website", GetString(STR_ABOUT_WEBSITE),
+						  "website-label", GetString(STR_ABOUT_WEBSITE_LABEL),
+						  "license", GetString(STR_ABOUT_LICENSE),
+						  "wrap-license", true,
+						  "logo-icon-name", "SheepShaver",
+						  NULL);
 }
 
 // "Zap NVRAM" selected
@@ -427,15 +428,14 @@ static void mn_zap_pram(...)
 
 // Menu item descriptions
 static GtkItemFactoryEntry menu_items[] = {
-	{(gchar *)GetString(STR_PREFS_MENU_FILE_GTK),		NULL,			NULL,							0, "<Branch>"},
-	{(gchar *)GetString(STR_PREFS_ITEM_START_GTK),		"<control>S",	G_CALLBACK(cb_start),		0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_SAVE_GTK),		NULL,			G_CALLBACK(cb_save),		0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_ZAP_PRAM_GTK),	NULL,			G_CALLBACK(mn_zap_pram),	0, NULL},
-	{(gchar *)GetString(STR_PREFS_ITEM_SEPL_GTK),		NULL,			NULL,							0, "<Separator>"},
-	{(gchar *)GetString(STR_PREFS_ITEM_QUIT_GTK),		"<control>Q",	G_CALLBACK(cb_quit),		0, NULL},
-	{(gchar *)GetString(STR_HELP_MENU_GTK),				NULL,			NULL,							0, "<LastBranch>"},
-	{(gchar *)GetString(STR_HELP_ITEM_ABOUT_GTK),		NULL,			G_CALLBACK(mn_about),		0, NULL}
-};
+	{(gchar *)GetString(STR_PREFS_MENU_FILE_GTK), NULL, NULL, 0, "<Branch>"},
+	{(gchar *)GetString(STR_PREFS_ITEM_START_GTK), "<control>S", G_CALLBACK(cb_start), 0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_SAVE_GTK), NULL, G_CALLBACK(cb_save), 0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_ZAP_PRAM_GTK), NULL, G_CALLBACK(mn_zap_pram), 0, NULL},
+	{(gchar *)GetString(STR_PREFS_ITEM_SEPL_GTK), NULL, NULL, 0, "<Separator>"},
+	{(gchar *)GetString(STR_PREFS_ITEM_QUIT_GTK), "<control>Q", G_CALLBACK(cb_quit), 0, NULL},
+	{(gchar *)GetString(STR_HELP_MENU_GTK), NULL, NULL, 0, "<LastBranch>"},
+	{(gchar *)GetString(STR_HELP_ITEM_ABOUT_GTK), NULL, G_CALLBACK(mn_about), 0, NULL}};
 
 bool PrefsEditor(void)
 {
@@ -480,8 +480,7 @@ bool PrefsEditor(void)
 	static const opt_desc buttons[] = {
 		{STR_START_BUTTON, G_CALLBACK(cb_start)},
 		{STR_QUIT_BUTTON, G_CALLBACK(cb_quit)},
-		{0, NULL}
-	};
+		{0, NULL}};
 	make_button_box(box, 4, buttons);
 
 	// Show window and enter main loop
@@ -489,7 +488,6 @@ bool PrefsEditor(void)
 	gtk_main();
 	return start_clicked;
 }
-
 
 /*
  *  "Volumes" pane
@@ -500,34 +498,37 @@ static GtkListStore *volume_list_model;
 static GtkWidget *volume_remove_button;
 
 // Volume list selection changed
-static void cl_selected(GtkTreeSelection * selection, gpointer user_data) {
-	if (selection) {
+static void cl_selected(GtkTreeSelection *selection, gpointer user_data)
+{
+	if (selection)
+	{
 		bool have_selection = gtk_tree_selection_get_selected(selection, NULL, NULL);
 
 		gtk_widget_set_sensitive(GTK_WIDGET(volume_remove_button), have_selection);
 	}
 }
 
-
 // Process proposed drop
-gboolean volume_list_drag_motion (GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time,
-                                            gpointer user_data)
+gboolean volume_list_drag_motion(GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y, guint time,
+								 gpointer user_data)
 {
 	GtkTreePath *path;
 	GtkTreeViewDropPosition pos;
 	// Don't allow tree-style drops onto, only list-style drops between
-	if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x,y, &path, &pos)) {
-		switch (pos) {
-			case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
-				gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_AFTER);
-				break;
-			case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
-				gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_BEFORE);
-				break;
-			case GTK_TREE_VIEW_DROP_BEFORE:
-			case GTK_TREE_VIEW_DROP_AFTER:
-				// these are ok, no change
-				break;
+	if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x, y, &path, &pos))
+	{
+		switch (pos)
+		{
+		case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
+			gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_AFTER);
+			break;
+		case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
+			gtk_tree_view_set_drag_dest_row(GTK_TREE_VIEW(volume_list), path, GTK_TREE_VIEW_DROP_BEFORE);
+			break;
+		case GTK_TREE_VIEW_DROP_BEFORE:
+		case GTK_TREE_VIEW_DROP_AFTER:
+			// these are ok, no change
+			break;
 		}
 		gdk_drag_status(drag_context, drag_context->suggested_action, time);
 		return TRUE;
@@ -535,50 +536,59 @@ gboolean volume_list_drag_motion (GtkWidget *widget, GdkDragContext *drag_contex
 	return FALSE;
 }
 
-
 // Something dropped on volume list
 static void drag_data_received(GtkWidget *list, GdkDragContext *drag_context, gint x, gint y, GtkSelectionData *data,
-	guint info, guint time, gpointer user_data)
+							   guint info, guint time, gpointer user_data)
 {
 	// reordering drags have already been handled by clist
-	if (data->type == gdk_atom_intern("gtk-clist-drag-reorder", true)) {
+	if (data->type == gdk_atom_intern("gtk-clist-drag-reorder", true))
+	{
 		return;
 	}
 
 	// get URIs from the drag selection data and add them
-	gchar ** uris = g_strsplit((gchar *)(data->data), "\r\n", -1);
-	for (gchar ** uri = uris; *uri != NULL; uri++) {
-		if (strlen(*uri) < 7) continue;
-		if (strncmp("file://", *uri, 7) != 0) continue;
+	gchar **uris = g_strsplit((gchar *)(data->data), "\r\n", -1);
+	for (gchar **uri = uris; *uri != NULL; uri++)
+	{
+		if (strlen(*uri) < 7)
+			continue;
+		if (strncmp("file://", *uri, 7) != 0)
+			continue;
 
-		gchar * filename = g_filename_from_uri(*uri, NULL, NULL);
-		if (filename) {
+		gchar *filename = g_filename_from_uri(*uri, NULL, NULL);
+		if (filename)
+		{
 			add_volume_entry_guessed(filename);
 
 			// figure out where in the list they dropped
 			GtkTreePath *path;
 			GtkTreeViewDropPosition pos;
-			if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x,y, &path, &pos)) {
+			if (gtk_tree_view_get_dest_row_at_pos(GTK_TREE_VIEW(volume_list), x, y, &path, &pos))
+			{
 				GtkTreeIter dest_iter;
-				if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &dest_iter, path)) {
+				if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &dest_iter, path))
+				{
 
 					// Find the item we just added and put it in place
 					GtkTreeIter last;
 					GtkTreeIter cur;
-					if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(volume_list_model), &cur)) {
-						do {
+					if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(volume_list_model), &cur))
+					{
+						do
+						{
 							last = cur;
 						} while (gtk_tree_model_iter_next(GTK_TREE_MODEL(volume_list_model), &cur));
 					}
-					switch (pos) {
-						case GTK_TREE_VIEW_DROP_AFTER:
-						case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
-							gtk_list_store_move_after(volume_list_model, &last, &dest_iter);
-							break;
-						case GTK_TREE_VIEW_DROP_BEFORE:
-						case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
-							gtk_list_store_move_before(volume_list_model, &last, &dest_iter);
-							break;
+					switch (pos)
+					{
+					case GTK_TREE_VIEW_DROP_AFTER:
+					case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
+						gtk_list_store_move_after(volume_list_model, &last, &dest_iter);
+						break;
+					case GTK_TREE_VIEW_DROP_BEFORE:
+					case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
+						gtk_list_store_move_before(volume_list_model, &last, &dest_iter);
+						break;
 					}
 				}
 			}
@@ -590,7 +600,7 @@ static void drag_data_received(GtkWidget *list, GdkDragContext *drag_context, gi
 }
 
 // Volume selected for addition
-static void cb_add_volume_response (GtkWidget *chooser, int response)
+static void cb_add_volume_response(GtkWidget *chooser, int response)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
@@ -601,7 +611,7 @@ static void cb_add_volume_response (GtkWidget *chooser, int response)
 }
 
 // Volume selected for creation
-static void cb_create_volume_response (GtkWidget *chooser, int response, GtkEntry *size_entry)
+static void cb_create_volume_response(GtkWidget *chooser, int response, GtkEntry *size_entry)
 {
 	if (response == GTK_RESPONSE_ACCEPT)
 	{
@@ -611,10 +621,10 @@ static void cb_create_volume_response (GtkWidget *chooser, int response, GtkEntr
 		if (disk_size < 1 || disk_size > 2000)
 		{
 			GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win),
-							(GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
-							GTK_MESSAGE_WARNING,
-							GTK_BUTTONS_CLOSE,
-							"Enter a valid size", NULL);
+													   (GtkDialogFlags)(GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT),
+													   GTK_MESSAGE_WARNING,
+													   GTK_BUTTONS_CLOSE,
+													   "Enter a valid size", NULL);
 			gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "The volume size should be between 1 and 2000.");
 			gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(chooser));
 			g_signal_connect(dialog, "response", G_CALLBACK(dl_quit), NULL);
@@ -622,26 +632,29 @@ static void cb_create_volume_response (GtkWidget *chooser, int response, GtkEntr
 			return; // Don't close the file chooser dialog
 		}
 		int fd = open(file, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
-		if (fd < 0) {
+		if (fd < 0)
+		{
 			fprintf(stderr, "Could not create %s (%s)\n", file, strerror(errno));
-		} else {
+		}
+		else
+		{
 			ftruncate(fd, disk_size * 1024 * 1024);
 			// A created empty volume is always a new disk
 			add_volume_entry_with_type(file, false);
 		}
 	}
-	gtk_widget_destroy (chooser);
+	gtk_widget_destroy(chooser);
 }
 
 // "Add Volume" button clicked
-static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_add_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_ADD_VOLUME_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_OPEN,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Add", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_OPEN,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Add", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_get_home_dir());
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
 	gtk_window_set_modal(GTK_WINDOW(chooser), true);
@@ -650,14 +663,14 @@ static void cb_add_volume (GSimpleAction *action, GVariant *parameter, gpointer 
 }
 
 // "Create Hardfile" button clicked
-static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+static void cb_create_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkWidget *chooser = gtk_file_chooser_dialog_new(GetString(STR_CREATE_VOLUME_TITLE),
-							GTK_WINDOW(win),
-							GTK_FILE_CHOOSER_ACTION_SAVE,
-							"Cancel", GTK_RESPONSE_CANCEL,
-							"Create", GTK_RESPONSE_ACCEPT,
-							NULL);
+													 GTK_WINDOW(win),
+													 GTK_FILE_CHOOSER_ACTION_SAVE,
+													 "Cancel", GTK_RESPONSE_CANCEL,
+													 "Create", GTK_RESPONSE_ACCEPT,
+													 NULL);
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), g_get_home_dir());
 	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(chooser), TRUE);
 	gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
@@ -684,9 +697,11 @@ static void cb_create_volume (GSimpleAction *action, GVariant *parameter, gpoint
 static void cb_remove_volume(GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(volume_list));
-	if (sel) {
+	if (sel)
+	{
 		GtkTreeIter row;
-		if (gtk_tree_selection_get_selected(sel, NULL, &row)) {
+		if (gtk_tree_selection_get_selected(sel, NULL, &row))
+		{
 			gtk_list_store_remove(volume_list_model, &row);
 		}
 	}
@@ -708,32 +723,35 @@ static void tb_nocdrom(GtkWidget *widget)
 }
 
 // Data source for the volumes list
-enum {
+enum
+{
 	VOLUME_LIST_FILENAME = 0,
 	VOLUME_LIST_CDROM,
 	VOLUME_LIST_SIZE_DESC,
 	NUM_VOLUME_LIST_FIELDS
 };
 
-static void init_volume_model() {
+static void init_volume_model()
+{
 	volume_list_model = gtk_list_store_new(NUM_VOLUME_LIST_FIELDS,
-		G_TYPE_STRING,	// filename
-		G_TYPE_BOOLEAN,	// is CD-ROM
-		G_TYPE_STRING	// size desc
-		);
+										   G_TYPE_STRING,  // filename
+										   G_TYPE_BOOLEAN, // is CD-ROM
+										   G_TYPE_STRING   // size desc
+	);
 }
 
-static void toggle_cdrom_val(GtkTreeIter *row) {
+static void toggle_cdrom_val(GtkTreeIter *row)
+{
 	gboolean cdrom;
 	gtk_tree_model_get(GTK_TREE_MODEL(volume_list_model), row,
-		VOLUME_LIST_CDROM, &cdrom,
-		-1);
+					   VOLUME_LIST_CDROM, &cdrom,
+					   -1);
 
 	cdrom = !cdrom;
 
 	gtk_list_store_set(volume_list_model, row,
-		VOLUME_LIST_CDROM, cdrom,
-		-1);
+					   VOLUME_LIST_CDROM, cdrom,
+					   -1);
 }
 
 // Read settings from widgets and set preferences
@@ -744,11 +762,13 @@ static void read_volumes_settings(void)
 	while (PrefsFindString("cdrom"))
 		PrefsRemoveItem("cdrom");
 
-	GtkTreeModel * m = GTK_TREE_MODEL(volume_list_model);
+	GtkTreeModel *m = GTK_TREE_MODEL(volume_list_model);
 
 	GtkTreeIter row;
-	if (gtk_tree_model_get_iter_first(m, &row)) {
-		do {
+	if (gtk_tree_model_get_iter_first(m, &row))
+	{
+		do
+		{
 			GValue filename = G_VALUE_INIT, is_cdrom = G_VALUE_INIT;
 
 			gtk_tree_model_get_value(m, &row, VOLUME_LIST_FILENAME, &filename);
@@ -756,7 +776,7 @@ static void read_volumes_settings(void)
 
 			D(bug("handling %d: %s\n", g_value_get_boolean(&is_cdrom), g_value_get_string(&filename)));
 
-			const char * pref_name = g_value_get_boolean(&is_cdrom) ? "cdrom": "disk";
+			const char *pref_name = g_value_get_boolean(&is_cdrom) ? "cdrom" : "disk";
 			PrefsAddString(pref_name, g_value_get_string(&filename));
 
 			g_value_unset(&filename);
@@ -769,10 +789,11 @@ static void read_volumes_settings(void)
 }
 
 // Gets the size of the volume as a pretty string
-static const char* get_file_size (const char * filename)
+static const char *get_file_size(const char *filename)
 {
 	std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
-	if (in.is_open()) {
+	if (in.is_open())
+	{
 		uint64_t size = in.tellg();
 		in.close();
 		char *sizestr = g_format_size_full(size, G_FORMAT_SIZE_IEC_UNITS);
@@ -784,48 +805,53 @@ static const char* get_file_size (const char * filename)
 	}
 }
 
-
-static bool volume_in_list(const char * filename) {
+static bool volume_in_list(const char *filename)
+{
 	bool found = false;
 
-	GtkTreeModel * m = GTK_TREE_MODEL(volume_list_model);
+	GtkTreeModel *m = GTK_TREE_MODEL(volume_list_model);
 
 	GtkTreeIter row;
-	if (gtk_tree_model_get_iter_first(m, &row)) {
-		do {
+	if (gtk_tree_model_get_iter_first(m, &row))
+	{
+		do
+		{
 			GValue cur_filename = G_VALUE_INIT;
 
 			gtk_tree_model_get_value(m, &row, VOLUME_LIST_FILENAME, &cur_filename);
 
-			if (strcmp(g_value_get_string(&cur_filename), filename) == 0) {
+			if (strcmp(g_value_get_string(&cur_filename), filename) == 0)
+			{
 				found = true;
 			}
 
 			g_value_unset(&cur_filename);
 
-			if (found) break;
+			if (found)
+				break;
 		} while (gtk_tree_model_iter_next(GTK_TREE_MODEL(volume_list_model), &row));
 	}
 
 	return found;
 }
 
-
 // Add a volume file as the given type
-static void add_volume_entry_with_type(const char * filename, bool cdrom) {
-	if (volume_in_list(filename)) return;
+static void add_volume_entry_with_type(const char *filename, bool cdrom)
+{
+	if (volume_in_list(filename))
+		return;
 
 	GtkTreeIter row;
 	gtk_list_store_append(GTK_LIST_STORE(volume_list_model), &row);
 	// set the values for the new row
 	gtk_list_store_set(GTK_LIST_STORE(volume_list_model), &row,
-		VOLUME_LIST_FILENAME, filename,
-		VOLUME_LIST_CDROM, cdrom,
-		VOLUME_LIST_SIZE_DESC, get_file_size(filename),
-		-1);
+					   VOLUME_LIST_FILENAME, filename,
+					   VOLUME_LIST_CDROM, cdrom,
+					   VOLUME_LIST_SIZE_DESC, get_file_size(filename),
+					   -1);
 }
 
-static bool has_file_ext (const char * str, const char *ext)
+static bool has_file_ext(const char *str, const char *ext)
 {
 	char *file_ext = g_utf8_strrchr(str, 255, '.');
 	if (!file_ext)
@@ -833,28 +859,31 @@ static bool has_file_ext (const char * str, const char *ext)
 	return (g_strcmp0(file_ext, ext) == 0);
 }
 
-static bool guess_if_file_is_cdrom(const char * volume) {
+static bool guess_if_file_is_cdrom(const char *volume)
+{
 	return has_file_ext(volume, ".iso") ||
 #ifdef BINCUE
-		has_file_ext(volume, ".cue") ||
+		   has_file_ext(volume, ".cue") ||
 #endif
-		has_file_ext(volume, ".toast");
+		   has_file_ext(volume, ".toast");
 }
 
 // Add a volume file and guess the type
-static void add_volume_entry_guessed(const char * filename) {
+static void add_volume_entry_guessed(const char *filename)
+{
 	add_volume_entry_with_type(filename, guess_if_file_is_cdrom(filename));
 }
 
 // CD-ROM checkbox changed
-static void cb_cdrom (GtkCellRendererToggle *cell, char *path_str, gpointer data)
+static void cb_cdrom(GtkCellRendererToggle *cell, char *path_str, gpointer data)
 {
 	GtkTreeIter iter;
-	GtkTreePath *path = gtk_tree_path_new_from_string (path_str);
-	if (gtk_tree_model_get_iter (GTK_TREE_MODEL(volume_list_model), &iter, path)) {
+	GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+	if (gtk_tree_model_get_iter(GTK_TREE_MODEL(volume_list_model), &iter, path))
+	{
 		toggle_cdrom_val(&iter);
 	}
-	gtk_tree_path_free (path);
+	gtk_tree_path_free(path);
 }
 
 // Create "Volumes" pane
@@ -891,8 +920,8 @@ static void create_volumes_pane(GtkWidget *top)
 	gtk_tree_view_column_set_title(column, GetString(STR_VOL_HEADING_CDROM));
 	gtk_tree_view_append_column(GTK_TREE_VIEW(volume_list), column);
 	renderer = gtk_cell_renderer_toggle_new();
-	g_signal_connect (renderer, "toggled",
-	                  G_CALLBACK (cb_cdrom), NULL);
+	g_signal_connect(renderer, "toggled",
+					 G_CALLBACK(cb_cdrom), NULL);
 	gtk_tree_view_column_set_alignment(column, 0.5);
 
 	gtk_tree_view_column_pack_start(column, renderer, TRUE);
@@ -920,10 +949,12 @@ static void create_volumes_pane(GtkWidget *top)
 
 	char *str;
 	int32 index;
-	const char * types[] = {"disk", "cdrom", NULL};
-	for (const char ** type = types; *type != NULL; type++) {
+	const char *types[] = {"disk", "cdrom", NULL};
+	for (const char **type = types; *type != NULL; type++)
+	{
 		index = 0;
-		while ((str = const_cast<char *>(PrefsFindString(*type, index))) != NULL) {
+		while ((str = const_cast<char *>(PrefsFindString(*type, index))) != NULL)
+		{
 			bool is_cdrom = strcmp(*type, "cdrom") == 0;
 			add_volume_entry_with_type(str, is_cdrom);
 			index++;
@@ -947,18 +978,21 @@ static void create_volumes_pane(GtkWidget *top)
 	static const combo_desc options[] = {
 		STR_BOOT_ANY_LAB,
 		STR_BOOT_CDROM_LAB,
-		0
-	};
+		0};
 	int bootdriver = PrefsFindInt32("bootdriver"), active = 0;
-	switch (bootdriver) {
-		case 0: active = 0; break;
-		case CDROMRefNum: active = 1; break;
+	switch (bootdriver)
+	{
+	case 0:
+		active = 0;
+		break;
+	case CDROMRefNum:
+		active = 1;
+		break;
 	}
 	menu = make_option_menu(box, STR_BOOTDRIVER_CTRL, options, G_CALLBACK(mn_bootdriver), active);
 
 	make_checkbox(box, STR_NOCDROM_CTRL, "nocdrom", G_CALLBACK(tb_nocdrom));
 }
-
 
 /*
  *  "JIT Compiler" pane
@@ -972,7 +1006,8 @@ static bool is_jit_capable(void)
 #elif defined __APPLE__ && defined __MACH__
 	// XXX run-time detect so that we can use a PPC GUI prefs editor
 	static char cpu[10];
-	if (cpu[0] == 0) {
+	if (cpu[0] == 0)
+	{
 		FILE *fp = popen("uname -p", "r");
 		if (fp == NULL)
 			return false;
@@ -1018,7 +1053,8 @@ static void create_jit_pane(GtkWidget *top)
 
 	box = make_pane(top, STR_JIT_PANE_TITLE);
 
-	if (is_jit_capable()) {
+	if (is_jit_capable())
+	{
 		make_checkbox(box, STR_JIT_CTRL, "jit", G_CALLBACK(tb_jit));
 		set_jit_sensitive();
 	}
@@ -1026,13 +1062,13 @@ static void create_jit_pane(GtkWidget *top)
 	make_checkbox(box, STR_JIT_68K_CTRL, "jit68k", G_CALLBACK(tb_jit_68k));
 }
 
-
 /*
  *  "Graphics/Sound" pane
  */
 
 // Display types
-enum {
+enum
+{
 	DISPLAY_WINDOW,
 	DISPLAY_SCREEN
 };
@@ -1060,14 +1096,26 @@ static void mn_display(GtkWidget *widget)
 static void mn_frameskip(GtkWidget *widget)
 {
 	int frameskip = 1;
-	switch(gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
+	switch (gtk_combo_box_get_active(GTK_COMBO_BOX(widget)))
 	{
-		case 0: frameskip = 12; break;
-		case 1: frameskip = 8; break;
-		case 2: frameskip = 6; break;
-		case 3: frameskip = 4; break;
-		case 4: frameskip = 2; break;
-		case 5: frameskip = 1; break;
+	case 0:
+		frameskip = 12;
+		break;
+	case 1:
+		frameskip = 8;
+		break;
+	case 2:
+		frameskip = 6;
+		break;
+	case 3:
+		frameskip = 4;
+		break;
+	case 4:
+		frameskip = 2;
+		break;
+	case 5:
+		frameskip = 1;
+		break;
 	}
 	PrefsReplaceInt32("frameskip", frameskip);
 }
@@ -1096,13 +1144,13 @@ static void tb_nosound(GtkWidget *widget)
 // "Nearest" button toggled
 static void tb_scale_nearest(GtkWidget *widget)
 {
-    PrefsReplaceBool("scale_nearest", GTK_TOGGLE_BUTTON(widget)->active);
+	PrefsReplaceBool("scale_nearest", GTK_TOGGLE_BUTTON(widget)->active);
 }
 
 // "Integer Scaling" button toggled
 static void tb_scale_integer(GtkWidget *widget)
 {
-    PrefsReplaceBool("scale_integer", GTK_TOGGLE_BUTTON(widget)->active);
+	PrefsReplaceBool("scale_integer", GTK_TOGGLE_BUTTON(widget)->active);
 }
 
 // Read and convert graphics preferences
@@ -1113,48 +1161,57 @@ static void parse_graphics_prefs(void)
 	dis_height = 480;
 
 	const char *str = PrefsFindString("screen");
-	if (str) {
+	if (str)
+	{
 		if (sscanf(str, "win/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_WINDOW;
 		else if (sscanf(str, "dga/%d/%d", &dis_width, &dis_height) == 2)
 			display_type = DISPLAY_SCREEN;
 #ifdef ENABLE_FBDEV_DGA
-		else if (sscanf(str, "fbdev/%d/%d", &dis_width, &dis_height) == 2) {
+		else if (sscanf(str, "fbdev/%d/%d", &dis_width, &dis_height) == 2)
+		{
 			is_fbdev_dga_mode = true;
 			display_type = DISPLAY_SCREEN;
 		}
 #endif
 	}
-	else {
+	else
+	{
 		uint32 window_modes = PrefsFindInt32("windowmodes");
 		uint32 screen_modes = PrefsFindInt32("screenmodes");
-		if (screen_modes) {
+		if (screen_modes)
+		{
 			display_type = DISPLAY_SCREEN;
-			static const struct {
+			static const struct
+			{
 				int id;
 				int width;
 				int height;
-			}
-			modes[] = {
-				{  1,	 640,	 480 },
-				{  2,	 800,	 600 },
-				{  4,	1024,	 768 },
-				{ 64,	1152,	 768 },
-				{  8,	1152,	 900 },
-				{ 16,	1280,	1024 },
-				{ 32,	1600,	1200 },
-				{ 0, }
-			};
-			for (int i = 0; modes[i].id != 0; i++) {
-				if (screen_modes & modes[i].id) {
-					if (modes[i].width <= screen_width && modes[i].height <= screen_height) {
+			} modes[] = {
+				{1, 640, 480},
+				{2, 800, 600},
+				{4, 1024, 768},
+				{64, 1152, 768},
+				{8, 1152, 900},
+				{16, 1280, 1024},
+				{32, 1600, 1200},
+				{
+					0,
+				}};
+			for (int i = 0; modes[i].id != 0; i++)
+			{
+				if (screen_modes & modes[i].id)
+				{
+					if (modes[i].width <= screen_width && modes[i].height <= screen_height)
+					{
 						dis_width = modes[i].width;
 						dis_height = modes[i].height;
 					}
 				}
 			}
 		}
-		else if (window_modes) {
+		else if (window_modes)
+		{
 			display_type = DISPLAY_WINDOW;
 			if (window_modes & 1)
 				dis_width = 640, dis_height = 480;
@@ -1181,19 +1238,21 @@ static void read_graphics_settings(void)
 
 	char pref[256];
 	bool use_screen_mode = true;
-	switch (display_type) {
-		case DISPLAY_WINDOW:
-			sprintf(pref, "win/%d/%d", dis_width, dis_height);
-			break;
-		case DISPLAY_SCREEN:
-			sprintf(pref, "dga/%d/%d", dis_width, dis_height);
-			break;
-		default:
-			use_screen_mode = false;
-			PrefsRemoveItem("screen");
-			return;
+	switch (display_type)
+	{
+	case DISPLAY_WINDOW:
+		sprintf(pref, "win/%d/%d", dis_width, dis_height);
+		break;
+	case DISPLAY_SCREEN:
+		sprintf(pref, "dga/%d/%d", dis_width, dis_height);
+		break;
+	default:
+		use_screen_mode = false;
+		PrefsRemoveItem("screen");
+		return;
 	}
-	if (use_screen_mode) {
+	if (use_screen_mode)
+	{
 		PrefsReplaceString("screen", pref);
 		// Old prefs are now migrated
 		PrefsRemoveItem("windowmodes");
@@ -1226,13 +1285,14 @@ static void create_graphics_pane(GtkWidget *top)
 	gtk_widget_show(combo);
 	gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(STR_WINDOW_CTRL));
 	gtk_combo_box_append_text(GTK_COMBO_BOX(combo), GetString(STR_FULLSCREEN_CTRL));
-	switch (display_type) {
-		case DISPLAY_WINDOW:
-			gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
-			break;
-		case DISPLAY_SCREEN:
-			gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 1);
-			break;
+	switch (display_type)
+	{
+	case DISPLAY_WINDOW:
+		gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
+		break;
+	case DISPLAY_SCREEN:
+		gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 1);
+		break;
 	}
 	g_signal_connect(combo, "changed", G_CALLBACK(mn_display), NULL);
 	gtk_table_attach(GTK_TABLE(table), combo, 1, 2, 0, 1, (GtkAttachOptions)GTK_FILL, (GtkAttachOptions)0, 4, 4);
@@ -1251,14 +1311,29 @@ static void create_graphics_pane(GtkWidget *top)
 	gtk_combo_box_append_text(GTK_COMBO_BOX(w_frameskip), GetString(STR_REF_60HZ_LAB));
 	int frameskip = PrefsFindInt32("frameskip");
 	int item = -1;
-	switch (frameskip) {
-		case 12: item = 0; break;
-		case 8: item = 1; break;
-		case 6: item = 2; break;
-		case 4: item = 3; break;
-		case 2: item = 4; break;
-		case 1: item = 5; break;
-		case 0: item = 5; break;
+	switch (frameskip)
+	{
+	case 12:
+		item = 0;
+		break;
+	case 8:
+		item = 1;
+		break;
+	case 6:
+		item = 2;
+		break;
+	case 4:
+		item = 3;
+		break;
+	case 2:
+		item = 4;
+		break;
+	case 1:
+		item = 5;
+		break;
+	case 0:
+		item = 5;
+		break;
 	}
 	if (item >= 0)
 		gtk_combo_box_set_active(GTK_COMBO_BOX(w_frameskip), item);
@@ -1310,7 +1385,7 @@ static void create_graphics_pane(GtkWidget *top)
 
 	// SDL scaling settings section
 	label = gtk_label_new(GetString(STR_SDL_SCALING));
-	markup = g_markup_printf_escaped ("<b>%s</b>", GetString(STR_SDL_SCALING));
+	markup = g_markup_printf_escaped("<b>%s</b>", GetString(STR_SDL_SCALING));
 	gtk_label_set_markup(GTK_LABEL(label), markup);
 	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
 	gtk_widget_show(label);
@@ -1337,7 +1412,6 @@ static void create_graphics_pane(GtkWidget *top)
 
 	set_graphics_sensitive();
 }
-
 
 /*
  *  "Input" pane
@@ -1417,12 +1491,16 @@ static void create_input_pane(GtkWidget *top)
 	static const combo_desc options[] = {
 		STR_MOUSEWHEELMODE_PAGE_LAB,
 		STR_MOUSEWHEELMODE_CURSOR_LAB,
-		0
-	};
+		0};
 	int wheelmode = PrefsFindInt32("mousewheelmode"), active = 0;
-	switch (wheelmode) {
-		case 0: active = 0; break;
-		case 1: active = 1; break;
+	switch (wheelmode)
+	{
+	case 0:
+		active = 0;
+		break;
+	case 1:
+		active = 1;
+		break;
 	}
 	menu = make_option_menu(box, STR_MOUSEWHEELMODE_CTRL, options, G_CALLBACK(mn_wheelmode), active);
 
@@ -1441,7 +1519,6 @@ static void create_input_pane(GtkWidget *top)
 
 	set_input_sensitive();
 }
-
 
 /*
  *  "Serial/Network" pane
@@ -1479,19 +1556,26 @@ static GList *add_serial_names(void)
 
 	// Search /dev for ttyS* and lp*
 	DIR *d = opendir("/dev");
-	if (d) {
+	if (d)
+	{
 		struct dirent *de;
-		while ((de = readdir(d)) != NULL) {
+		while ((de = readdir(d)) != NULL)
+		{
 #if defined(__linux__)
-			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0) {
+			if (strncmp(de->d_name, "ttyS", 4) == 0 || strncmp(de->d_name, "lp", 2) == 0)
+			{
 #elif defined(__FreeBSD__)
-			if (strncmp(de->d_name, "cuaa", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
+			if (strncmp(de->d_name, "cuaa", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
+			{
 #elif defined(__NetBSD__)
-			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0) {
+			if (strncmp(de->d_name, "tty0", 4) == 0 || strncmp(de->d_name, "lpt", 3) == 0)
+			{
 #elif defined(sgi)
-			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0) {
+			if (strncmp(de->d_name, "ttyf", 4) == 0 || strncmp(de->d_name, "plp", 3) == 0)
+			{
 #else
-			if (false) {
+			if (false)
+			{
 #endif
 				char *str = new char[64];
 				sprintf(str, "/dev/%s", de->d_name);
@@ -1514,21 +1598,27 @@ static GList *add_ether_names(void)
 
 	// Get list of all Ethernet interfaces
 	int s = socket(PF_INET, SOCK_DGRAM, 0);
-	if (s >= 0) {
+	if (s >= 0)
+	{
 		char inbuf[8192];
 		struct ifconf ifc;
 		ifc.ifc_len = sizeof(inbuf);
 		ifc.ifc_buf = inbuf;
-		if (ioctl(s, SIOCGIFCONF, &ifc) == 0) {
+		if (ioctl(s, SIOCGIFCONF, &ifc) == 0)
+		{
 			struct ifreq req, *ifr = ifc.ifc_req;
-			for (int i=0; i<ifc.ifc_len; i+=sizeof(ifreq), ifr++) {
+			for (int i = 0; i < ifc.ifc_len; i += sizeof(ifreq), ifr++)
+			{
 				req = *ifr;
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(sgi)
-				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER+1)) {
+				if (ioctl(s, SIOCGIFADDR, &req) == 0 && (req.ifr_addr.sa_family == ARPHRD_ETHER || req.ifr_addr.sa_family == ARPHRD_ETHER + 1))
+				{
 #elif defined(__linux__)
-				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
+				if (ioctl(s, SIOCGIFHWADDR, &req) == 0 && req.ifr_hwaddr.sa_family == ARPHRD_ETHER)
+				{
 #else
-				if (false) {
+				if (false)
+				{
 #endif
 					char *str = new char[64];
 					strncpy(str, ifr->ifr_name, 63);
@@ -1571,9 +1661,9 @@ static void create_serial_pane(GtkWidget *top)
 	gtk_widget_show(w_serialb);
 	while (glist)
 	{
-	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_seriala), (gchar *)glist->data);
-	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_serialb), (gchar *)glist->data);
-	    glist = glist->next;
+		gtk_combo_box_append_text(GTK_COMBO_BOX(w_seriala), (gchar *)glist->data);
+		gtk_combo_box_append_text(GTK_COMBO_BOX(w_serialb), (gchar *)glist->data);
+		glist = glist->next;
 	}
 
 	const char *str = PrefsFindString("seriala");
@@ -1597,8 +1687,8 @@ static void create_serial_pane(GtkWidget *top)
 	gtk_widget_show(w_ether);
 	while (glist)
 	{
-	    gtk_combo_box_append_text(GTK_COMBO_BOX(w_ether), (gchar *)glist->data);
-	    glist = glist->next;
+		gtk_combo_box_append_text(GTK_COMBO_BOX(w_ether), (gchar *)glist->data);
+		glist = glist->next;
 	}
 	str = PrefsFindString("ether");
 	if (str == NULL)
@@ -1606,7 +1696,6 @@ static void create_serial_pane(GtkWidget *top)
 	gtk_entry_set_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(w_ether))), str);
 	gtk_table_attach(GTK_TABLE(table), w_ether, 1, 2, 2, 3, (GtkAttachOptions)(GTK_FILL | GTK_EXPAND), (GtkAttachOptions)0, 4, 4);
 }
-
 
 /*
  *  "Memory/Misc" pane
@@ -1656,8 +1745,7 @@ static void create_memory_pane(GtkWidget *top)
 		STR_RAMSIZE_256MB_LAB,
 		STR_RAMSIZE_512MB_LAB,
 		STR_RAMSIZE_1024MB_LAB,
-		0
-	};
+		0};
 	char default_ramsize[16];
 	sprintf(default_ramsize, "%d", PrefsFindInt32("ramsize") >> 20);
 	w_ramsize = table_make_combobox(table, 0, STR_RAMSIZE_CTRL, default_ramsize, options);
@@ -1667,7 +1755,6 @@ static void create_memory_pane(GtkWidget *top)
 	make_checkbox(box, STR_IGNORESEGV_CTRL, "ignoresegv", G_CALLBACK(tb_ignoresegv));
 	make_checkbox(box, STR_IDLEWAIT_CTRL, "idlewait", G_CALLBACK(tb_idlewait));
 }
-
 
 /*
  *  Read settings from widgets and set preferences
@@ -1683,7 +1770,6 @@ static void read_settings(void)
 	read_jit_settings();
 }
 
-
 #ifdef STANDALONE_GUI
 #include <errno.h>
 #include <sys/wait.h>
@@ -1694,17 +1780,16 @@ static void read_settings(void)
  */
 
 uint8 XPRAM[XPRAM_SIZE];
-void MountVolume(void *fh) { }
-void FileDiskLayout(loff_t size, uint8 *data, loff_t &start_byte, loff_t &real_size) { }
+void MountVolume(void *fh) {}
+void FileDiskLayout(loff_t size, uint8 *data, loff_t &start_byte, loff_t &real_size) {}
 
 #if defined __APPLE__ && defined __MACH__
-void DarwinSysInit(void) { }
-void DarwinSysExit(void) { }
-void DarwinAddFloppyPrefs(void) { }
-void DarwinAddSerialPrefs(void) { }
-bool DarwinCDReadTOC(char *, uint8 *) { }
+void DarwinSysInit(void) {}
+void DarwinSysExit(void) {}
+void DarwinAddFloppyPrefs(void) {}
+void DarwinAddSerialPrefs(void) {}
+bool DarwinCDReadTOC(char *, uint8 *) {}
 #endif
-
 
 /*
  *  Display alert
@@ -1720,18 +1805,17 @@ static GCallback dl_destroyed(GtkWidget *dialog)
 void display_alert(int title_id, int prefix_id, int button_id, const char *text)
 {
 	GtkWidget *dialog = gtk_message_dialog_new(NULL,
-	                                           GTK_DIALOG_MODAL,
-	                                           GTK_MESSAGE_WARNING,
-	                                           GTK_BUTTONS_NONE,
-	                                           GetString(title_id), NULL);
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
+											   GTK_DIALOG_MODAL,
+											   GTK_MESSAGE_WARNING,
+											   GTK_BUTTONS_NONE,
+											   GetString(title_id), NULL);
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", text);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GetString(button_id), GTK_RESPONSE_CLOSE);
 	g_signal_connect(dialog, "response", G_CALLBACK(dl_destroyed), NULL);
 	gtk_widget_show(dialog);
 
 	gtk_main();
 }
-
 
 /*
  *  Display error alert
@@ -1742,7 +1826,6 @@ void ErrorAlert(const char *text)
 	display_alert(STR_ERROR_ALERT_TITLE, STR_GUI_ERROR_PREFIX, STR_QUIT_BUTTON, text);
 }
 
-
 /*
  *  Display warning alert
  */
@@ -1751,7 +1834,6 @@ void WarningAlert(const char *text)
 {
 	display_alert(STR_WARNING_ALERT_TITLE, STR_GUI_WARNING_PREFIX, STR_OK_BUTTON, text);
 }
-
 
 /*
  *  RPC handlers
@@ -1795,7 +1877,6 @@ static int handle_Exit(rpc_connection_t *connection)
 	return RPC_ERROR_NO_ERROR;
 }
 
-
 /*
  *  SIGCHLD handler
  */
@@ -1816,22 +1897,23 @@ static void sigchld_handler(int sig, siginfo_t *sip, void *)
 	if (WIFEXITED(status))
 		status = WEXITSTATUS(status);
 	if (status & 0x80)
-		status |= -1 ^0xff;
+		status |= -1 ^ 0xff;
 
-	if (status < 0) {	// negative -> execlp/-errno
+	if (status < 0)
+	{ // negative -> execlp/-errno
 		char str[256];
 		sprintf(str, GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(-status));
 		ErrorAlert(str);
 		status = 1;
 	}
 
-	if (status != 0) {
+	if (status != 0)
+	{
 		if (g_gui_connection)
 			rpc_exit(g_gui_connection);
 		exit(status);
 	}
 }
-
 
 /*
  *  Start standalone GUI
@@ -1853,7 +1935,8 @@ int main(int argc, char *argv[])
 	PrefsExit();
 
 	// Transfer control to the executable
-	if (start) {
+	if (start)
+	{
 		char gui_connection_path[64];
 		sprintf(gui_connection_path, "/org/SheepShaver/GUI/%d", getpid());
 
@@ -1862,7 +1945,8 @@ int main(int argc, char *argv[])
 		sigemptyset(&sigchld_sa.sa_mask);
 		sigchld_sa.sa_sigaction = sigchld_handler;
 		sigchld_sa.sa_flags = SA_NOCLDSTOP | SA_SIGINFO;
-		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0) {
+		if (sigaction(SIGCHLD, &sigchld_sa, &old_sigchld_sa) < 0)
+		{
 			char str[256];
 			sprintf(str, GetString(STR_SIG_INSTALL_ERR), SIGCHLD, strerror(errno));
 			ErrorAlert(str);
@@ -1872,22 +1956,27 @@ int main(int argc, char *argv[])
 		// Search and run the SheepShaver executable
 		char *p;
 		strcpy(g_app_path, argv[0]);
-		if ((p = strstr(g_app_path, "SheepShaverGUI.app/Contents/MacOS")) != NULL) {
-		    strcpy(p, "SheepShaver.app/Contents/MacOS/SheepShaver");
-			if (access(g_app_path, X_OK) < 0) {
+		if ((p = strstr(g_app_path, "SheepShaverGUI.app/Contents/MacOS")) != NULL)
+		{
+			strcpy(p, "SheepShaver.app/Contents/MacOS/SheepShaver");
+			if (access(g_app_path, X_OK) < 0)
+			{
 				char str[256];
 				sprintf(str, GetString(STR_NO_B2_EXE_FOUND), g_app_path, strerror(errno));
 				WarningAlert(str);
 				strcpy(g_app_path, "/Applications/SheepShaver.app/Contents/MacOS/SheepShaver");
 			}
-		} else {
+		}
+		else
+		{
 			p = strrchr(g_app_path, '/');
 			p = p ? p + 1 : g_app_path;
 			strcpy(p, "SheepShaver");
 		}
 
 		int pid = fork();
-		if (pid == 0) {
+		if (pid == 0)
+		{
 			D(bug("Trying to execute %s\n", g_app_path));
 			execlp(g_app_path, g_app_path, "--gui-connection", gui_connection_path, (char *)NULL);
 #ifdef _POSIX_PRIORITY_SCHEDULING
@@ -1898,31 +1987,35 @@ int main(int argc, char *argv[])
 		}
 
 		// Establish a connection to Basilisk II
-		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL) {
+		if ((g_gui_connection = rpc_init_server(gui_connection_path)) == NULL)
+		{
 			printf("ERROR: failed to initialize GUI-side RPC server connection\n");
 			return 1;
 		}
 		static const rpc_method_descriptor_t vtable[] = {
-			{ RPC_METHOD_ERROR_ALERT,			handle_ErrorAlert },
-			{ RPC_METHOD_WARNING_ALERT,			handle_WarningAlert },
-			{ RPC_METHOD_EXIT,					handle_Exit }
-		};
-		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0) {
+			{RPC_METHOD_ERROR_ALERT, handle_ErrorAlert},
+			{RPC_METHOD_WARNING_ALERT, handle_WarningAlert},
+			{RPC_METHOD_EXIT, handle_Exit}};
+		if (rpc_method_add_callbacks(g_gui_connection, vtable, sizeof(vtable) / sizeof(vtable[0])) < 0)
+		{
 			printf("ERROR: failed to setup GUI method callbacks\n");
 			return 1;
 		}
 		int socket;
-		if ((socket = rpc_listen_socket(g_gui_connection)) < 0) {
+		if ((socket = rpc_listen_socket(g_gui_connection)) < 0)
+		{
 			printf("ERROR: failed to initialize RPC server thread\n");
 			return 1;
 		}
 
 		g_gui_loop = g_main_new(TRUE);
-		while (g_main_is_running(g_gui_loop)) {
+		while (g_main_is_running(g_gui_loop))
+		{
 
 			// Process a few events pending
 			const int N_EVENTS_DISPATCH = 10;
-			for (int i = 0; i < N_EVENTS_DISPATCH; i++) {
+			for (int i = 0; i < N_EVENTS_DISPATCH; i++)
+			{
 				if (!g_main_iteration(FALSE))
 					break;
 			}


### PR DESCRIPTION
Getting the following error when compiling:

```
main_unix.cpp: In function 'void display_alert(int, int, int, const char*)':
main_unix.cpp:1684:49: error: format not a string literal and no format arguments []
 1684 |         gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), text);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixed with the attached patch.
