### PR TITLE
sheep_net.c: use module_init instead of init_module for newer kernel …

### DIFF
--- a/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
+++ b/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
@@ -220,8 +220,7 @@ static struct proto sheep_proto = {
 /*
  *  Initialize module
  */
-
-int init_module(void)
+static int __init sheep_net_init(void)
 {
 	int ret;
 
@@ -231,18 +230,19 @@ int init_module(void)
 	return ret;
 }
 
+module_init(sheep_net_init);
 
 /*
  *  Deinitialize module
  */
 
-void cleanup_module(void)
+static void __exit sheep_net_exit(void)
 {
-	/* Unregister driver */
-	misc_deregister(&sheep_net_device);
-	printk("sheep net: driver removed\n");
+    misc_deregister(&sheep_net_device);
+    printk(KERN_INFO "sheep net: driver removed\n");
 }
 
+module_exit(sheep_net_exit);
 
 /*
  *  Driver open() function


### PR DESCRIPTION
The build will fail on newer kernels due to function name deprecation:

`sheep_net.o: error: objtool: init_module(): Magic init_module() function name is deprecated, use module_init(fn) instead`