### PR TITLE
Re-add support for running on a real PowerPC

### DIFF
--- a/SheepShaver/src/Unix/Linux/sheepthreads.c
+++ b/SheepShaver/src/Unix/Linux/sheepthreads.c
@@ -35,6 +35,11 @@
 #include <signal.h>
 #include <pthread.h>
 
+#include "config.h"
+
+#ifdef HAVE_LINUX_SCHED_H
+	#include <linux/sched.h>
+#endif
 
 /* Thread stack size */
 #define STACK_SIZE 65536

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -422,7 +422,7 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(malloc.h stdint.h)
-AC_CHECK_HEADERS(mach/vm_map.h mach/mach_init.h sys/mman.h)
+AC_CHECK_HEADERS(mach/vm_map.h mach/mach_init.h sys/mman.h linux/sched.h)
 AC_CHECK_HEADERS(unistd.h fcntl.h byteswap.h dirent.h)
 AC_CHECK_HEADERS(sys/socket.h sys/ioctl.h sys/filio.h sys/bitypes.h sys/wait.h)
 AC_CHECK_HEADERS(sys/time.h sys/poll.h sys/select.h arpa/inet.h)

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -421,7 +421,7 @@ AC_SYS_LARGEFILE
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(malloc.h stdint.h)
+AC_CHECK_HEADERS(malloc.h stdint.h sys/types.h)
 AC_CHECK_HEADERS(mach/vm_map.h mach/mach_init.h sys/mman.h linux/sched.h)
 AC_CHECK_HEADERS(unistd.h fcntl.h byteswap.h dirent.h)
 AC_CHECK_HEADERS(sys/socket.h sys/ioctl.h sys/filio.h sys/bitypes.h sys/wait.h)

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -1535,10 +1535,9 @@ static void *tick_func(void *arg)
 
 			// Yes, dump registers
 			sigregs *r = &sigsegv_regs;
-			char str[256];
 			if (crash_reason == NULL)
 				crash_reason = "SIGSEGV";
