### PR TITLE
Fix two crashes when using SDL on Linux (for Basilisk II, it does not affect SheepShaver)

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -746,8 +746,9 @@ static SDL_Surface *init_sdl_video(int width, int height, int depth, Uint32 flag
 		int old_window_width, old_window_height, old_window_flags;
 		SDL_GetWindowSize(sdl_window, &old_window_width, &old_window_height);
 		old_window_flags = SDL_GetWindowFlags(sdl_window);
-		if (old_window_width != window_width ||
-			old_window_height != window_height ||
+		float m = get_mag_rate();
+		if (old_window_width != m * window_width ||
+			old_window_height != m * window_height ||
 			(old_window_flags & window_flags_to_monitor) != (window_flags & window_flags_to_monitor))
 		{
 			delete_sdl_video_window();
@@ -1648,6 +1649,9 @@ void VideoExit(void)
 	vector<monitor_desc *>::iterator i, end = VideoMonitors.end();
 	for (i = VideoMonitors.begin(); i != end; ++i)
 		dynamic_cast<SDL_monitor_desc *>(*i)->video_close();
+
+	// Destroy SDL video window
+	delete_sdl_video_window();
 
 	// Destroy locks
 	if (frame_buffer_lock)

--- a/BasiliskII/src/SDL/video_sdl3.cpp
+++ b/BasiliskII/src/SDL/video_sdl3.cpp
@@ -734,8 +734,9 @@ static SDL_Surface *init_sdl_video(int width, int height, int depth, Uint32 flag
 		int old_window_width, old_window_height, old_window_flags;
 		SDL_GetWindowSize(sdl_window, &old_window_width, &old_window_height);
 		old_window_flags = SDL_GetWindowFlags(sdl_window);
-		if (old_window_width != window_width ||
-			old_window_height != window_height ||
+		float m = get_mag_rate();
+		if (old_window_width != m * window_width ||
+			old_window_height != m * window_height ||
 			(old_window_flags & window_flags_to_monitor) != (window_flags & window_flags_to_monitor))
 		{
 			delete_sdl_video_window();
@@ -1637,6 +1638,9 @@ void VideoExit(void)
 	vector<monitor_desc *>::iterator i, end = VideoMonitors.end();
 	for (i = VideoMonitors.begin(); i != end; ++i)
 		dynamic_cast<SDL_monitor_desc *>(*i)->video_close();
+
+	// Destroy SDL video window
+	delete_sdl_video_window();
 
 	// Destroy locks
 	if (frame_buffer_lock)


### PR DESCRIPTION
1. The SDL window is created at mag_rate * dimensions (for example, 3 * 960 = 2880), but the size check compared against the raw mode dimensions, causing the renderer to be destroyed and recreated on every `init_sdl_video` call. This triggered a crash in SDL's GL shader cleanup, which is now fixed by scaling the comparison by `get_mag_rate()`.

2. The `driver_base` destructor intentionally skips destroying the SDL renderer/window (see [video_sdl2.cpp:1161-1168](https://github.com/kanjitalk755/macemu/blob/35e82471adf84204ab64088cf51e28d61545f550/BasiliskII/src/SDL/video_sdl2.cpp#L1165) and the same in [video_sdl3.cpp:1146-1153](https://github.com/kanjitalk755/macemu/blob/35e82471adf84204ab64088cf51e28d61545f550/BasiliskII/src/SDL/video_sdl3.cpp#L1151)), which seems to be an OSX-specific fullscreen workaround. But `VideoExit()` never cleans up either, so `SDL_Quit`'s `atexit` handler tries to destroy the renderer with stale GL function pointers lying around, which leads to a `SIGSEGV` on exit. Fixed by calling `delete_sdl_video_window()` in `VideoExit()` for both SDL2 and 3.