### PR TITLE
Fix linker script check

### DIFF
--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -1731,7 +1731,7 @@ if [[ -n "$LINKER_SCRIPT_FLAGS" ]]; then
     saved_LDFLAGS="$LDFLAGS"
     LDFLAGS="$LDFLAGS $LINKER_SCRIPT_FLAGS"
     AC_TRY_RUN(
-      [int main() {if ((char *)&main < (char *)0x70000000) return 1;}],
+      [int main() {if ((char *)(&main) < (char *)0x70000000) return 1;}],
       [ac_cv_linker_script_works=yes],
       [ac_cv_linker_script_works=no],
       dnl When cross-compiling, assume it works


### PR DESCRIPTION
On GCC 16, `(char*)&main < ...` is rejected without extra brackets. This causes the linker script check to fail, and SS fails to start with an error about the memory map