### PR TITLE
SheepShaver Windows: fix command-line args processing

### DIFF
--- a/SheepShaver/src/Windows/main_windows.cpp
+++ b/SheepShaver/src/Windows/main_windows.cpp
@@ -184,6 +184,8 @@ int main(int argc, char **argv)
 	printf(" %s\n", GetString(STR_ABOUT_TEXT2));
 
 	// Parse command line arguments
+
+	// Check for options we want to process before PrefsInit
 	for (int i=1; i<argc; i++) {
 		if (strcmp(argv[i], "--help") == 0) {
 			usage(argv[0]);
@@ -194,14 +196,32 @@ int main(int argc, char **argv)
 				UserPrefsPath = to_tstring(argv[i]);
 				argv[i] = NULL;
 			}
-		} else if (argv[i][0] == '-') {
-			fprintf(stderr, "Unrecognized option '%s'\n", argv[i]);
-			usage(argv[0]);
+		}
+	}
+
+	// Remove processed arguments
+	for (int i=1; i<argc; i++) {
+		int k;
+		for (k=i; k<argc; k++)
+			if (argv[k] != NULL)
+				break;
+		if (k > i) {
+			k -= i;
+			for (int j=i+k; j<argc; j++)
+				argv[j-k] = argv[j];
+			argc -= k;
 		}
 	}
 
 	// Read preferences
 	PrefsInit(NULL, argc, argv);
+
+	for (int i=1; i<argc; i++) {
+		if (argv[i][0] == '-') {
+			fprintf(stderr, "Unrecognized option '%s'\n", argv[i]);
+			usage(argv[0]);
+		}
+	}
 
 	// #chenchijung 2024/2/21: move vm_init(), memory allocation for Mac RAM and Mac ROM here to avoid "cannot map RAM: no Error" bug.
 	//   caused by MSI afterburner (RIVA Tuner statistic tuner Server?). It is a workaround since I don't know why. But it works in my test env.


### PR DESCRIPTION
In the current SheepShaver for Windows, the command-line options for prefs don't work; the `Usage` output shows the command line options but if you try to use any of them it says `Unrecognized option`.

The problem is with the reordering in `main_windows.cpp` in 33c3419b08db536efa756a2362951bc19e1e137f : the `Unrecognized option` branch of the `if` is supposed to be last so it only sees otherwise unhandled options, but you've put it above the call to `PrefsInit` which actually handles the prefs-related options.

I've rearranged this to avoid the problem. I also added removal of the already-handled options from `argc`/`argv` before the call to `PrefsInit` for consistency with the B2 version.