### PR TITLE
Add support for VDE to SheepShaver

### DIFF
--- a/BasiliskII/src/Unix/ether_unix.cpp
+++ b/BasiliskII/src/Unix/ether_unix.cpp
@@ -313,6 +313,11 @@ bool ether_init(void)
 		net_if_type = NET_IF_VDE;
 		printf("selected Ethernet device type VDE\n");
 	}
+	else if (strncmp(name, "vde:", 4) == 0) {
+		net_if_type = NET_IF_VDE;
+		vde_sock = strdup(name+4);
+		printf("selected Ethernet device type VDE\n");
+	}
 #endif
 #ifdef ENABLE_MACOSX_ETHERHELPER
 	else if (strncmp(name, "etherhelper", 10) == 0)
@@ -897,9 +902,9 @@ static int16 ether_do_write(uint32 arg)
 			return -1;
 		}
 
-		do {
-			len = vde_send(vde_conn, packet, sizeof(packet), 0);
-		} while (len < 0);
+		if (vde_send(vde_conn, packet, len, 0) < 0) {
+			return excessCollsns;
+		}
 
 		return noErr;
 	} else

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -747,6 +747,11 @@ AS_IF([test  "x$have_libvhd" = "xyes" ], [
 ])
 
 
+AC_ARG_WITH(vdeplug,
+AS_HELP_STRING([--with-vdeplug], [Enable VDE virtual network support]),
+[],
+[with_vdeplug=yes])
+
 
 
 dnl Is the slirp library supported?
@@ -767,6 +772,13 @@ if [[ -n "$CAN_SLIRP" ]]; then
     ../slirp/ip_input.c  ../slirp/socket.c     ../slirp/udp.c"
 fi
 AC_SUBST(SLIRP_SRCS)
+
+dnl Is libvdeplug available?
+have_vdeplug=no
+AS_IF([test "x$with_vdeplug" = "xyes"], [
+have_vdeplug=yes
+AC_CHECK_LIB(vdeplug, vde_close, [], [have_vdeplug=no])
+])
 
 dnl SDL overrides
 if [[ "x$WANT_SDL" = "xyes" ]]; then
@@ -1761,6 +1773,7 @@ echo SDL support ...................... : $SDL_SUPPORT
 echo SDL major-version ................ : $WANT_SDL_VERSION_MAJOR
 echo BINCUE support ................... : $have_bincue
 echo LIBVHD support ................... : $have_libvhd
+echo VDE support ...................... : $have_vdeplug
 echo FBDev DGA support ................ : $WANT_FBDEV_DGA
 echo XFree86 DGA support .............. : $WANT_XF86_DGA
 echo XFree86 VidMode support .......... : $WANT_XF86_VIDMODE

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -207,6 +207,8 @@ int64 TimebaseSpeed;	// Timebase clock speed (Hz)
 uint8 *RAMBaseHost;		// Base address of Mac RAM (host address space)
 uint8 *ROMBaseHost;		// Base address of Mac ROM (host address space)
 uint32 ROMEnd;
+// vde switch variable
+char* vde_sock;
 
 #if defined(__APPLE__) && defined(__x86_64__) || defined(MEM_BULK)
 uint8 gZeroPage[0x3000], gKernelData[0x2000];

--- a/SheepShaver/src/include/main.h
+++ b/SheepShaver/src/include/main.h
@@ -30,6 +30,7 @@ extern uint32 PVR;				// Theoretical PVR
 extern int64 CPUClockSpeed;		// Processor clock speed (Hz)
 extern int64 BusClockSpeed;		// Bus clock speed (Hz)
 extern int64 TimebaseSpeed;		// Timebase clock speed (Hz)
+extern char* vde_sock;					// vde switch variable
 
 #ifdef __BEOS__
 extern system_info SysInfo;		// System information


### PR DESCRIPTION
This PR fixes and extends the existing support for VDE with:

- packets now have the correct length, instead of having trailing garbage
- support in SheepShaver's `configure` script
- The destination VDE link can be configured as part of the `ether` pref, which means it can be saved with the other prefs

With this PR and linking against [vdeplug4](https://github.com/rd235/vdeplug4), it's now possible to launch SheepShaver as

```
sheepshaver --ether 'vde:cmd://ssh root@server vde_plug tap://tap0'
```

to establish a remote TAP device over ssh. I've been using this to get native EtherTalk support on my WiFi-connected laptop. (There are a variety of other backends that VDE supports as well, documented [here](http://wiki.virtualsquare.org/#/man/index).)