### PR TITLE
Unix/configure: use POSIX-compatible function definition syntax

### DIFF
--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -1606,7 +1606,7 @@ if [[ "x$EMULATED_PPC" = "xyes" ]]; then
           DYNGEN_CC=$CXX
         elif command -v g++ >/dev/null; then
           vers=`g++ -dumpversion`
-          function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+          version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
           if [[ $(version $vers) -ge $(version "2.7.0") ]] && [[ $(version $vers) -lt $(version "4.0.0") ]]; then
             DYNGEN_CC="$gxx"
           fi


### PR DESCRIPTION
`function` is a `ksh` extension not specified by POSIX, and might not be implemented by all POSIX-compatible `/bin/sh` implementations. `dash` in particular does not, and fails to run the configure script because of that.