### PR TITLE
Windows: add .txt extension to prefs files

### DIFF
--- a/BasiliskII/src/Windows/prefs_windows.cpp
+++ b/BasiliskII/src/Windows/prefs_windows.cpp
@@ -61,7 +61,7 @@ prefs_desc platform_prefs_items[] = {
 
 
 // Prefs file name and path
-const TCHAR PREFS_FILE_NAME[] = TEXT("BasiliskII_prefs");
+const TCHAR PREFS_FILE_NAME[] = TEXT("BasiliskII_prefs.txt");
 tstring UserPrefsPath;
 static tstring prefs_path;
 

--- a/SheepShaver/src/Windows/prefs_windows.cpp
+++ b/SheepShaver/src/Windows/prefs_windows.cpp
@@ -65,7 +65,7 @@ prefs_desc platform_prefs_items[] = {
 
 
 // Prefs file name and path
-const char PREFS_FILE_NAME[] = "SheepShaver_prefs";
+const char PREFS_FILE_NAME[] = "SheepShaver_prefs.txt";
 string UserPrefsPath;
 static string prefs_path;
 


### PR DESCRIPTION
Windows only: add .txt extension to prefs files so that the default Windows text editor can open them easily.