-			sprintf(str, "%s\n"
+			printf("%s\n"
 				"   pc %08lx     lr %08lx    ctr %08lx    msr %08lx\n"
 				"  xer %08lx     cr %08lx  \n"
 				"   r0 %08lx     r1 %08lx     r2 %08lx     r3 %08lx\n"
@@ -1560,7 +1559,6 @@ static void *tick_func(void *arg)
 				r->gpr[20], r->gpr[21], r->gpr[22], r->gpr[23],
 				r->gpr[24], r->gpr[25], r->gpr[26], r->gpr[27],
 				r->gpr[28], r->gpr[29], r->gpr[30], r->gpr[31]);
-			printf(str);
 			VideoQuitFullScreen();
 
 #ifdef ENABLE_MON
@@ -2100,7 +2098,7 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 	// For all other errors, jump into debugger (sort of...)
 	crash_reason = (sig == SIGBUS) ? "SIGBUS" : "SIGSEGV";
 	if (!ready_for_signals) {
-		printf("%s\n");
+		printf("%s\n", crash_reason);
 		printf(" sigcontext %p, machine_regs %p\n", scp, r);
 		printf(
 			"   pc %08lx     lr %08lx    ctr %08lx    msr %08lx\n"
@@ -2113,7 +2111,6 @@ static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 			"  r20 %08lx    r21 %08lx    r22 %08lx    r23 %08lx\n"
 			"  r24 %08lx    r25 %08lx    r26 %08lx    r27 %08lx\n"
 			"  r28 %08lx    r29 %08lx    r30 %08lx    r31 %08lx\n",
-			crash_reason,
 			r->pc(), r->lr(), r->ctr(), r->msr(),
 			r->xer(), r->cr(),
 			r->gpr(0), r->gpr(1), r->gpr(2), r->gpr(3),
@@ -2275,7 +2272,7 @@ power_inst:		sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(
 	// For all other errors, jump into debugger (sort of...)
 	crash_reason = "SIGILL";
 	if (!ready_for_signals) {
-		printf("%s\n");
+		printf("%s\n", crash_reason);
 		printf(" sigcontext %p, machine_regs %p\n", scp, r);
 		printf(
 			"   pc %08lx     lr %08lx    ctr %08lx    msr %08lx\n"
@@ -2288,7 +2285,6 @@ power_inst:		sprintf(str, GetString(STR_POWER_INSTRUCTION_ERR), r->pc(), r->gpr(
 			"  r20 %08lx    r21 %08lx    r22 %08lx    r23 %08lx\n"
 			"  r24 %08lx    r25 %08lx    r26 %08lx    r27 %08lx\n"
 			"  r28 %08lx    r29 %08lx    r30 %08lx    r31 %08lx\n",
-			crash_reason,
 			r->pc(), r->lr(), r->ctr(), r->msr(),
 			r->xer(), r->cr(),
 			r->gpr(0), r->gpr(1), r->gpr(2), r->gpr(3),

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -922,7 +922,8 @@ int main(int argc, char **argv)
 	if (use_gui == -1)
 		use_gui = !PrefsFindBool("nogui");
 
-#if SDL_PLATFORM_MACOS && SDL_VERSION_ATLEAST(2,0,0)
+#if SDL_PLATFORM_MACOS
+#if SDL_VERSION_ATLEAST(2,0,0)
 	// On Mac OS X hosts, SDL2 will create its own menu bar.  This is mostly OK,
 	// except that it will also install keyboard shortcuts, such as Command + Q,
 	// which can interfere with keyboard shortcuts in the guest OS.
@@ -930,6 +931,7 @@ int main(int argc, char **argv)
 	// HACK: disable these shortcuts, while leaving all other pieces of SDL2's
 	// menu bar in-place.
 	disable_SDL2_macosx_menu_bar_keyboard_shortcuts();
+#endif
 #endif
 	
 	// Any command line arguments left?

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -1769,6 +1769,7 @@ void EnableInterrupt(void)
  */
 
 #if !EMULATED_PPC
+__attribute__((no_stack_protector))
 void sigusr2_handler(int sig, siginfo_t *sip, void *scp)
 {
 	machine_regs *r = MACHINE_REGISTERS(scp);
@@ -1876,6 +1877,7 @@ void sigusr2_handler(int sig, siginfo_t *sip, void *scp)
  */
 
 #if !EMULATED_PPC
+__attribute__((no_stack_protector))
 static void sigsegv_handler(int sig, siginfo_t *sip, void *scp)
 {
 	machine_regs *r = MACHINE_REGISTERS(scp);
@@ -2138,7 +2140,7 @@ rti:;
 /*
  *  SIGILL handler
  */
-
+__attribute__((no_stack_protector))
 static void sigill_handler(int sig, siginfo_t *sip, void *scp)
 {
 	machine_regs *r = MACHINE_REGISTERS(scp);

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -1796,8 +1796,8 @@ void sigusr2_handler(int sig, siginfo_t *sip, void *scp)
 	switch (ReadMacInt32(XLM_RUN_MODE)) {
 		case MODE_68K:
 			// 68k emulator active, trigger 68k interrupt level 1
-			WriteMacInt16(ReadMacInt32(0x67c), 1);
-			r->cr() |= ReadMacInt32(0x674);
+			WriteMacInt16(ReadMacInt32(KERNEL_DATA_BASE + 0x67c), 1);
+			r->cr() |= ReadMacInt32(KERNEL_DATA_BASE + 0x674);
 			break;
 
 #if INTERRUPTS_IN_NATIVE_MODE
@@ -1809,8 +1809,10 @@ void sigusr2_handler(int sig, siginfo_t *sip, void *scp)
 				sigaltstack(&extra_stack, NULL);
 				
 				// Prepare for 68k interrupt level 1
-				WriteMacInt16(ReadMacInt32(0x67c), 1);
-				WriteMacInt32(ReadMacInt32(0x658) + 0xdc, ReadMacInt32(ReadMacInt32(0x658) + 0xdc) | ReadMacInt32(0x674));
+				WriteMacInt16(ReadMacInt32(KERNEL_DATA_BASE + 0x67c), 1);
+				WriteMacInt32(ReadMacInt32(KERNEL_DATA_BASE + 0x658) + 0xdc,
+								ReadMacInt32(ReadMacInt32(KERNEL_DATA_BASE + 0x658) + 0xdc)
+								| ReadMacInt32(KERNEL_DATA_BASE + 0x674));
 
 				// Execute nanokernel interrupt routine (this will activate the 68k emulator)
 				DisableInterrupt();

--- a/SheepShaver/src/Unix/paranoia.cpp
+++ b/SheepShaver/src/Unix/paranoia.cpp
@@ -248,6 +248,7 @@ static void *emul_func(void *)
 #undef LOAD_REG
 		: :  "r" ((uintptr)&emul_thread_regs[0]) : "r0");
 #undef REG
+	return NULL;
 }
 
 


### PR DESCRIPTION
It's kinda crazy, but I have modern [ArchPower](https://archlinuxpower.org/) running on an iBook G3. SheepShaver used to support this configuration, but there's been a lot of decay due to advances in compilers and system headers, and changes in SheepShaver that were never tested in native mode. Anyhow, I've fixed all those problems.

All my fixes should be fairly straightforward. You probably want to look at each commit rather than the whole thing at once. I've verified that everything still builds fine on Linux/amd64.

Once these are all applied, SheepShaver works pretty well! I have [SheepShaver packaged up for ArchPower](https://github.com/vasi/archpower-packages/tree/main/sheepshaver-git) using these fixes. Pretty much all features work, as long as they don't need SDL: sound, networking, sparsebundles are all fine.

The only breakages are occasional mysterious X11 protocol disconnections, and that the X window refuses to close on shutdown.