### PR TITLE
Fix for SDL compilation on Unix-like systems

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -334,6 +334,7 @@ if [[ "x$WANT_SDL" = "xyes" ]]; then
 
     if [[ "x$TEMP_WANT_SDL_VERSION_MAJOR" = "x3" ]]; then
       PKG_CHECK_MODULES([sdl3], [sdl3 >= 3.0], [
+        CFLAGS="$CFLAGS $sdl3_CFLAGS"
         CXXFLAGS="$CXXFLAGS $sdl3_CFLAGS"
         LIBS="$LIBS $sdl3_LIBS"
 	AC_DEFINE([USE_SDL3], [1], [Use SDL3])
@@ -344,6 +345,7 @@ if [[ "x$WANT_SDL" = "xyes" ]]; then
     fi
     if [[ "x$TEMP_WANT_SDL_VERSION_MAJOR" = "x2" ]]; then
       PKG_CHECK_MODULES([sdl2], [sdl2 >= 2.0], [
+        CFLAGS="$CFLAGS $sdl2_CFLAGS"
         CXXFLAGS="$CXXFLAGS $sdl2_CFLAGS"
         LIBS="$LIBS $sdl2_LIBS"
 	AC_DEFINE([USE_SDL2], [1], [Use SDL2])

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -223,6 +223,7 @@ if [[ "x$WANT_SDL" = "xyes" ]]; then
 
     if [[ "x$TEMP_WANT_SDL_VERSION_MAJOR" = "x3" ]]; then
       PKG_CHECK_MODULES([sdl3], [sdl3 >= 3.0], [
+        CFLAGS="$CFLAGS $sdl3_CFLAGS"
         CXXFLAGS="$CXXFLAGS $sdl3_CFLAGS"
         LIBS="$LIBS $sdl3_LIBS"
         AC_DEFINE([USE_SDL3], [1], [Use SDL3])
@@ -233,6 +234,7 @@ if [[ "x$WANT_SDL" = "xyes" ]]; then
     fi
     if [[ "x$TEMP_WANT_SDL_VERSION_MAJOR" = "x2" ]]; then
       PKG_CHECK_MODULES([sdl2], [sdl2 >= 2.0], [
+        CFLAGS="$CFLAGS $sdl2_CFLAGS"
         CXXFLAGS="$CXXFLAGS $sdl2_CFLAGS"
         LIBS="$LIBS $sdl2_LIBS"
         AC_DEFINE([USE_SDL2], [1], [Use SDL2])


### PR DESCRIPTION
Fixes regression from change set https://github.com/kanjitalk755/macemu/commit/9a7751f1a2b2db75fbebbeef850832921e7d2a7a.

Compilation and basic functionality when run using the SDL2 library tested on Raspberry Pi Zero 2W with current Raspbian OS (Full, reference 2025-05-13) based on Debian 12 (Bookworm).

Closes issue https://github.com/kanjitalk755/macemu/issues/284.