### PR TITLE
Decouple clock from host after startup

### DIFF
--- a/BasiliskII/src/Windows/main_windows.cpp
+++ b/BasiliskII/src/Windows/main_windows.cpp
@@ -599,7 +599,7 @@ static int xpram_func(void *arg)
 static void one_second(void)
 {
 	// Pseudo Mac 1Hz interrupt, update local time
-	WriteMacInt32(0x20c, TimerDateTime());
+	WriteMacInt32(0x20c, ReadMacInt32(0x20c) + 1);
 
 	SetInterruptFlag(INTFLAG_1HZ);
 	TriggerInterrupt();

--- a/BasiliskII/src/emul_op.cpp
+++ b/BasiliskII/src/emul_op.cpp
@@ -170,8 +170,17 @@ void EmulOp(uint16 opcode, M68kRegisters *r)
 						XPRAM[reg] = r->d[2];
 					}
 				} else if (reg < 0x08 && is_read) {
-					uint32 t = TimerDateTime();
-					uint8 b = t;
+					uint32 t;
+					uint8 b;
+					
+					if (HasMacStarted()) {
+						t = ReadMacInt32(0x20c);
+					} else {
+						t = TimerDateTime();
+					}
+					
+					b = t;
+					
 					switch (reg & 3) {
 						case 1: b = t >> 8; break;
 						case 2: b = t >> 16; break;

--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -32,6 +32,7 @@
 #include "video.h"
 #include "extfs.h"
 #include "prefs.h"
+#include "timer.h"
 
 #if ENABLE_MON
 #include "mon.h"
@@ -1295,8 +1296,13 @@ static bool patch_rom_32(void)
 		*wp = htons(0x602c);		// bra.b	#$2c
 #endif
 	
-	// Don't write to VIA in InitTimeMgr
+	// Don't write to VIA in InitTimeMgr, but load in host time
 	wp = (uint16 *)(ROMBaseHost + 0xb0e2);
+	/**wp++ = htons(0x307c);			// move.w	#0x20c,a0
+	*wp++ = htons(0x020c);
+	*wp++ = htons(0x20bc);			// move.l	[host_time],(a0)
+	*wp++ = htons((TimerDateTime() >> 16));
+	*wp++ = htons((TimerDateTime() & 0xffff));*/
 	*wp++ = htons(0x4cdf);			// movem.l	(sp)+,d0-d5/a0-a4
 	*wp++ = htons(0x1f3f);
 	*wp = htons(M68K_RTS);
@@ -1642,7 +1648,13 @@ static bool patch_rom_32(void)
 	if ((base = find_rom_resource(FOURCC('P','A','C','K'), 4)) == 0) return false;
 	if ((base = find_rom_resource(FOURCC('P','A','C','K'), 4, true)) == 0 && FPUType == 0)
 		printf("WARNING: This ROM seems to require an FPU\n");
-
+	
+	// Patch SetDateTime to skip clock chip verification
+	base = find_rom_trap(0xa03a);
+	wp = (uint16 *)(ROMBaseHost + base + 4);
+	*wp++ = htons(0x7000);		// moveq	#0,d0 (always noErr)
+	*wp = htons(M68K_RTS);
+	
 	// Patch VIA interrupt handler
 	wp = (uint16 *)(ROMBaseHost + 0x9bc4);	// Level 1 handler
 	*wp++ = htons(0x7002);		// moveq	#2,d0 (always 60Hz interrupt)

--- a/SheepShaver/src/Windows/main_windows.cpp
+++ b/SheepShaver/src/Windows/main_windows.cpp
@@ -692,7 +692,7 @@ static DWORD tick_func(void *arg)
 		// Pseudo Mac 1Hz interrupt, update local time
 		if (++tick_counter > 60) {
 			tick_counter = 0;
-			WriteMacInt32(0x20c, TimerDateTime());
+			WriteMacInt32(0x20c, ReadMacInt32(0x20c) + 1);
 		}
 
 		// Trigger 60Hz interrupt

--- a/SheepShaver/src/rom_patches.cpp
+++ b/SheepShaver/src/rom_patches.cpp
@@ -2333,6 +2333,12 @@ static bool patch_68k(void)
 			D(bug("SynchIdleTime patch not installed\n"));
 		}
 	}
+	
+	// Patch SetDateTime to skip clock chip verification
+	base = find_rom_trap(0xa03a);
+	wp = (uint16 *)(ROMBaseHost + base + 4);
+	*wp++ = htons(0x7000);		// moveq	#0,d0 (always noErr)
+	*wp = htons(M68K_RTS);
 
 	// Construct list of all sifters used by sound components in ROM
 	D(bug("Searching for sound components with type sdev in ROM\n"));

--- a/SheepShaver/src/rom_patches.cpp
+++ b/SheepShaver/src/rom_patches.cpp
@@ -40,6 +40,7 @@
 #include "audio_defs.h"
 #include "serial.h"
 #include "macos_util.h"
+#include "timer.h"
 #include "thunks.h"
 
 #define DEBUG 0
@@ -1938,11 +1939,16 @@ static bool patch_68k(void)
 		*wp = htons(M68K_RTS);
 	}
 
-	// Don't poke VIA in InitTimeMgr (via 0x298)
+	// Don't poke VIA in InitTimeMgr (via 0x298), but load in host time
 	static const uint8 time_via_dat[] = {0x40, 0xe7, 0x00, 0x7c, 0x07, 0x00, 0x28, 0x78, 0x01, 0xd4, 0x43, 0xec, 0x10, 0x00};
 	if ((base = find_rom_data(0x30000, 0x40000, time_via_dat, sizeof(time_via_dat))) == 0) return false;
 	D(bug("time_via %08lx\n", base));
 	wp = (uint16 *)(ROMBaseHost + base);
+	*wp++ = htons(0x307c);			// move.w	#0x20c,a0
+	*wp++ = htons(0x020c);
+	*wp++ = htons(0x20bc);			// move.l	[host_time],(a0)
+	*wp++ = htons(TimerDateTime() >> 16);
+	*wp++ = htons(TimerDateTime() & 0xffff);
 	*wp++ = htons(0x4cdf);			// movem.l	(sp)+,d0-d5/a0-a4
 	*wp++ = htons(0x1f3f);
 	*wp = htons(M68K_RTS);


### PR DESCRIPTION
A quick patch I made so that the SheepShaver clock is set to the host time upon boot and then it's changeable within the emulated environment. Windows only for now.