### PR TITLE
fix for "error: ordered comparison of pointer with integer zero" in timer.cpp

### DIFF
--- a/BasiliskII/src/timer.cpp
+++ b/BasiliskII/src/timer.cpp
@@ -294,7 +294,7 @@ void TimerExit(void)
 {
 #if PRECISE_TIMING
 	// Quit timer thread
-	if (timer_thread != 0) {
+	if (timer_thread_active) {
 #ifdef PRECISE_TIMING_BEOS
 		status_t l;
 		thread_active = false;


### PR DESCRIPTION
resolves https://github.com/kanjitalk755/macemu/issues/286

basilisk & sheepshaver returns the following error during gmake compilation on freebsd 14.3
```
./../timer.cpp: In function 'void TimerExit()':
./../timer.cpp:297:26: error: ordered comparison of pointer with integer zero ('pthread_t' {aka 'pthread*'} and 'int')
  297 |         if (timer_thread > 0) {
      |             ~~~~~~~~~~~~~^~~
gmake: *** [Makefile:202: obj/timer.o] Error 1
```

Fix: minor change to replace numeric comparison with non-zero check
from `if (timer_thread > 0) {`
to `if (timer_thread != 0) {` 


tested on freebsd 14.3 , ubuntu 25.04  -  basilisk & sheepshaver both compile, start and load to system desktop