### PR TITLE
Fix ROM deallocation in Windows

### DIFF
--- a/BasiliskII/src/Windows/main_windows.cpp
+++ b/BasiliskII/src/Windows/main_windows.cpp
@@ -475,11 +475,8 @@ void QuitEmulator(void)
 
 	// Free ROM/RAM areas
 	if (RAMBaseHost != VM_MAP_FAILED) {
-		vm_release(RAMBaseHost, RAMSize);
+		vm_release(RAMBaseHost, RAMSize + 0x100000);
 		RAMBaseHost = NULL;
-	}
-	if (ROMBaseHost != VM_MAP_FAILED) {
-		vm_release(ROMBaseHost, 0x100000);
 		ROMBaseHost = NULL;
 	}
 


### PR DESCRIPTION
When I fixed the Windows port to ensure ROM is always above RAM in Windows in commit 0980a87e3f, I forgot to update the corresponding code that calls vm_release(). There is no need to try to release ROMBaseHost because the vm_release() for RAMBaseHost takes care of it.

Update the vm_release code to do the exact same thing the Unix port does.